### PR TITLE
Derive Hash on a bunch of Value types

### DIFF
--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -9,7 +9,7 @@ use crate::types::ArrayType;
 use crate::values::traits::AsValueRef;
 use crate::values::{Value, InstructionValue, MetadataValue};
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ArrayValue {
     array_value: Value
 }

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -8,7 +8,7 @@ use crate::values::{IntValue, FunctionValue, PointerValue, VectorValue, ArrayVal
 
 macro_rules! enum_value_set {
     ($enum_name:ident: $($args:ident),*) => (
-        #[derive(Debug, EnumAsGetters, EnumIntoGetters, EnumIsA, Clone, Copy, PartialEq, Eq)]
+        #[derive(Debug, EnumAsGetters, EnumIntoGetters, EnumIsA, Clone, Copy, PartialEq, Eq, Hash)]
         pub enum $enum_name {
             $(
                 $args($args),

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -9,7 +9,7 @@ use crate::types::{AsTypeRef, FloatType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value, MetadataValue};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FloatValue {
     float_value: Value
 }

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -19,7 +19,7 @@ use crate::types::{BasicTypeEnum, FunctionType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValueEnum, GlobalValue, Value, MetadataValue};
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FunctionValue {
     fn_value: Value,
 }

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -16,7 +16,7 @@ use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value};
 
 // REVIEW: GlobalValues are always PointerValues. With SubTypes, we should
 // compress this into a PointerValue<Global> type
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct GlobalValue {
     global_value: Value,
 }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -12,7 +12,7 @@ use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, Value};
 // REVIEW: Split up into structs for SubTypes on InstructionValues?
 // REVIEW: This should maybe be split up into InstructionOpcode and ConstOpcode?
 // see LLVMGetConstOpcode
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum InstructionOpcode {
     // Actual Instructions:
     Add,
@@ -236,7 +236,7 @@ impl InstructionOpcode {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy)]
+#[derive(Debug, PartialEq, Eq, Copy, Hash)]
 pub struct InstructionValue {
     instruction_value: Value,
 }

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -11,7 +11,7 @@ use crate::types::{AsTypeRef, FloatType, PointerType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value, MetadataValue};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct IntValue {
     int_value: Value,
 }

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -33,7 +33,7 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 #[cfg(feature = "llvm7-0")]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue {
     metadata_value: Value,
 }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -47,7 +47,7 @@ use std::fmt;
 
 use crate::support::LLVMString;
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 struct Value {
     value: LLVMValueRef,
 }

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -11,7 +11,7 @@ use crate::values::{BasicValue, BasicValueEnum, InstructionValue, Value};
 // REVIEW: Metadata for phi values?
 /// A Phi Instruction returns a value based on which basic block branched into
 /// the Phi's containing basic block.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct PhiValue {
     phi_value: Value
 }

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -7,7 +7,7 @@ use crate::support::LLVMString;
 use crate::types::{AsTypeRef, IntType, PointerType};
 use crate::values::{AsValueRef, InstructionValue, IntValue, Value, MetadataValue};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct PointerValue {
     ptr_value: Value,
 }

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -7,7 +7,7 @@ use crate::types::StructType;
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, Value, MetadataValue};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct StructValue {
     struct_value: Value
 }

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -8,7 +8,7 @@ use crate::types::{VectorType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValueEnum, BasicValue, InstructionValue, Value, IntValue, MetadataValue};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct VectorValue {
     vec_value: Value,
 }


### PR DESCRIPTION
## Description

This is a very small PR, so I hope you don't mind I submitted it without making an issue first (although I can certainly go back and make an issue if you want).  This PR simply adds `#[derive(Hash)]` to `Value`, its subtypes (e.g. `IntValue`), and the value-related enums (e.g. `BasicValueEnum`).  The primary motivation is so that downstream users can use any of these types as keys in `HashMap`s.  No functionality should be affected.

## How This Has Been Tested

I tested this on the `llvm7-0` branch and all tests still pass.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
