### PR TITLE
Impl debug

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -421,6 +421,11 @@ impl fmt::Debug for BasicBlock {
             LLVMIsConstant(self.basic_block as LLVMValueRef) == 1
         };
 
-        write!(f, "BasicBlock {{\n    address: {:?}\n    is_const: {:?}\n    llvm_value: {:?}\n    llvm_type: {:?}\n}}", self.basic_block, is_const, llvm_value, llvm_type)
+        f.debug_struct("BasicBlock")
+            .field("address", &self.basic_block)
+            .field("is_const", &is_const)
+            .field("llvm_value", &llvm_value)
+            .field("llvm_type", &llvm_type)
+            .finish()
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,6 +10,7 @@ use types::{AsTypeRef, BasicType, PointerType, IntType, FloatType};
 
 use std::ffi::CString;
 
+#[derive(Debug)]
 pub struct Builder {
     builder: LLVMBuilderRef,
 }

--- a/src/data_layout.rs
+++ b/src/data_layout.rs
@@ -36,9 +36,10 @@ impl PartialEq for DataLayout {
 
 impl fmt::Debug for DataLayout {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "DataLayout {{\n    ")?;
-        write!(f, "address: {:?}\n    ", self.data_layout.get())?;
-        write!(f, "repr: {:?}\n}}", self.as_str())
+        f.debug_struct("DataLayout")
+            .field("address", &self.data_layout.get())
+            .field("repr", &self.as_str())
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_debug_implementations)]
 extern crate either;
 #[macro_use]
 extern crate enum_methods;

--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -9,6 +9,7 @@ use std::mem::zeroed;
 use std::path::Path;
 use std::ptr;
 
+#[derive(Debug)]
 pub struct MemoryBuffer {
     pub(crate) memory_buffer: LLVMMemoryBufferRef
 }

--- a/src/object_file.rs
+++ b/src/object_file.rs
@@ -5,7 +5,7 @@ use std::ffi::CStr;
 // REVIEW: Make sure SectionIterator's object_file ptr doesn't outlive ObjectFile
 // REVIEW: This module is very untested
 // TODO: More references to account for lifetimes
-
+#[derive(Debug)]
 pub struct ObjectFile {
     object_file: LLVMObjectFileRef
 }
@@ -44,6 +44,7 @@ impl Drop for ObjectFile {
     }
 }
 
+#[derive(Debug)]
 pub struct SectionIterator {
     section_iterator: LLVMSectionIteratorRef,
     object_file: LLVMObjectFileRef,
@@ -91,6 +92,7 @@ impl Drop for SectionIterator {
     }
 }
 
+#[derive(Debug)]
 pub struct Section {
     section: LLVMSectionIteratorRef,
     object_file: LLVMObjectFileRef,
@@ -139,6 +141,7 @@ impl Section {
     }
 }
 
+#[derive(Debug)]
 pub struct RelocationIterator {
     relocation_iterator: LLVMRelocationIteratorRef,
     section_iterator: LLVMSectionIteratorRef,
@@ -188,6 +191,7 @@ impl Drop for RelocationIterator {
     }
 }
 
+#[derive(Debug)]
 pub struct Relocation {
     relocation: LLVMRelocationIteratorRef,
     object_file: LLVMObjectFileRef,
@@ -236,6 +240,7 @@ impl Relocation {
     }
 }
 
+#[derive(Debug)]
 pub struct SymbolIterator {
     symbol_iterator: LLVMSymbolIteratorRef,
     object_file: LLVMObjectFileRef,
@@ -283,6 +288,7 @@ impl Drop for SymbolIterator {
     }
 }
 
+#[derive(Debug)]
 pub struct Symbol {
     symbol: LLVMSymbolIteratorRef,
 }

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -18,6 +18,7 @@ use values::{AsValueRef, FunctionValue};
 
 // REVIEW: Opt Level might be identical to targets::Option<CodeGenOptLevel>
 // REVIEW: size_level 0-2 according to llvmlite
+#[derive(Debug)]
 pub struct PassManagerBuilder {
     pass_manager_builder: LLVMPassManagerBuilderRef,
 }
@@ -107,6 +108,7 @@ impl Drop for PassManagerBuilder {
 }
 
 // SubTypes: PassManager<Module>, PassManager<FunctionValue>
+#[derive(Debug)]
 pub struct PassManager {
     pub(crate) pass_manager: LLVMPassManagerRef,
 }
@@ -525,6 +527,7 @@ impl Drop for PassManager {
     }
 }
 
+#[derive(Debug)]
 pub struct PassRegistry {
     pass_registry: LLVMPassRegistryRef,
 }

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -82,7 +82,10 @@ impl fmt::Debug for FunctionType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let llvm_type = self.print_to_string();
 
-        write!(f, "FunctionType {{\n    address: {:?}\n    llvm_type: {:?}\n}}", self.as_type_ref(), llvm_type)
+        f.debug_struct("FunctionType")
+            .field("address", &self.as_type_ref())
+            .field("llvm_type", &llvm_type)
+            .finish()
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -171,6 +171,9 @@ impl fmt::Debug for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let llvm_type = self.print_to_string();
 
-        write!(f, "Type {{\n    address: {:?}\n    llvm_type: {:?}\n}}", self.type_, llvm_type)
+        f.debug_struct("Type")
+            .field("address", &self.type_)
+            .field("llvm_type", &llvm_type)
+            .finish()
     }
 }

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -93,6 +93,15 @@ impl fmt::Debug for ArrayValue {
             !LLVMIsAConstantDataArray(self.as_value_ref()).is_null()
         };
 
-        write!(f, "Value {{\n    name: {:?}\n    address: {:?}\n    is_const: {:?}\n    is_const_array: {:?}\n    is_const_data_array: {:?}\n    is_null: {:?}\n    llvm_value: {:?}\n    llvm_type: {:?}\n}}", name, self.as_value_ref(), is_const, is_const_array, is_const_data_array, is_null, llvm_value, llvm_type.print_to_string())
+        f.debug_struct("Value")
+            .field("name", &name)
+            .field("address", &self.as_value_ref())
+            .field("is_const", &is_const)
+            .field("is_const_array", &is_const_array)
+            .field("is_const_data_array", &is_const_data_array)
+            .field("is_null", &is_null)
+            .field("llvm_value", &llvm_value)
+            .field("llvm_type",  &llvm_type)
+            .finish()
     }
 }

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -330,10 +330,18 @@ impl fmt::Debug for FunctionValue {
         };
         let is_null = self.is_null();
 
-        write!(f, "FunctionValue {{\n    name: {:?}\n    address: {:?}\n    is_const: {:?}\n    is_null: {:?}\n    llvm_value: {:?}\n    llvm_type: {:?}\n}}", name, self.as_value_ref(), is_const, is_null, llvm_value, llvm_type.print_to_string())
+        f.debug_struct("FunctionValue")
+            .field("name", &name)
+            .field("address", &self.as_value_ref())
+            .field("is_const", &is_const)
+            .field("is_null", &is_null)
+            .field("llvm_value", &llvm_value)
+            .field("llvm_type", &llvm_type.print_to_string())
+            .finish()
     }
 }
 
+#[derive(Debug)]
 pub struct ParamValueIter {
     param_iter_value: LLVMValueRef,
     start: bool,

--- a/src/values/generic_value.rs
+++ b/src/values/generic_value.rs
@@ -4,6 +4,7 @@ use llvm_sys::execution_engine::{LLVMCreateGenericValueOfPointer, LLVMDisposeGen
 use types::{AsTypeRef, FloatType};
 
 // SubTypes: GenericValue<IntValue, FloatValue, or PointerValue>
+#[derive(Debug)]
 pub struct GenericValue {
     pub(crate) generic_value: LLVMGenericValueRef,
 }

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -143,17 +143,17 @@ impl AsValueRef for MetadataValue {
 
 impl fmt::Debug for MetadataValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MetadataValue {{\n    ")?;
-        write!(f, "address: {:?}\n", self.as_value_ref())?;
+        let mut d = f.debug_struct("MetadataValue");
+        d.field("address", &self.as_value_ref());
 
         if self.is_string() {
-            write!(f, "value: {:?}\n", self.get_string_value().unwrap())?;
+            d.field("value", &self.get_string_value().unwrap());
         } else {
-            write!(f, "values: {:?}\n", self.get_node_values())?;
+            d.field("values", &self.get_node_values());
         }
 
-        write!(f, "repr: {:?}", self.print_to_string())?;
+        d.field("repr", &self.print_to_string());
 
-        write!(f, "\n}}")
+        d.finish()
     }
 }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -168,6 +168,14 @@ impl fmt::Debug for Value {
         let is_null = self.is_null();
         let is_undef = self.is_undef();
 
-        write!(f, "Value {{\n    name: {:?}\n    address: {:?}\n    is_const: {:?}\n    is_null: {:?}\n    is_undef: {:?}\n    llvm_value: {:?}\n    llvm_type: {:?}\n}}", name, self.value, is_const, is_null, is_undef, llvm_value, llvm_type)
+        f.debug_struct("Value")
+            .field("name", &name)
+            .field("address", &self.value)
+            .field("is_const", &is_const)
+            .field("is_null", &is_null)
+            .field("is_undef", &is_undef)
+            .field("llvm_value", &llvm_value)
+            .field("llvm_type", &llvm_type)
+            .finish()
     }
 }


### PR DESCRIPTION
## Description

Implements the `Debug` trait for all public-facing APIs. I also added a `#[deny(missing_debug_implementations)]` lint so non-`Debug` types can't accidentally sneak back in over time.

## Related Issue

Fixes #7

## How This Has Been Tested

It compiles.