### PR TITLE
bugfix: use CString when passing path across FFI

### DIFF
--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -26,7 +26,7 @@ impl MemoryBuffer {
     }
 
     pub fn create_from_file(path: &Path) -> Result<Self, LLVMString> {
-        let path = path.to_str().expect("Did not find a valid Unicode path string");
+        let path = CString::new(path.to_str().expect("Did not find a valid Unicode path string")).expect("Failed to convert to CString");
         let mut memory_buffer = ptr::null_mut();
         let mut err_string = unsafe { zeroed() };
 


### PR DESCRIPTION
## Description

One-line fix for #83

## Related Issue

Fixes #83

## How This Has Been Tested

The reproduction example in #83 throws an error without this patch, and does not throw an error after this patch has been applied (to the `llvm7-0` branch).  `cargo test` still passes on the `llvm7-0` branch after this patch has been applied.  I have not tested branches other than the `llvm7-0` branch, including `master` (although the patch applies cleanly), and have not tested on platforms other than macOS.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
