### PR TITLE
Add ability to set linkage on GlobalValues

### DIFF
--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -1,5 +1,5 @@
 use llvm_sys::LLVMThreadLocalMode;
-use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMHasUnnamedAddr, LLVMSetUnnamedAddr, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment};
+use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMHasUnnamedAddr, LLVMSetUnnamedAddr, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
 #[llvm_versions(7.0 => latest)]
 use llvm_sys::LLVMUnnamedAddr;
 use llvm_sys::prelude::LLVMValueRef;
@@ -7,6 +7,7 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::{CString, CStr};
 
 use crate::{GlobalVisibility, ThreadLocalMode, DLLStorageClass};
+use crate::module::Linkage;
 use crate::support::LLVMString;
 #[llvm_versions(7.0 => latest)]
 use crate::comdat::Comdat;
@@ -274,6 +275,20 @@ impl GlobalValue {
 
         unsafe {
             LLVMSetUnnamedAddress(self.as_value_ref(), address.as_llvm_enum())
+        }
+    }
+
+    pub fn get_linkage(&self) -> Linkage {
+        let linkage = unsafe {
+            LLVMGetLinkage(self.as_value_ref())
+        };
+
+        Linkage::new(linkage)
+    }
+
+    pub fn set_linkage(&self, linkage: Linkage) {
+        unsafe {
+            LLVMSetLinkage(self.as_value_ref(), linkage.as_llvm_enum())
         }
     }
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -815,6 +815,7 @@ fn test_globals() {
     assert_eq!(global.get_section(), &*CString::new("").unwrap());
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());
+    assert_eq!(global.get_linkage(), External);
     assert_eq!(module.get_first_global().unwrap(), global);
     assert_eq!(module.get_last_global().unwrap(), global);
     assert_eq!(module.get_global("my_global").unwrap(), global);
@@ -843,6 +844,12 @@ fn test_globals() {
     assert!(global.is_constant());
     assert!(!global.is_declaration());
     assert_eq!(global.get_section(), &*CString::new("not sure what goes here").unwrap());
+
+    global.set_linkage(Private);
+
+    assert_eq!(global.get_linkage(), Private);
+    // Setting linkage seems to reset visibility
+    assert_eq!(global.get_visibility(), GlobalVisibility::Default);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]


### PR DESCRIPTION
## Description

Add ability to set linkage on GlobalValues.

Added basic tests as well, if you want some more tests, tell me and I will add them.

## Related Issue
https://github.com/TheDan64/inkwell/issues/79

## How This Has Been Tested
I believe this should be a very localized change. There are some very basic tests.

I have tested this with LLVM 7.0 only. I presume CI will run tests for everything else.