### PR TITLE
AddressSpace everywhere (fixes #24)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,33 @@ pub fn shutdown_llvm() {
     }
 }
 
+/// Defines the address space in which a global will be inserted.
+///
+/// # Remarks
+/// See also: http://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum AddressSpace {
+    Generic = 0,
+    Global  = 1,
+    Shared  = 3,
+    Const   = 4,
+    Local   = 5
+}
+
+impl From<u32> for AddressSpace {
+    fn from(val: u32) -> Self {
+        match val {
+            0 => AddressSpace::Generic,
+            1 => AddressSpace::Global,
+            2 => AddressSpace::Shared,
+            3 => AddressSpace::Const,
+            4 => AddressSpace::Local,
+            _ => unreachable!("Invalid value for AddressSpace"),
+        }
+    }
+}
+
 // REVIEW: Maybe this belongs in some sort of prelude?
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IntPredicate {

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,7 +11,7 @@ use std::mem::{forget, uninitialized, zeroed};
 use std::path::Path;
 use std::slice::from_raw_parts;
 
-use OptimizationLevel;
+use {AddressSpace, OptimizationLevel};
 use context::{Context, ContextRef};
 use data_layout::DataLayout;
 use execution_engine::ExecutionEngine;
@@ -39,32 +39,6 @@ pub enum Linkage {
     PrivateLinkage,
     WeakAnyLinkage,
     WeakODRLinkage,
-}
-
-/// Defines the address space in which a global will be inserted.
-///
-/// # Remarks
-/// See also: http://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum AddressSpace {
-    Generic = 0,
-    Global  = 1,
-    Shared  = 3,
-    Const   = 4,
-    Local   = 5
-}
-
-impl From<u32> for AddressSpace {
-    fn from(val: u32) -> Self {
-        match val {
-            0 => AddressSpace::Generic,
-            1 => AddressSpace::Global,
-            2 => AddressSpace::Shared,
-            3 => AddressSpace::Const,
-            4 => AddressSpace::Local,
-            _ => unreachable!("Invalid value for AddressSpace"),
-        }
-    }
 }
 
 impl Linkage {

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -3,6 +3,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use std::ffi::CStr;
 
+use AddressSpace;
 use context::ContextRef;
 use types::traits::AsTypeRef;
 use types::{Type, BasicType, PointerType, FunctionType};
@@ -36,7 +37,7 @@ impl ArrayType {
         None
     }
 
-    pub fn ptr_type(&self, address_space: u32) -> PointerType {
+    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         self.array_type.ptr_type(address_space)
     }
 

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -4,6 +4,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use std::ffi::CStr;
 
+use AddressSpace;
 use context::ContextRef;
 use types::traits::AsTypeRef;
 use types::{Type, PointerType, FunctionType, BasicType, ArrayType, VectorType};
@@ -77,7 +78,7 @@ impl FloatType {
         self.float_type.get_context()
     }
 
-    pub fn ptr_type(&self, address_space: u32) -> PointerType {
+    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         self.float_type.ptr_type(address_space)
     }
 

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -4,6 +4,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use std::ffi::CStr;
 
+use AddressSpace;
 use context::ContextRef;
 use types::traits::AsTypeRef;
 use types::{Type, ArrayType, BasicType, VectorType, PointerType, FunctionType};
@@ -296,7 +297,7 @@ impl IntType {
         self.int_type.size_of()
     }
 
-    pub fn ptr_type(&self, address_space: u32) -> PointerType {
+    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         self.int_type.ptr_type(address_space)
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -28,6 +28,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use std::ffi::CStr;
 use std::fmt;
 
+use AddressSpace;
 use context::{Context, ContextRef};
 use values::{IntValue, PointerValue};
 
@@ -62,9 +63,9 @@ impl Type {
         PointerValue::new(ptr_type)
     }
 
-    fn ptr_type(&self, address_space: u32) -> PointerType {
+    fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         let ptr_type = unsafe {
-            LLVMPointerType(self.type_, address_space)
+            LLVMPointerType(self.type_, address_space as u32)
         };
 
         PointerType::new(ptr_type)

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -3,8 +3,8 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use std::ffi::CStr;
 
+use AddressSpace;
 use context::ContextRef;
-use module::AddressSpace;
 use types::traits::AsTypeRef;
 use types::{Type, BasicType, ArrayType, FunctionType, VectorType};
 use values::{PointerValue, IntValue};
@@ -31,7 +31,7 @@ impl PointerType {
         self.ptr_type.size_of()
     }
 
-    pub fn ptr_type(&self, address_space: u32) -> PointerType {
+    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         self.ptr_type.ptr_type(address_space)
     }
 

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -4,6 +4,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use std::ffi::CStr;
 use std::mem::forget;
 
+use AddressSpace;
 use context::ContextRef;
 use types::traits::AsTypeRef;
 use types::{Type, BasicType, BasicTypeEnum, ArrayType, PointerType, FunctionType, VectorType};
@@ -115,7 +116,7 @@ impl StructType {
         Some(c_str)
     }
 
-    pub fn ptr_type(&self, address_space: u32) -> PointerType {
+    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         self.struct_type.ptr_type(address_space)
     }
 

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -1,6 +1,7 @@
 use llvm_sys::core::LLVMVoidType;
 use llvm_sys::prelude::LLVMTypeRef;
 
+use AddressSpace;
 use context::ContextRef;
 use types::traits::AsTypeRef;
 use types::{Type, BasicType, FunctionType, PointerType};
@@ -31,7 +32,7 @@ impl VoidType {
         self.void_type.get_context()
     }
 
-    pub fn ptr_type(&self, address_space: u32) -> PointerType {
+    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         self.void_type.ptr_type(address_space)
     }
 

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -1,6 +1,6 @@
 extern crate inkwell;
 
-use self::inkwell::OptimizationLevel;
+use self::inkwell::{AddressSpace, OptimizationLevel};
 use self::inkwell::context::Context;
 use self::inkwell::builder::Builder;
 use self::inkwell::targets::{InitializationConfig, Target};
@@ -56,7 +56,7 @@ fn test_null_checked_ptr_ops() {
     // }
 
     let i8_type = context.i8_type();
-    let i8_ptr_type = i8_type.ptr_type(0);
+    let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
     let i64_type = context.i64_type();
     let fn_type = i8_type.fn_type(&[&i8_ptr_type], false);
     let neg_one = i8_type.const_all_ones();

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -2,6 +2,7 @@ extern crate inkwell;
 
 use std::ffi::CString;
 
+use self::inkwell::AddressSpace;
 use self::inkwell::context::Context;
 use self::inkwell::types::{FloatType, IntType, StructType, VoidType};
 
@@ -156,26 +157,26 @@ fn test_sized_types() {
     assert!(!fn_type3.is_sized());
     assert!(!fn_type4.is_sized());
 
-    assert!(void_type.ptr_type(0).is_sized());
-    assert!(bool_type.ptr_type(0).is_sized());
-    assert!(i8_type.ptr_type(0).is_sized());
-    assert!(i16_type.ptr_type(0).is_sized());
-    assert!(i32_type.ptr_type(0).is_sized());
-    assert!(i64_type.ptr_type(0).is_sized());
-    assert!(i128_type.ptr_type(0).is_sized());
-    assert!(f16_type.ptr_type(0).is_sized());
-    assert!(f32_type.ptr_type(0).is_sized());
-    assert!(f64_type.ptr_type(0).is_sized());
-    assert!(f128_type.ptr_type(0).is_sized());
-    assert!(ppc_f128_type.ptr_type(0).is_sized());
-    assert!(struct_type.ptr_type(0).is_sized());
-    assert!(struct_type2.ptr_type(0).is_sized());
-    assert!(struct_type3.ptr_type(0).is_sized());
-    assert!(struct_type4.ptr_type(0).is_sized());
-    assert!(opaque_struct_type.ptr_type(0).is_sized());
+    assert!(void_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(bool_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(i8_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(i16_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(i32_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(i64_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(i128_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(f16_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(f32_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(f64_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(f128_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(ppc_f128_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(struct_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(struct_type2.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(struct_type3.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(struct_type4.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(opaque_struct_type.ptr_type(AddressSpace::Generic).is_sized());
 
     // REVIEW: You can't have array of void right?
-    assert!(void_type.ptr_type(0).array_type(42).is_sized());
+    assert!(void_type.ptr_type(AddressSpace::Generic).array_type(42).is_sized());
     assert!(bool_type.array_type(42).is_sized());
     assert!(i8_type.array_type(42).is_sized());
     assert!(i16_type.array_type(42).is_sized());
@@ -194,7 +195,7 @@ fn test_sized_types() {
     assert!(!opaque_struct_type.array_type(0).is_sized());
 
     // REVIEW: You can't have vec of void right?
-    assert!(void_type.ptr_type(0).vec_type(42).is_sized());
+    assert!(void_type.ptr_type(AddressSpace::Generic).vec_type(42).is_sized());
     assert!(bool_type.vec_type(42).is_sized());
     assert!(i8_type.vec_type(42).is_sized());
     assert!(i16_type.vec_type(42).is_sized());
@@ -228,7 +229,7 @@ fn test_const_null() {
     let f64_type = context.f64_type();
     let f128_type = context.f128_type();
     let struct_type = context.struct_type(&[&i8_type, &f128_type], false);
-    let ptr_type = f64_type.ptr_type(0);
+    let ptr_type = f64_type.ptr_type(AddressSpace::Generic);
     let vec_type = f64_type.vec_type(42);
     let array_type = f64_type.array_type(42);
 

--- a/tests/test_values.rs
+++ b/tests/test_values.rs
@@ -1,8 +1,7 @@
 extern crate inkwell;
 
-use self::inkwell::{DLLStorageClass, FloatPredicate, GlobalVisibility, ThreadLocalMode};
+use self::inkwell::{DLLStorageClass, FloatPredicate, GlobalVisibility, ThreadLocalMode, AddressSpace};
 use self::inkwell::context::Context;
-use self::inkwell::module::AddressSpace::*;
 use self::inkwell::module::Linkage::*;
 use self::inkwell::types::{StructType, VectorType};
 use self::inkwell::values::InstructionOpcode::*;
@@ -32,7 +31,7 @@ fn test_instructions() {
     let void_type = context.void_type();
     let i64_type = context.i64_type();
     let f32_type = context.f32_type();
-    let f32_ptr_type = f32_type.ptr_type(0);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
     let fn_type = void_type.fn_type(&[&f32_ptr_type], false);
 
     let function = module.add_function("free_f32", &fn_type, None);
@@ -170,7 +169,7 @@ fn test_set_get_name() {
     assert_eq!(ppc_f128_val.get_name(), &*CString::new("").unwrap());
 
     let void_type = context.void_type();
-    let ptr_type = bool_type.ptr_type(0);
+    let ptr_type = bool_type.ptr_type(AddressSpace::Generic);
     let struct_type = context.struct_type(&[&bool_type], false);
     let vec_type = bool_type.vec_type(1);
 
@@ -278,7 +277,7 @@ fn test_undef() {
     let f32_undef = f32_type.get_undef();
     let f64_undef = f64_type.get_undef();
     let f128_undef = f128_type.get_undef();
-    let ptr_undef = bool_type.ptr_type(0).get_undef();
+    let ptr_undef = bool_type.ptr_type(AddressSpace::Generic).get_undef();
     let array_undef = array_type.get_undef();
     let struct_undef = StructType::struct_type(&[&bool_type], false).get_undef();
     let vec_undef = bool_type.vec_type(1).get_undef();
@@ -448,7 +447,7 @@ fn test_metadata() {
     let f64_val = f64_type.const_float(0.0);
     let f128_val = f128_type.const_float(0.0);
     // let ppc_f128_val = ppc_f128_type.const_float(0.0);
-    let ptr_val = bool_type.ptr_type(0).const_null();
+    let ptr_val = bool_type.ptr_type(AddressSpace::Generic).const_null();
     let array_val = array_type.const_array(&[&f64_val]);
     let struct_val = context.const_struct(&[&i8_val, &f128_val], false);
     let vec_val = VectorType::const_vector(&[&i8_val]);
@@ -791,7 +790,7 @@ fn test_globals() {
 
     assert!(global.get_thread_local_mode().is_none());
 
-    let global2 = module.add_global(&i8_type, Some(Const), "my_global2");
+    let global2 = module.add_global(&i8_type, Some(AddressSpace::Const), "my_global2");
 
     assert_eq!(global2.get_previous_global().unwrap(), global);
     assert_eq!(global.get_next_global().unwrap(), global2);


### PR DESCRIPTION
## Description
Use `AddressSpace` instead of `u32` everywhere.

## Related Issue
#24.

## How This Has Been Tested
All existing tests have been run again.

## Breaking Changes
Many methods can no longer be called with an integer, and now need an enum. The methods should be clearer and safer to use, although some calls may have to be changed.

## Checklist
- [X] I have read the [Contributing Guide](../blob/master/.github/CONTRIBUTING.md)
