### PR TITLE
Derive Clone, Copy, and Hash for BasicBlock

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 /// A well formed `BasicBlock` is a list of non terminating instructions followed by a single terminating
 /// instruction. `BasicBlock`s are allowed to be malformed prior to running validation because it may be useful
 /// when constructing or modifying a program.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct BasicBlock {
     pub(crate) basic_block: LLVMBasicBlockRef,
 }


### PR DESCRIPTION
## Description

Like many other structs in this crate, `BasicBlock` is under-the-hood just a wrapper around an LLVM ref; however, unlike most similar structs, it doesn't implement `Clone` or `Copy`.  I added derives for `Clone` and `Copy` (and while I was at it, `Hash`).  I'm presuming that this won't be contentious, unless I'm missing something about how `BasicBlock` behaves.

## Related Issue

None; can make one if discussion is needed.

## How This Has Been Tested

All tests still pass after this patch has been applied to the `llvm7-0` branch.  Not tested with other branches, or on platforms other than macOS.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
