### PR TITLE
Revert "Bind Symbol to the engine using lifetime not Rc"

### DIFF
--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -14,12 +14,12 @@ use std::error::Error;
 /// do `unsafe` operations internally.
 type SumFunc = unsafe extern "C" fn(u64, u64, u64) -> u64;
 
-fn jit_compile_sum<'engine>(
+fn jit_compile_sum(
     context: &Context,
     module: &Module,
     builder: &Builder,
-    execution_engine: &'engine ExecutionEngine,
-) -> Option<JitFunction<'engine, SumFunc>> {
+    execution_engine: &ExecutionEngine,
+) -> Option<JitFunction<SumFunc>> {
     let i64_type = context.i64_type();
     let fn_type = i64_type.fn_type(&[i64_type.into(), i64_type.into(), i64_type.into()], false);
 


### PR DESCRIPTION
This reverts commit 05f768efd31d3e8f7d41fc9526904f2c1633f5e2.

As discussed in https://github.com/TheDan64/inkwell/pull/57, introduction of a lifetime was somewhat controversial and makes API for the JIT compiler actually harder to use for common cases, so I went ahead and decided to create a PR to revert it at least for now.

If you think the lifetime change still makes more sense, feel free to close this PR.