### PR TITLE
Support vector types in math ops, fixes #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ fn jit_compile_sum(
     let y = function.get_nth_param(1)?.into_int_value();
     let z = function.get_nth_param(2)?.into_int_value();
 
-    let sum = builder.build_int_add(&x, &y, "sum");
-    let sum = builder.build_int_add(&sum, &z, "sum");
+    let sum = builder.build_int_add(x, y, "sum");
+    let sum = builder.build_int_add(sum, z, "sum");
 
     builder.build_return(Some(&sum));
 

--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -32,8 +32,8 @@ fn jit_compile_sum(
     let y = function.get_nth_param(1)?.into_int_value();
     let z = function.get_nth_param(2)?.into_int_value();
 
-    let sum = builder.build_int_add(&x, &y, "sum");
-    let sum = builder.build_int_add(&sum, &z, "sum");
+    let sum = builder.build_int_add(x, y, "sum");
+    let sum = builder.build_int_add(sum, z, "sum");
 
     builder.build_return(Some(&sum));
 

--- a/examples/kaleidoscope/main.rs
+++ b/examples/kaleidoscope/main.rs
@@ -941,19 +941,19 @@ impl<'a> Compiler<'a> {
                     let rhs = self.compile_expr(right)?;
 
                     match op {
-                        '+' => Ok(self.builder.build_float_add(&lhs, &rhs, "tmpadd")),
-                        '-' => Ok(self.builder.build_float_sub(&lhs, &rhs, "tmpsub")),
-                        '*' => Ok(self.builder.build_float_mul(&lhs, &rhs, "tmpmul")),
-                        '/' => Ok(self.builder.build_float_div(&lhs, &rhs, "tmpdiv")),
+                        '+' => Ok(self.builder.build_float_add(lhs, rhs, "tmpadd")),
+                        '-' => Ok(self.builder.build_float_sub(lhs, rhs, "tmpsub")),
+                        '*' => Ok(self.builder.build_float_mul(lhs, rhs, "tmpmul")),
+                        '/' => Ok(self.builder.build_float_div(lhs, rhs, "tmpdiv")),
                         '<' => Ok({
-                            let cmp = self.builder.build_float_compare(FloatPredicate::ULT, &lhs, &rhs, "tmpcmp");
+                            let cmp = self.builder.build_float_compare(FloatPredicate::ULT, lhs, rhs, "tmpcmp");
 
-                            self.builder.build_unsigned_int_to_float(&cmp, &self.context.f64_type(), "tmpbool")
+                            self.builder.build_unsigned_int_to_float(cmp, self.context.f64_type(), "tmpbool")
                         }),
                         '>' => Ok({
-                            let cmp = self.builder.build_float_compare(FloatPredicate::ULT, &rhs, &lhs, "tmpcmp");
+                            let cmp = self.builder.build_float_compare(FloatPredicate::ULT, rhs, lhs, "tmpcmp");
 
-                            self.builder.build_unsigned_int_to_float(&cmp, &self.context.f64_type(), "tmpbool")
+                            self.builder.build_unsigned_int_to_float(cmp, self.context.f64_type(), "tmpbool")
                         }),
 
                         custom => {
@@ -1002,7 +1002,7 @@ impl<'a> Compiler<'a> {
 
                 // create condition by comparing without 0.0 and returning an int
                 let cond = self.compile_expr(cond)?;
-                let cond = self.builder.build_float_compare(FloatPredicate::ONE, &cond, &zero_const, "ifcond");
+                let cond = self.builder.build_float_compare(FloatPredicate::ONE, cond, zero_const, "ifcond");
 
                 // build branch
                 let then_bb = self.context.append_basic_block(&parent, "then");
@@ -1069,11 +1069,11 @@ impl<'a> Compiler<'a> {
                 let end_cond = self.compile_expr(end)?;
 
                 let curr_var = self.builder.build_load(&start_alloca, var_name);
-                let next_var = self.builder.build_float_add(curr_var.as_float_value(), &step, "nextvar");
+                let next_var = self.builder.build_float_add(curr_var.into_float_value(), step, "nextvar");
 
                 self.builder.build_store(&start_alloca, &next_var);
 
-                let end_cond = self.builder.build_float_compare(FloatPredicate::ONE, &end_cond, &self.context.f64_type().const_float(0.0), "loopcond");
+                let end_cond = self.builder.build_float_compare(FloatPredicate::ONE, end_cond, self.context.f64_type().const_float(0.0), "loopcond");
                 let after_bb = self.context.append_basic_block(&parent, "afterloop");
 
                 self.builder.build_conditional_branch(&end_cond, &loop_bb, &after_bb);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,8 +5,8 @@ use llvm_sys::{LLVMTypeKind, LLVMAtomicOrdering};
 
 use {IntPredicate, FloatPredicate};
 use basic_block::BasicBlock;
-use values::{AggregateValue, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, InstructionOpcode};
-use types::{AsTypeRef, BasicType, PointerType, IntType, IntMathType, FloatMathType};
+use values::{AggregateValue, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, PointerMathValue, InstructionOpcode};
+use types::{AsTypeRef, BasicType, PointerType, IntMathType, FloatMathType, PointerMathType};
 
 use std::ffi::CString;
 
@@ -384,45 +384,45 @@ impl Builder {
     }
 
     // REVIEW: Consolidate these two casts into one via subtypes
-    pub fn build_float_to_unsigned_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::ConvType, name: &str) -> <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType {
+    pub fn build_float_to_unsigned_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::MathConvType, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPToUI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType::new(value)
+        <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_to_signed_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::ConvType, name: &str) -> <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType {
+    pub fn build_float_to_signed_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::MathConvType, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPToSI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType::new(value)
+        <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
     // REVIEW: Consolidate these two casts into one via subtypes
-    pub fn build_unsigned_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::ConvType, name: &str) -> <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType {
+    pub fn build_unsigned_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::MathConvType, name: &str) -> <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildUIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType::new(value)
+        <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_signed_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::ConvType, name: &str) -> <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType {
+    pub fn build_signed_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::MathConvType, name: &str) -> <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType::new(value)
+        <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
     pub fn build_float_trunc<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
@@ -805,14 +805,14 @@ impl Builder {
     }
 
     // SubType: <F>(&self, op, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name) -> IntValue<bool> { ?
-    pub fn build_float_compare<T: FloatMathValue>(&self, op: FloatPredicate, lhs: &T, rhs: &T, name: &str) -> <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType {
+    pub fn build_float_compare<T: FloatMathValue>(&self, op: FloatPredicate, lhs: &T, rhs: &T, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFCmp(self.builder, op.as_llvm_predicate(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType::new(value)
+        <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
     pub fn build_unconditional_branch(&self, destination_block: &BasicBlock) -> InstructionValue {
@@ -972,47 +972,47 @@ impl Builder {
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_null(&self, ptr: &PointerValue, name: &str) -> IntValue {
+    pub fn build_is_null<T: PointerMathValue>(&self, ptr: &T, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let val = unsafe {
             LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(val)
+        <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_not_null(&self, ptr: &PointerValue, name: &str) -> IntValue {
+    pub fn build_is_not_null<T: PointerMathValue>(&self, ptr: &T, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let val = unsafe {
             LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(val)
+        <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <I, P>(&self, int: &IntValue<I>, ptr_type: &PointerType<P>, name) -> PointerValue<P> {
-    pub fn build_int_to_ptr(&self, int: &IntValue, ptr_type: &PointerType, name: &str) -> PointerValue {
+    pub fn build_int_to_ptr<T: IntMathValue>(&self, int: &T, ptr_type: &<T::BaseType as IntMathType>::PtrConvType, name: &str) -> <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildIntToPtr(self.builder, int.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
         };
 
-        PointerValue::new(value)
+        <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType::new(value)
     }
 
     // SubType: <I, P>(&self, ptr: &PointerValue<P>, int_type: &IntType<I>, name) -> IntValue<I> {
-    pub fn build_ptr_to_int(&self, ptr: &PointerValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_ptr_to_int<T: PointerMathValue>(&self, ptr: &T, int_type: &<T::BaseType as PointerMathType>::PtrConvType, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildPtrToInt(self.builder, ptr.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(value)
     }
 
     pub fn clear_insertion_position(&self) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -783,14 +783,14 @@ impl Builder {
     }
 
     // SubType: <F, T>(&self, from: &PointerValue<F>, to: &PointerType<T>, name: &str) -> PointerValue<T> {
-    pub fn build_pointer_cast(&self, from: &PointerValue, to: &PointerType, name: &str) -> PointerValue {
+    pub fn build_pointer_cast<T: PointerMathValue>(&self, from: &T, to: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildPointerCast(self.builder, from.as_value_ref(), to.as_type_ref(), c_string.as_ptr())
         };
 
-        PointerValue::new(value)
+        T::new(value)
     }
 
     // SubType: <I>(&self, op, lhs: &IntValue<I>, rhs: &IntValue<I>, name) -> IntValue<bool> { ?

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -254,7 +254,7 @@ impl Builder {
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I: IntSubType>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
     //     if I::sign() == Unsigned { LLVMBuildUDiv() } else { LLVMBuildSDiv() }
-    pub fn build_int_unsigned_div<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_unsigned_div<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -266,7 +266,7 @@ impl Builder {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_signed_div<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_signed_div<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -278,7 +278,7 @@ impl Builder {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_exact_signed_div<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_exact_signed_div<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -290,7 +290,7 @@ impl Builder {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_unsigned_rem<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_unsigned_rem<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -303,7 +303,7 @@ impl Builder {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_signed_rem<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_signed_rem<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -313,7 +313,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_int_s_extend<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_s_extend<T: IntMathValue>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -323,7 +323,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -333,7 +333,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_int_z_extend<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_z_extend<T: IntMathValue>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
@@ -343,7 +343,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
@@ -353,7 +353,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_int_truncate<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_truncate<T: IntMathValue>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
@@ -363,7 +363,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_int_truncate_or_bit_cast<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_truncate_or_bit_cast<T: IntMathValue>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
@@ -373,7 +373,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_float_rem<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_float_rem<T: FloatMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -384,7 +384,7 @@ impl Builder {
     }
 
     // REVIEW: Consolidate these two casts into one via subtypes
-    pub fn build_float_to_unsigned_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::MathConvType, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
+    pub fn build_float_to_unsigned_int<T: FloatMathValue>(&self, float: T, int_type: <T::BaseType as FloatMathType>::MathConvType, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -394,7 +394,7 @@ impl Builder {
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_to_signed_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::MathConvType, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
+    pub fn build_float_to_signed_int<T: FloatMathValue>(&self, float: T, int_type: <T::BaseType as FloatMathType>::MathConvType, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -405,7 +405,7 @@ impl Builder {
     }
 
     // REVIEW: Consolidate these two casts into one via subtypes
-    pub fn build_unsigned_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::MathConvType, name: &str) -> <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType {
+    pub fn build_unsigned_int_to_float<T: IntMathValue>(&self, int: T, float_type: <T::BaseType as IntMathType>::MathConvType, name: &str) -> <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -415,7 +415,7 @@ impl Builder {
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_signed_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::MathConvType, name: &str) -> <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType {
+    pub fn build_signed_int_to_float<T: IntMathValue>(&self, int: T, float_type: <T::BaseType as IntMathType>::MathConvType, name: &str) -> <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -425,7 +425,7 @@ impl Builder {
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_trunc<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
+    pub fn build_float_trunc<T: FloatMathValue>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -435,7 +435,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_float_ext<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
+    pub fn build_float_ext<T: FloatMathValue>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -445,7 +445,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_float_cast<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
+    pub fn build_float_cast<T: FloatMathValue>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -456,7 +456,7 @@ impl Builder {
     }
 
     // SubType: <L, R>(&self, lhs: &IntValue<L>, rhs: &IntType<R>, name: &str) -> IntValue<R> {
-    pub fn build_int_cast<T: IntMathValue>(&self, int: &T, int_type: &T::BaseType, name: &str) -> T {
+    pub fn build_int_cast<T: IntMathValue>(&self, int: T, int_type: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -466,7 +466,7 @@ impl Builder {
         T::new(value)
     }
 
-    pub fn build_float_div<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_float_div<T: FloatMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -477,7 +477,7 @@ impl Builder {
     }
 
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_add<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_add<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -489,7 +489,7 @@ impl Builder {
 
     // REVIEW: Possibly incorperate into build_int_add via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nsw_add<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_nsw_add<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -501,7 +501,7 @@ impl Builder {
 
     // REVIEW: Possibly incorperate into build_int_add via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nuw_add<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_nuw_add<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -512,7 +512,7 @@ impl Builder {
     }
 
     // SubType: <F>(&self, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name: &str) -> FloatValue<F> {
-    pub fn build_float_add<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_float_add<T: FloatMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -523,7 +523,7 @@ impl Builder {
     }
 
     // SubType: (&self, lhs: &IntValue<bool>, rhs: &IntValue<bool>, name: &str) -> IntValue<bool> {
-    pub fn build_xor<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_xor<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -534,7 +534,7 @@ impl Builder {
     }
 
     // SubType: (&self, lhs: &IntValue<bool>, rhs: &IntValue<bool>, name: &str) -> IntValue<bool> {
-    pub fn build_and<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_and<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -545,7 +545,7 @@ impl Builder {
     }
 
     // SubType: (&self, lhs: &IntValue<bool>, rhs: &IntValue<bool>, name: &str) -> IntValue<bool> {
-    pub fn build_or<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_or<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -598,7 +598,7 @@ impl Builder {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_left_shift<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_left_shift<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -667,7 +667,7 @@ impl Builder {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_right_shift<T: IntMathValue>(&self, lhs: &T, rhs: &T, sign_extend: bool, name: &str) -> T {
+    pub fn build_right_shift<T: IntMathValue>(&self, lhs: T, rhs: T, sign_extend: bool, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -682,7 +682,7 @@ impl Builder {
     }
 
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_sub<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_sub<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -693,7 +693,7 @@ impl Builder {
     }
 
     // REVIEW: Possibly incorperate into build_int_sub via flag param
-    pub fn build_int_nsw_sub<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_nsw_sub<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -705,7 +705,7 @@ impl Builder {
 
     // REVIEW: Possibly incorperate into build_int_sub via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nuw_sub<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_nuw_sub<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -716,7 +716,7 @@ impl Builder {
     }
 
     // SubType: <F>(&self, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name: &str) -> FloatValue<F> {
-    pub fn build_float_sub<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_float_sub<T: FloatMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -727,7 +727,7 @@ impl Builder {
     }
 
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_mul<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_mul<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -739,7 +739,7 @@ impl Builder {
 
     // REVIEW: Possibly incorperate into build_int_mul via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nsw_mul<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_nsw_mul<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -751,7 +751,7 @@ impl Builder {
 
     // REVIEW: Possibly incorperate into build_int_mul via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nuw_mul<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_int_nuw_mul<T: IntMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -762,7 +762,7 @@ impl Builder {
     }
 
     // SubType: <F>(&self, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name: &str) -> FloatValue<F> {
-    pub fn build_float_mul<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
+    pub fn build_float_mul<T: FloatMathValue>(&self, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -783,7 +783,7 @@ impl Builder {
     }
 
     // SubType: <F, T>(&self, from: &PointerValue<F>, to: &PointerType<T>, name: &str) -> PointerValue<T> {
-    pub fn build_pointer_cast<T: PointerMathValue>(&self, from: &T, to: &T::BaseType, name: &str) -> T {
+    pub fn build_pointer_cast<T: PointerMathValue>(&self, from: T, to: T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -794,7 +794,10 @@ impl Builder {
     }
 
     // SubType: <I>(&self, op, lhs: &IntValue<I>, rhs: &IntValue<I>, name) -> IntValue<bool> { ?
-    pub fn build_int_compare<T: IntMathValue>(&self, op: IntPredicate, lhs: &T, rhs: &T, name: &str) -> T {
+    // Note: we need a way to get an appropriate return type, since this method's return value
+    // is always a bool (or vector of bools), not necessarily the same as the input value
+    // See https://github.com/TheDan64/inkwell/pull/47#discussion_r197599297
+    pub fn build_int_compare<T: IntMathValue>(&self, op: IntPredicate, lhs: T, rhs: T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -805,7 +808,8 @@ impl Builder {
     }
 
     // SubType: <F>(&self, op, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name) -> IntValue<bool> { ?
-    pub fn build_float_compare<T: FloatMathValue>(&self, op: FloatPredicate, lhs: &T, rhs: &T, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
+    // Note: see comment on build_int_compare regarding return value type
+    pub fn build_float_compare<T: FloatMathValue>(&self, op: FloatPredicate, lhs: T, rhs: T, name: &str) -> <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -972,7 +976,7 @@ impl Builder {
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_null<T: PointerMathValue>(&self, ptr: &T, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
+    pub fn build_is_null<T: PointerMathValue>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let val = unsafe {
@@ -983,7 +987,7 @@ impl Builder {
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_not_null<T: PointerMathValue>(&self, ptr: &T, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
+    pub fn build_is_not_null<T: PointerMathValue>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let val = unsafe {
@@ -994,7 +998,7 @@ impl Builder {
     }
 
     // SubType: <I, P>(&self, int: &IntValue<I>, ptr_type: &PointerType<P>, name) -> PointerValue<P> {
-    pub fn build_int_to_ptr<T: IntMathValue>(&self, int: &T, ptr_type: &<T::BaseType as IntMathType>::PtrConvType, name: &str) -> <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType {
+    pub fn build_int_to_ptr<T: IntMathValue>(&self, int: T, ptr_type: <T::BaseType as IntMathType>::PtrConvType, name: &str) -> <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -1005,7 +1009,7 @@ impl Builder {
     }
 
     // SubType: <I, P>(&self, ptr: &PointerValue<P>, int_type: &IntType<I>, name) -> IntValue<I> {
-    pub fn build_ptr_to_int<T: PointerMathValue>(&self, ptr: &T, int_type: &<T::BaseType as PointerMathType>::PtrConvType, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
+    pub fn build_ptr_to_int<T: PointerMathValue>(&self, ptr: T, int_type: <T::BaseType as PointerMathType>::PtrConvType, name: &str) -> <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,8 +5,8 @@ use llvm_sys::{LLVMTypeKind, LLVMAtomicOrdering};
 
 use {IntPredicate, FloatPredicate};
 use basic_block::BasicBlock;
-use values::{AggregateValue, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, FloatValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, InstructionOpcode};
-use types::{AsTypeRef, BasicType, PointerType, IntType, FloatType};
+use values::{AggregateValue, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, FloatValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, InstructionOpcode};
+use types::{AsTypeRef, BasicType, PointerType, IntType, FloatType, IntMathType, FloatMathType};
 
 use std::ffi::CString;
 
@@ -254,305 +254,305 @@ impl Builder {
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I: IntSubType>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
     //     if I::sign() == Unsigned { LLVMBuildUDiv() } else { LLVMBuildSDiv() }
-    pub fn build_int_unsigned_div(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_unsigned_div<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildUDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_signed_div(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_signed_div<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_exact_signed_div(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_exact_signed_div<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildExactSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_unsigned_rem(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_unsigned_rem<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildURem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_signed_rem(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_signed_rem<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_int_s_extend(&self, int_value: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_s_extend<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_int_s_extend_or_bit_cast(&self, int_value: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_int_z_extend(&self, int_value: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_z_extend<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
             LLVMBuildZExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_int_z_extend_or_bit_cast(&self, int_value: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
             LLVMBuildZExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_int_truncate(&self, int_value: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_truncate<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
             LLVMBuildTrunc(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_int_truncate_or_bit_cast(&self, int_value: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_truncate_or_bit_cast<T: IntMathValue>(&self, int_value: &T, int_type: &T::BaseType, name: &str) -> T {
        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
        let value = unsafe {
             LLVMBuildTruncOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_float_rem(&self, lhs: &FloatValue, rhs: &FloatValue, name: &str) -> FloatValue {
+    pub fn build_float_rem<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Consolidate these two casts into one via subtypes
-    pub fn build_float_to_unsigned_int(&self, float: &FloatValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_float_to_unsigned_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::ConvType, name: &str) -> <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPToUI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_to_signed_int(&self, float: &FloatValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_float_to_signed_int<T: FloatMathValue>(&self, float: &T, int_type: &<T::BaseType as FloatMathType>::ConvType, name: &str) -> <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPToSI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType::new(value)
     }
 
     // REVIEW: Consolidate these two casts into one via subtypes
-    pub fn build_unsigned_int_to_float(&self, int: &IntValue, float_type: &FloatType, name: &str) -> FloatValue {
+    pub fn build_unsigned_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::ConvType, name: &str) -> <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildUIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_signed_int_to_float(&self, int: &FloatValue, float_type: &FloatType, name: &str) -> FloatValue {
+    pub fn build_signed_int_to_float<T: IntMathValue>(&self, int: &T, float_type: &<T::BaseType as IntMathType>::ConvType, name: &str) -> <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        <<T::BaseType as IntMathType>::ConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_trunc(&self, float: &FloatValue, float_type: &FloatType, name: &str) -> FloatValue {
+    pub fn build_float_trunc<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPTrunc(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_float_ext(&self, float: &FloatValue, float_type: &FloatType, name: &str) -> FloatValue {
+    pub fn build_float_ext<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPExt(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_float_cast(&self, float: &FloatValue, float_type: &FloatType, name: &str) -> FloatValue {
+    pub fn build_float_cast<T: FloatMathValue>(&self, float: &T, float_type: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFPCast(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     // SubType: <L, R>(&self, lhs: &IntValue<L>, rhs: &IntType<R>, name: &str) -> IntValue<R> {
-    pub fn build_int_cast(&self, int: &IntValue, int_type: &IntType, name: &str) -> IntValue {
+    pub fn build_int_cast<T: IntMathValue>(&self, int: &T, int_type: &T::BaseType, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildIntCast(self.builder, int.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
-    pub fn build_float_div(&self, lhs: &FloatValue, rhs: &FloatValue, name: &str) -> FloatValue {
+    pub fn build_float_div<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_add(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_add<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_add via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nsw_add(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nsw_add<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNSWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_add via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nuw_add(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nuw_add<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNUWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <F>(&self, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name: &str) -> FloatValue<F> {
-    pub fn build_float_add(&self, lhs: &FloatValue, rhs: &FloatValue, name: &str) -> FloatValue {
+    pub fn build_float_add<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     // SubType: (&self, lhs: &IntValue<bool>, rhs: &IntValue<bool>, name: &str) -> IntValue<bool> {
-    pub fn build_xor(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_xor<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildXor(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: (&self, lhs: &IntValue<bool>, rhs: &IntValue<bool>, name: &str) -> IntValue<bool> {
-    pub fn build_and(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_and<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildAnd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: (&self, lhs: &IntValue<bool>, rhs: &IntValue<bool>, name: &str) -> IntValue<bool> {
-    pub fn build_or(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_or<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildOr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     /// Builds an `IntValue` containing the result of a logical left shift instruction.
@@ -598,14 +598,14 @@ impl Builder {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_left_shift(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_left_shift<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildShl(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     /// Builds an `IntValue` containing the result of a right shift instruction.
@@ -667,7 +667,7 @@ impl Builder {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_right_shift(&self, lhs: &IntValue, rhs: &IntValue, sign_extend: bool, name: &str) -> IntValue {
+    pub fn build_right_shift<T: IntMathValue>(&self, lhs: &T, rhs: &T, sign_extend: bool, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
@@ -678,98 +678,98 @@ impl Builder {
             }
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_sub(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_sub<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_sub via flag param
-    pub fn build_int_nsw_sub(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nsw_sub<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNSWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_sub via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nuw_sub(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nuw_sub<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNUWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <F>(&self, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name: &str) -> FloatValue<F> {
-    pub fn build_float_sub(&self, lhs: &FloatValue, rhs: &FloatValue, name: &str) -> FloatValue {
+    pub fn build_float_sub<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_mul(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_mul<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_mul via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nsw_mul(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nsw_mul<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNSWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_mul via flag param
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_nuw_mul(&self, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nuw_mul<T: IntMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNUWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <F>(&self, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name: &str) -> FloatValue<F> {
-    pub fn build_float_mul(&self, lhs: &FloatValue, rhs: &FloatValue, name: &str) -> FloatValue {
+    pub fn build_float_mul<T: FloatMathValue>(&self, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     pub fn build_cast(&self, op: InstructionOpcode, from_value: &BasicValue, to_type: &BasicType, name: &str) -> BasicValueEnum {
@@ -794,25 +794,25 @@ impl Builder {
     }
 
     // SubType: <I>(&self, op, lhs: &IntValue<I>, rhs: &IntValue<I>, name) -> IntValue<bool> { ?
-    pub fn build_int_compare(&self, op: IntPredicate, lhs: &IntValue, rhs: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_compare<T: IntMathValue>(&self, op: IntPredicate, lhs: &T, rhs: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildICmp(self.builder, op.as_llvm_predicate(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <F>(&self, op, lhs: &FloatValue<F>, rhs: &FloatValue<F>, name) -> IntValue<bool> { ?
-    pub fn build_float_compare(&self, op: FloatPredicate, lhs: &FloatValue, rhs: &FloatValue, name: &str) -> IntValue {
+    pub fn build_float_compare<T: FloatMathValue>(&self, op: FloatPredicate, lhs: &T, rhs: &T, name: &str) -> <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFCmp(self.builder, op.as_llvm_predicate(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        <<T::BaseType as FloatMathType>::ConvType as IntMathType>::ValueType::new(value)
     }
 
     pub fn build_unconditional_branch(&self, destination_block: &BasicBlock) -> InstructionValue {
@@ -832,59 +832,59 @@ impl Builder {
     }
 
     // SubType: <I>(&self, value: &IntValue<I>, name) -> IntValue<I> {
-    pub fn build_int_neg(&self, value: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_neg<T: IntMathValue>(&self, value: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: Possibly incorperate into build_int_neg via flag and subtypes
     // SubType: <I>(&self, value: &IntValue<I>, name) -> IntValue<I> {
-    pub fn build_int_nsw_neg(&self, value: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nsw_neg<T: IntMathValue>(&self, value: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <I>(&self, value: &IntValue<I>, name) -> IntValue<I> {
-    pub fn build_int_nuw_neg(&self, value: &IntValue, name: &str) -> IntValue {
+    pub fn build_int_nuw_neg<T: IntMathValue>(&self, value: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // SubType: <F>(&self, value: &FloatValue<F>, name) -> FloatValue<F> {
-    pub fn build_float_neg(&self, value: &FloatValue, name: &str) -> FloatValue {
+    pub fn build_float_neg<T: FloatMathValue>(&self, value: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
         };
 
-        FloatValue::new(value)
+        T::new(value)
     }
 
     // SubType: <I>(&self, value: &IntValue<I>, name) -> IntValue<bool> { ?
-    pub fn build_not(&self, value: &IntValue, name: &str) -> IntValue {
+    pub fn build_not<T: IntMathValue>(&self, value: &T, name: &str) -> T {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
             LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr())
         };
 
-        IntValue::new(value)
+        T::new(value)
     }
 
     // REVIEW: What if instruction and basic_block are completely unrelated?

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,8 +5,8 @@ use llvm_sys::{LLVMTypeKind, LLVMAtomicOrdering};
 
 use {IntPredicate, FloatPredicate};
 use basic_block::BasicBlock;
-use values::{AggregateValue, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, FloatValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, InstructionOpcode};
-use types::{AsTypeRef, BasicType, PointerType, IntType, FloatType, IntMathType, FloatMathType};
+use values::{AggregateValue, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, InstructionOpcode};
+use types::{AsTypeRef, BasicType, PointerType, IntType, IntMathType, FloatMathType};
 
 use std::ffi::CString;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -594,7 +594,7 @@ impl Builder {
     ///
     /// builder.position_at_end(&entry_block);
     ///
-    /// let shift = builder.build_left_shift(&value, &n, "left_shift"); // value << n
+    /// let shift = builder.build_left_shift(value, n, "left_shift"); // value << n
     ///
     /// builder.build_return(Some(&shift));
     /// ```
@@ -663,7 +663,7 @@ impl Builder {
     ///
     /// // Whether or not your right shift is sign extended (true) or logical (false) depends
     /// // on the boolean input parameter:
-    /// let shift = builder.build_right_shift(&value, &n, false, "right_shift"); // value >> n
+    /// let shift = builder.build_right_shift(value, n, false, "right_shift"); // value >> n
     ///
     /// builder.build_return(Some(&shift));
     /// ```

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,7 +16,7 @@ pub use types::fn_type::FunctionType;
 pub use types::int_type::IntType;
 pub use types::ptr_type::PointerType;
 pub use types::struct_type::StructType;
-pub use types::traits::{AnyType, BasicType};
+pub use types::traits::{AnyType, BasicType, IntMathType, FloatMathType};
 pub use types::vec_type::VectorType;
 pub use types::void_type::VoidType;
 pub(crate) use types::traits::AsTypeRef;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,7 +16,7 @@ pub use types::fn_type::FunctionType;
 pub use types::int_type::IntType;
 pub use types::ptr_type::PointerType;
 pub use types::struct_type::StructType;
-pub use types::traits::{AnyType, BasicType, IntMathType, FloatMathType};
+pub use types::traits::{AnyType, BasicType, IntMathType, FloatMathType, PointerMathType};
 pub use types::vec_type::VectorType;
 pub use types::void_type::VoidType;
 pub(crate) use types::traits::AsTypeRef;

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use types::{IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VectorType, VoidType, Type};
 use types::enums::{AnyTypeEnum, BasicTypeEnum};
-use values::{IntMathValue, FloatMathValue, IntValue, FloatValue, VectorValue};
+use values::{IntMathValue, FloatMathValue, PointerMathValue, IntValue, FloatValue, PointerValue, VectorValue};
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -17,17 +17,6 @@ macro_rules! trait_type_set {
     ($trait_name:ident: $($args:ident),*) => (
         $(
             impl $trait_name for $args {}
-        )*
-    );
-}
-
-macro_rules! math_trait_type_set {
-    ($trait_name: ident: $(($base_type:ident => $value_type:ident, $conv_type:ident)),*) => (
-        $(
-            impl $trait_name for $base_type {
-                type ValueType = $value_type;
-                type ConvType = $conv_type;
-            }
         )*
     );
 }
@@ -55,16 +44,53 @@ pub trait BasicType: AnyType {
 /// Represents an LLVM type that can have integer math operations applied to it.
 pub trait IntMathType: BasicType {
     type ValueType: IntMathValue;
-    type ConvType: FloatMathType;
+    type MathConvType: FloatMathType;
+    type PtrConvType: PointerMathType;
 }
 
 /// Represents an LLVM type that can have floating point math operations applied to it.
 pub trait FloatMathType: BasicType {
     type ValueType: FloatMathValue;
-    type ConvType: IntMathType;
+    type MathConvType: IntMathType;
+}
+
+/// Represents an LLVM type that can have pointer operations applied to it.
+pub trait PointerMathType: BasicType {
+    type ValueType: PointerMathValue;
+    type PtrConvType: IntMathType;
 }
 
 trait_type_set! {AnyType: AnyTypeEnum, BasicTypeEnum, IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VoidType, VectorType}
 trait_type_set! {BasicType: BasicTypeEnum, IntType, FloatType, PointerType, StructType, ArrayType, VectorType}
-math_trait_type_set! {IntMathType: (IntType => IntValue, FloatType), (VectorType => VectorValue, VectorType)}
-math_trait_type_set! {FloatMathType: (FloatType => FloatValue, IntType), (VectorType => VectorValue, VectorType)}
+
+impl IntMathType for IntType {
+    type ValueType = IntValue;
+    type MathConvType = FloatType;
+    type PtrConvType = PointerType;
+}
+
+impl IntMathType for VectorType {
+    type ValueType = VectorValue;
+    type MathConvType = VectorType;
+    type PtrConvType = VectorType;
+}
+
+impl FloatMathType for FloatType {
+    type ValueType = FloatValue;
+    type MathConvType = IntType;
+}
+
+impl FloatMathType for VectorType {
+    type ValueType = VectorValue;
+    type MathConvType = VectorType;
+}
+
+impl PointerMathType for PointerType {
+    type ValueType = PointerValue;
+    type PtrConvType = IntType;
+}
+
+impl PointerMathType for VectorType {
+    type ValueType = VectorValue;
+    type PtrConvType = VectorType;
+}

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -25,7 +25,7 @@ pub use values::metadata_value::{MetadataValue, FIRST_CUSTOM_METADATA_KIND_ID};
 pub use values::phi_value::PhiValue;
 pub use values::ptr_value::PointerValue;
 pub use values::struct_value::StructValue;
-pub use values::traits::{AnyValue, AggregateValue, BasicValue, IntMathValue, FloatMathValue};
+pub use values::traits::{AnyValue, AggregateValue, BasicValue, IntMathValue, FloatMathValue, PointerMathValue};
 pub use values::vec_value::VectorValue;
 pub(crate) use values::traits::AsValueRef;
 

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -25,7 +25,7 @@ pub use values::metadata_value::{MetadataValue, FIRST_CUSTOM_METADATA_KIND_ID};
 pub use values::phi_value::PhiValue;
 pub use values::ptr_value::PointerValue;
 pub use values::struct_value::StructValue;
-pub use values::traits::{AnyValue, AggregateValue, BasicValue};
+pub use values::traits::{AnyValue, AggregateValue, BasicValue, IntMathValue, FloatMathValue};
 pub use values::vec_value::VectorValue;
 pub(crate) use values::traits::AsValueRef;
 

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -38,6 +38,12 @@ pub trait BasicValue: AnyValue {
     }
 }
 
+/// Represents a value which is permitted in integer math operations
+pub trait IntMathValue: BasicValue {}
+
+/// Represents a value which is permitted in floating point math operations
+pub trait FloatMathValue: BasicValue {}
+
 /// Defines any struct wrapping an LLVM value.
 pub trait AnyValue: AsValueRef + Debug {
     /// Returns an enum containing a typed version of `AnyValue`.
@@ -49,3 +55,5 @@ pub trait AnyValue: AsValueRef + Debug {
 trait_value_set! {AggregateValue: ArrayValue, AggregateValueEnum, StructValue}
 trait_value_set! {AnyValue: AnyValueEnum, BasicValueEnum, AggregateValueEnum, ArrayValue, IntValue, FloatValue, GlobalValue, PhiValue, PointerValue, FunctionValue, StructValue, VectorValue, InstructionValue}
 trait_value_set! {BasicValue: ArrayValue, BasicValueEnum, AggregateValueEnum, IntValue, FloatValue, GlobalValue, StructValue, PointerValue, VectorValue}
+trait_value_set! {IntMathValue: IntValue, VectorValue}
+trait_value_set! {FloatMathValue: FloatValue, VectorValue}

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -3,7 +3,7 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::fmt::Debug;
 
 use values::{ArrayValue, AggregateValueEnum, GlobalValue, StructValue, BasicValueEnum, AnyValueEnum, IntValue, FloatValue, PointerValue, PhiValue, VectorValue, FunctionValue, InstructionValue};
-use types::{IntMathType, FloatMathType, IntType, FloatType, VectorType};
+use types::{IntMathType, FloatMathType, PointerMathType, IntType, FloatType, PointerType, VectorType};
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -64,6 +64,11 @@ pub trait FloatMathValue: BasicValue {
     fn new(value: LLVMValueRef) -> Self;
 }
 
+pub trait PointerMathValue: BasicValue {
+    type BaseType: PointerMathType;
+    fn new(value: LLVMValueRef) -> Self;
+}
+
 /// Defines any struct wrapping an LLVM value.
 pub trait AnyValue: AsValueRef + Debug {
     /// Returns an enum containing a typed version of `AnyValue`.
@@ -77,3 +82,4 @@ trait_value_set! {AnyValue: AnyValueEnum, BasicValueEnum, AggregateValueEnum, Ar
 trait_value_set! {BasicValue: ArrayValue, BasicValueEnum, AggregateValueEnum, IntValue, FloatValue, GlobalValue, StructValue, PointerValue, VectorValue}
 math_trait_value_set! {IntMathValue: (IntValue => IntType), (VectorValue => VectorType)}
 math_trait_value_set! {FloatMathValue: (FloatValue => FloatType), (VectorValue => VectorType)}
+math_trait_value_set! {PointerMathValue: (PointerValue => PointerType), (VectorValue => VectorType)}

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -68,7 +68,7 @@ fn test_null_checked_ptr_ops() {
 
     let ptr = function.get_first_param().unwrap().into_pointer_value();
 
-    let is_null = builder.build_is_null(&ptr, "is_null");
+    let is_null = builder.build_is_null(ptr, "is_null");
 
     let ret_0 = function.append_basic_block("ret_0");
     let ret_idx = function.append_basic_block("ret_idx");
@@ -82,9 +82,9 @@ fn test_null_checked_ptr_ops() {
 
     // FIXME: This might not work if compiled on non 64bit devices. Ideally we'd
     // be able to create pointer sized ints easily
-    let ptr_as_int = builder.build_ptr_to_int(&ptr, &i64_type, "ptr_as_int");
-    let new_ptr_as_int = builder.build_int_add(&ptr_as_int, &one, "add");
-    let new_ptr = builder.build_int_to_ptr(&new_ptr_as_int, &i8_ptr_type, "int_as_ptr");
+    let ptr_as_int = builder.build_ptr_to_int(ptr, i64_type, "ptr_as_int");
+    let new_ptr_as_int = builder.build_int_add(ptr_as_int, one, "add");
+    let new_ptr = builder.build_int_to_ptr(new_ptr_as_int, i8_ptr_type, "int_as_ptr");
     let index1 = builder.build_load(&new_ptr, "deref");
 
     builder.build_return(Some(&index1));
@@ -105,7 +105,7 @@ fn test_null_checked_ptr_ops() {
 
     let ptr = function.get_first_param().unwrap().into_pointer_value();
 
-    let is_not_null = builder.build_is_not_null(&ptr, "is_not_null");
+    let is_not_null = builder.build_is_not_null(ptr, "is_not_null");
 
     let ret_idx = function.append_basic_block("ret_idx");
     let ret_0 = function.append_basic_block("ret_0");
@@ -119,9 +119,9 @@ fn test_null_checked_ptr_ops() {
 
     // FIXME: This might not work if compiled on non 64bit devices. Ideally we'd
     // be able to create pointer sized ints easily
-    let ptr_as_int = builder.build_ptr_to_int(&ptr, &i64_type, "ptr_as_int");
-    let new_ptr_as_int = builder.build_int_add(&ptr_as_int, &one, "add");
-    let new_ptr = builder.build_int_to_ptr(&new_ptr_as_int, &i8_ptr_type, "int_as_ptr");
+    let ptr_as_int = builder.build_ptr_to_int(ptr, i64_type, "ptr_as_int");
+    let new_ptr_as_int = builder.build_int_add(ptr_as_int, one, "add");
+    let new_ptr = builder.build_int_to_ptr(new_ptr_as_int, i8_ptr_type, "int_as_ptr");
     let index1 = builder.build_load(&new_ptr, "deref");
 
     builder.build_return(Some(&index1));
@@ -167,7 +167,7 @@ fn test_binary_ops() {
     let left = fn_value.get_first_param().unwrap().into_int_value();
     let right = fn_value.get_last_param().unwrap().into_int_value();
 
-    let and = builder.build_and(&left, &right, "and_op");
+    let and = builder.build_and(left, right, "and_op");
 
     builder.build_return(Some(&and));
 
@@ -184,7 +184,7 @@ fn test_binary_ops() {
     let left = fn_value.get_first_param().unwrap().into_int_value();
     let right = fn_value.get_last_param().unwrap().into_int_value();
 
-    let or = builder.build_or(&left, &right, "or_op");
+    let or = builder.build_or(left, right, "or_op");
 
     builder.build_return(Some(&or));
 
@@ -201,7 +201,7 @@ fn test_binary_ops() {
     let left = fn_value.get_first_param().unwrap().into_int_value();
     let right = fn_value.get_last_param().unwrap().into_int_value();
 
-    let xor = builder.build_xor(&left, &right, "xor_op");
+    let xor = builder.build_xor(left, right, "xor_op");
 
     builder.build_return(Some(&xor));
 
@@ -274,7 +274,7 @@ fn test_switch() {
 
     builder.position_at_end(&else_);
 
-    let double = builder.build_int_mul(&value, &i8_two, "double");
+    let double = builder.build_int_mul(value, i8_two, "double");
 
     builder.build_return(Some(&double));
 
@@ -312,7 +312,7 @@ fn test_bit_shifts() {
 
     builder.position_at_end(&entry);
 
-    let shift = builder.build_left_shift(&value, &bits, "shl");
+    let shift = builder.build_left_shift(value, bits, "shl");
 
     builder.build_return(Some(&shift));
 
@@ -328,7 +328,7 @@ fn test_bit_shifts() {
 
     builder.position_at_end(&entry);
 
-    let shift = builder.build_right_shift(&value, &bits, false, "shr");
+    let shift = builder.build_right_shift(value, bits, false, "shr");
 
     builder.build_return(Some(&shift));
 
@@ -344,7 +344,7 @@ fn test_bit_shifts() {
 
     builder.position_at_end(&entry);
 
-    let shift = builder.build_right_shift(&value, &bits, true, "shr");
+    let shift = builder.build_right_shift(value, bits, true, "shr");
 
     builder.build_return(Some(&shift));
 

--- a/tests/test_execution_engine.rs
+++ b/tests/test_execution_engine.rs
@@ -81,7 +81,7 @@ fn test_jit_execution_engine() {
     builder.position_at_end(&check_argc);
 
     let eq = IntPredicate::EQ;
-    let argc_check = builder.build_int_compare(eq, &main_argc, &three_i32, "argc_cmp");
+    let argc_check = builder.build_int_compare(eq, main_argc, three_i32, "argc_cmp");
 
     builder.build_conditional_branch(&argc_check, &check_arg3, &error1);
 

--- a/tests/test_tari_example.rs
+++ b/tests/test_tari_example.rs
@@ -26,8 +26,8 @@ fn test_tari_example() {
     let y = function.get_nth_param(1).unwrap().into_int_value();
     let z = function.get_nth_param(2).unwrap().into_int_value();
 
-    let sum = builder.build_int_add(&x, &y, "sum");
-    let sum = builder.build_int_add(&sum, &z, "sum");
+    let sum = builder.build_int_add(x, y, "sum");
+    let sum = builder.build_int_add(sum, z, "sum");
 
     builder.build_return(Some(&sum));
 

--- a/tests/test_values.rs
+++ b/tests/test_values.rs
@@ -46,8 +46,8 @@ fn test_instructions() {
     let f32_val = f32_type.const_float(::std::f64::consts::PI);
 
     let store_instruction = builder.build_store(&arg1, &f32_val);
-    let ptr_val = builder.build_ptr_to_int(&arg1, &i64_type, "ptr_val");
-    let ptr = builder.build_int_to_ptr(&ptr_val, &f32_ptr_type, "ptr");
+    let ptr_val = builder.build_ptr_to_int(arg1, i64_type, "ptr_val");
+    let ptr = builder.build_int_to_ptr(ptr_val, f32_ptr_type, "ptr");
     let free_instruction = builder.build_free(&arg1);
     let return_instruction = builder.build_return(None);
 


### PR DESCRIPTION
This PR introduces the ability for math functions to take and return vector values in a type-safe way, as discussed in #45. Please note that I'm pretty new to Rust in general, so there are possibly some things here that can be done better :)

## Description

The PR primarily introduces two new traits, `FloatMathValue` and `IntMathValue`, which are implemented by `FloatValue`/`VectorValue` and `IntValue`/`VectorValue` respectively. Applicable methods on the `Builder` have been adjusted to take and return a type that implements these traits - meaning, for example, if you call `build_float_add` with a vector as the LHS, you must pass a vector for the RHS and you will get a vector back. Since there's no sub-type support yet we can't ensure the passed vectors are actually composed of integers or floats, however I assume this will be a part of 0.2.0.

There are some more complicated statements that require both a value and a target type, such as `build_float_to_signed_int` (which takes a floating point and new integer type, and returns an integer). LLVM allows us to pass in a vector as the value here, but also requires in that case that we pass in a vector type - in order to support this, the PR adds `FloatMathType` and `IntMathType` traits and associated types to navigate between value -> type -> converted type -> value. This means we can ensure the target type is valid (i.e is a vector when the input value is a vector, or an int type otherwise in the `build_float_to_signed_int` case), at the cost of some long type paths in `builder.rs`.

**Note:** this PR doesn't implement vector support for functions like `build_ptr_to_int`, although [LLVM does support vectors](https://llvm.org/docs/LangRef.html#ptrtoint-to-instruction) for these functions, since I didn't want to complicate the PR too much. I can add these in if it makes sense though.

## Breaking Changes

As per one of the requested changes, all math functions now take ownership of their input types/values instead of taking references.

## How This Has Been Tested

Due to some weird `llvm-sys` linking issues on my computer, I haven't actually been able to run the test suite (so we'll see if the CI passes :)). However, this PR is entirely type changes and shouldn't affect anything during runtime. Both the tests, the example, and my own personal project compile fine without any changes.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
