### PR TITLE
Add macos cases for linux specific tests

### DIFF
--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -307,7 +307,7 @@ fn test_print_to_file() {
     builder.position_at_end(&basic_block);
     builder.build_return(None);
 
-    let bad_path = Path::new("/");
+    let bad_path = Path::new("/tmp/some/silly/path/that/sure/doesn't/exist");
 
     assert_eq!(*module.print_to_file(bad_path).unwrap_err(), *CString::new("No such file or directory").unwrap());
 

--- a/tests/test_targets.rs
+++ b/tests/test_targets.rs
@@ -120,6 +120,8 @@ fn test_default_target_triple() {
     let cond = *default_target_triple == *CString::new("x86_64-pc-linux-gnu").unwrap() ||
                *default_target_triple == *CString::new("x86_64-unknown-linux-gnu").unwrap();
 
+    #[cfg(target_os = "macos")]
+    let cond = *default_target_triple == *CString::new("x86_64-apple-darwin17.5.0").unwrap();
 
     // let cond = *default_target_triple == *CString::new("x86_64-pc-linux-gnu").unwrap() |
     //     *default_target_triple == *CString::new("x86_64-unknown-linux-gnu").unwrap();
@@ -140,7 +142,15 @@ fn test_target_data() {
 
     let data_layout = target_data.get_data_layout();
 
+    #[cfg(target_os = "linux")]
     assert_eq!(data_layout.as_str(), &*CString::new("e-m:e-i64:64-f80:128-n8:16:32:64-S128").unwrap());
+
+    #[cfg(target_os = "macos")]
+    assert_eq!(
+        data_layout.as_str(),
+        &*CString::new("e-m:o-i64:64-f80:128-n8:16:32:64-S128").unwrap()
+    );
+
     #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8"))]
     assert_eq!(*module.get_data_layout().as_str(), *CString::new("").unwrap());
     // REVIEW: Why is llvm 3.9+ a %? 4.0 on travis doesn't have it, but does for me locally...


### PR DESCRIPTION
Add `terget_os="macos"` cases for tests (in place of #50 against master, and w/o rust-formating the files to minimize the diff). 

## Description

For the tests that were linux specific this adds cases to run on macos

## Related Issue
https://github.com/TheDan64/inkwell/issues/49

## How This Has Been Tested

The changes are exclusive to tests.

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
