### PR TITLE
Add support for LLVM 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,18 @@ matrix:
             - *BASE_PACKAGES
             - llvm-7-dev
       rust: nightly-2019-01-15
+    - env:
+        - LLVM_VERSION="8.0"
+      <<: *BASE
+      addons:
+        apt:
+          sources:
+            - *BASE_SOURCES
+            - llvm-toolchain-trusty-8
+          packages:
+            - *BASE_PACKAGES
+            - llvm-8-dev
+      rust: nightly-2019-01-15
     - deploy: # Documentation build; Only latest supported LLVM version for now
         provider: pages
         skip-cleanup: true
@@ -139,10 +151,10 @@ matrix:
         on:
           branch: master
       before_install:
-        - export PATH=/usr/lib/llvm-7/bin/:$HOME/.local/bin:$PATH
-        - export LLVM_PATH=/usr/share/llvm-7/cmake/
+        - export PATH=/usr/lib/llvm-8/bin/:$HOME/.local/bin:$PATH
+        - export LLVM_PATH=/usr/share/llvm-8/cmake/
       script:
-        - cargo doc --no-default-features --features llvm7-0 --color=always
+        - cargo doc --no-default-features --features llvm8-0 --color=always
         - echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > target/doc/index.html
       rust: nightly
       name: "GitHub IO Documentation Deployment"
@@ -157,7 +169,8 @@ matrix:
             # - llvm-toolchain-trusty-4.0
             # - llvm-toolchain-trusty-5.0
             # - llvm-toolchain-trusty-6.0
-            - llvm-toolchain-trusty-7
+            # - llvm-toolchain-trusty-7
+            - llvm-toolchain-trusty-8
           packages:
             - *BASE_PACKAGES
             # - llvm-3.6-dev
@@ -167,7 +180,8 @@ matrix:
             # - llvm-4.0-dev
             # - llvm-5.0-dev
             # - llvm-6.0-dev
-            - llvm-7-dev
+            # - llvm-7-dev
+            - llvm-8-dev
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,14 @@ llvm4-0 = []
 llvm5-0 = []
 llvm6-0 = []
 llvm7-0 = []
+llvm8-0 = []
 
 [dependencies]
 either = "1.5"
 enum-methods = "0.0.8"
 inkwell_internal_macros = { path = "./internal_macros", version = "0.1.0" }
 libc = "0.2"
-llvm-sys = "70.0"
+llvm-sys = "80.0"
 
 [badges]
 travis-ci = { repository = "TheDan64/inkwell" }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inkwell aims to help you pen your own programming languages by safely wrapping l
 
 * Rust 1.31+
 * Rust Stable, Beta, or Nightly
-* LLVM 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, or 7.0
+* LLVM 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, or 8.0
 
 ## Usage
 
@@ -38,6 +38,7 @@ Supported versions:
 | 5.0.x        | llvm5-0       |
 | 6.0.x        | llvm6-0       |
 | 7.0.x        | llvm7-0       |
+| 8.0.x        | llvm8-0       |
 
 ## Documentation
 

--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -40,7 +40,7 @@ fn jit_compile_sum(
     unsafe { execution_engine.get_function("sum").ok() }
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let context = Context::create();
     let module = context.create_module("sum");
     let builder = context.create_builder();

--- a/examples/kaleidoscope/main.rs
+++ b/examples/kaleidoscope/main.rs
@@ -155,7 +155,7 @@ impl<'a> Lexer<'a> {
                 Ok(Token::Comment)
             },
 
-            '.' | '0' ... '9' => {
+            '.' | '0' ..= '9' => {
                 // Parse number literal
                 loop {
                     let ch = match chars.peek() {
@@ -175,7 +175,7 @@ impl<'a> Lexer<'a> {
                 Ok(Token::Number(src[start..pos].parse().unwrap()))
             },
 
-            'a' ... 'z' | 'A' ... 'Z' | '_' => {
+            'a' ..= 'z' | 'A' ..= 'Z' | '_' => {
                 // Parse identifier
                 loop {
                     let ch = match chars.peek() {

--- a/internal_macros/Cargo.toml
+++ b/internal_macros/Cargo.toml
@@ -3,10 +3,15 @@ name = "inkwell_internal_macros"
 version = "0.1.0"
 authors = ["Daniel Kolsoi <thadan64@gmail.com>"]
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 quote = "0.6"
 syn = { version = "0.15", features = ["full"] }
+proc-macro2 = "0.4"
+
+[build-dependencies]
+cargo_toml = "0.6"
 
 [lib]
 proc-macro = true

--- a/internal_macros/Cargo.toml
+++ b/internal_macros/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 quote = "0.6"
-syn = { version = "0.15", features = ["full"] }
+syn = { version = "0.15", features = ["full", "fold"] }
 proc-macro2 = "0.4"
 
 [build-dependencies]

--- a/internal_macros/build.rs
+++ b/internal_macros/build.rs
@@ -1,0 +1,24 @@
+extern crate cargo_toml;
+
+use cargo_toml::Manifest;
+
+use std::path::Path;
+
+fn main() {
+    let manifest_path = "../Cargo.toml";
+    let manifest = Manifest::from_path(Path::new(manifest_path))
+        .expect("Unable to load Cargo manifest!");
+
+    let features = manifest.features
+        .keys()
+        .filter(|feature| feature.as_str().starts_with("llvm"))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let features_csv = features.as_slice().join(",");
+
+    // Exports a comma-separated feature list in the environment during compilation
+    // Can be fetched with `env!("INKWELL_FEATURES")`
+    println!("cargo:rustc-env=INKWELL_FEATURES={}", features_csv);
+    println!("cargo:rerun-if-changed={}", manifest_path);
+}

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -8,11 +8,13 @@ extern crate syn;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Arm, Expr, ExprLit, Item, Lit, punctuated::Pair, Pat, PatLit, parse_macro_input};
+use syn::parse_macro_input;
+use syn::parse::{Parse, ParseStream, Result, Error};
+use syn::{Token, LitFloat, Ident, Item};
 
 // We could include_str! inkwell's Cargo.toml and extract these features
 // so that they don't need to also be managed here...
-const ALL_FEATURE_VERSIONS: [&str; 8] = [
+const ALL_FEATURE_VERSIONS: [&str; 9] = [
     "llvm3-6",
     "llvm3-7",
     "llvm3-8",
@@ -21,25 +23,41 @@ const ALL_FEATURE_VERSIONS: [&str; 8] = [
     "llvm5-0",
     "llvm6-0",
     "llvm7-0",
+    "llvm8-0",
 ];
 
 fn panic_with_usage() -> ! {
-    panic!("llvm_versions must take the form: X.Y => (X.Y || latest)");
+    panic!("llvm_versions must take the form: X.Y or X.Y => (X.Y || latest)");
 }
 
-fn get_latest_feature() -> String {
-    ALL_FEATURE_VERSIONS[ALL_FEATURE_VERSIONS.len() - 1].into()
+fn get_latest_feature_index() -> usize {
+    ALL_FEATURE_VERSIONS.len() - 1
 }
 
-fn get_feature_slice(start_feature: &str, end_feature: &str) -> Option<&'static [&'static str]> {
-    let start_index = ALL_FEATURE_VERSIONS.iter().position(|&str| str == start_feature)?;
-    let end_index = ALL_FEATURE_VERSIONS.iter().position(|&str| str == end_feature)?;
-
-    if end_index < start_index {
-        return None;
+fn get_feature_slice(vt: VersionType) -> Option<&'static [&'static str]> {
+    match vt {
+        VersionType::Specific(version) => {
+            let feature = f64_to_feature_string(version);
+            let index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == feature)?;
+            Some(&ALL_FEATURE_VERSIONS[index..index])
+        }
+        VersionType::RangeToLatest(version) => {
+            let latest = get_latest_feature_index();
+            let feature = f64_to_feature_string(version);
+            let index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == feature)?;
+            Some(&ALL_FEATURE_VERSIONS[index..=latest])
+        }
+        VersionType::Range(start, end) => {
+            let start_feature = f64_to_feature_string(start);
+            let end_feature = f64_to_feature_string(end);
+            let start_index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == start_feature)?;
+            let end_index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == end_feature)?;
+            if end_index < start_index {
+                return None;
+            }
+            Some(&ALL_FEATURE_VERSIONS[start_index..=end_index])
+        }
     }
-
-    Some(&ALL_FEATURE_VERSIONS[start_index..=end_index])
 }
 
 fn f64_to_feature_string(float: f64) -> String {
@@ -48,29 +66,52 @@ fn f64_to_feature_string(float: f64) -> String {
     format!("llvm{}-{}", int, (float * 10.) % 10.)
 }
 
+enum VersionType {
+    Specific(f64),
+    RangeToLatest(f64),
+    Range(f64, f64),
+}
+impl Parse for VersionType {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(LitFloat) {
+            let from = input.parse::<LitFloat>().unwrap().value();
+            if input.is_empty() {
+                return Ok(VersionType::Specific(from));
+            }
+            let lookahead = input.lookahead1();
+            if lookahead.peek(Token![=>]) {
+                let _: Token![=>] = input.parse().unwrap();
+                let lookahead = input.lookahead1();
+                if lookahead.peek(Ident) {
+                    let to = input.parse::<Ident>().unwrap();
+                    if to.to_string() == "latest" {
+                        Ok(VersionType::RangeToLatest(from))
+                    } else {
+                        Err(Error::new(to.span(), "expected `latest`"))
+                    }
+                } else if lookahead.peek(LitFloat) {
+                    let to = input.parse::<LitFloat>().unwrap().value();
+                    Ok(VersionType::Range(from, to))
+                } else {
+                    Err(lookahead.error())
+                }
+            } else {
+                Err(lookahead.error())
+            }
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
 #[proc_macro_attribute]
 pub fn llvm_versions(attribute_args: TokenStream, attributee: TokenStream) -> TokenStream {
-    let arm = parse_macro_input!(attribute_args as Arm);
+    let vt = parse_macro_input!(attribute_args as VersionType);
 
-    if arm.pats.len() != 1 {
-        panic_with_usage();
-    }
+    let features = get_feature_slice(vt)
+        .unwrap_or_else(|| panic_with_usage());
 
-    let start_feature = match arm.pats.first().unwrap() {
-        Pair::End(Pat::Lit(PatLit { expr })) => match **expr {
-            Expr::Lit(ExprLit { lit: Lit::Float(ref literal_float), .. }) => f64_to_feature_string(literal_float.value()),
-            _ => panic_with_usage(),
-        },
-        _ => panic_with_usage(),
-    };
-    let end_feature = match *arm.body {
-        Expr::Lit(ExprLit { lit: Lit::Float(literal_float), .. }) => Some(f64_to_feature_string(literal_float.value())),
-        // We could assert the path is just "latest" but this seems like a lot of extra work...
-        Expr::Path(_) => None,
-        _ => panic_with_usage(),
-    }.unwrap_or_else(get_latest_feature);
-
-    let features = get_feature_slice(&start_feature, &end_feature).unwrap_or_else(|| panic_with_usage());
     let attributee: Item = syn::parse(attributee).expect("Could not parse attributed item");
 
     let q = quote! {

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -18,19 +18,19 @@ use syn::{Token, LitFloat, Ident, Item};
 
 const FEATURES_ENV: &'static str = env!("INKWELL_FEATURES");
 
-// Fetches a vector of feature version strings, e.g. llvm8-0
+/// Fetches a vector of feature version strings, e.g. llvm8-0
 fn get_feature_versions() -> Vec<&'static str> {
     FEATURES_ENV
         .split(',')
         .collect()
 }
 
-// Gets the index of the feature version that represents `latest`
+/// Gets the index of the feature version that represents `latest`
 fn get_latest_feature_index(features: &[&str]) -> usize {
     features.len() - 1
 }
 
-// Gets the index of the feature version that matches the input string
+/// Gets the index of the feature version that matches the input string
 fn get_feature_index(features: &[&str], feature: String, span: Span) -> Result<usize> {
     let feat = feature.as_str();
     match features.iter().position(|&s| s == feat) {
@@ -39,7 +39,7 @@ fn get_feature_index(features: &[&str], feature: String, span: Span) -> Result<u
     }
 }
 
-// Gets a vector of feature versions represented by the given VersionType
+/// Gets a vector of feature versions represented by the given VersionType
 fn get_features(vt: VersionType) -> Result<Vec<&'static str>> {
     let features = get_feature_versions();
     let latest = get_latest_feature_index(&features);
@@ -94,8 +94,8 @@ fn get_features(vt: VersionType) -> Result<Vec<&'static str>> {
     }
 }
 
-// Converts a version number as a float to its feature version 
-// string form (e.g. 8.0 => llvm8-0)
+/// Converts a version number as a float to its feature version 
+/// string form (e.g. 8.0 ..= llvm8-0)
 fn f64_to_feature_string(float: f64) -> String {
     let int = float as u64;
 

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -3,97 +3,160 @@
 //! Here be dragons 🐉
 
 extern crate proc_macro;
+extern crate proc_macro2;
 extern crate quote;
 extern crate syn;
 
+use std::iter::IntoIterator;
+
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
 use syn::parse_macro_input;
 use syn::parse::{Parse, ParseStream, Result, Error};
 use syn::{Token, LitFloat, Ident, Item};
 
-// We could include_str! inkwell's Cargo.toml and extract these features
-// so that they don't need to also be managed here...
-const ALL_FEATURE_VERSIONS: [&str; 9] = [
-    "llvm3-6",
-    "llvm3-7",
-    "llvm3-8",
-    "llvm3-9",
-    "llvm4-0",
-    "llvm5-0",
-    "llvm6-0",
-    "llvm7-0",
-    "llvm8-0",
-];
+const FEATURES_ENV: &'static str = env!("INKWELL_FEATURES");
 
-fn panic_with_usage() -> ! {
-    panic!("llvm_versions must take the form: X.Y or X.Y => (X.Y || latest)");
+// Fetches a vector of feature version strings, e.g. llvm8-0
+fn get_feature_versions() -> Vec<&'static str> {
+    FEATURES_ENV
+        .split(',')
+        .collect()
 }
 
-fn get_latest_feature_index() -> usize {
-    ALL_FEATURE_VERSIONS.len() - 1
+// Gets the index of the feature version that represents `latest`
+fn get_latest_feature_index(features: &[&str]) -> usize {
+    features.len() - 1
 }
 
-fn get_feature_slice(vt: VersionType) -> Option<&'static [&'static str]> {
+// Gets the index of the feature version that matches the input string
+fn get_feature_index(features: &[&str], feature: String, span: Span) -> Result<usize> {
+    let feat = feature.as_str();
+    match features.iter().position(|&s| s == feat) {
+        None => Err(Error::new(span, format!("Invalid feature version: {}, not defined", feature))),
+        Some(index) => Ok(index)
+    }
+}
+
+// Gets a vector of feature versions represented by the given VersionType
+fn get_features(vt: VersionType) -> Result<Vec<&'static str>> {
+    let features = get_feature_versions();
+    let latest = get_latest_feature_index(&features);
     match vt {
-        VersionType::Specific(version) => {
+        VersionType::Specific(version, span) => {
             let feature = f64_to_feature_string(version);
-            let index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == feature)?;
-            Some(&ALL_FEATURE_VERSIONS[index..=index])
+            let index = get_feature_index(&features, feature, span.clone())?;
+            Ok(features[index..=index].to_vec())
         }
-        VersionType::RangeToLatest(version) => {
-            let latest = get_latest_feature_index();
+        VersionType::InclusiveRangeToLatest(version, span) => {
             let feature = f64_to_feature_string(version);
-            let index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == feature)?;
-            Some(&ALL_FEATURE_VERSIONS[index..=latest])
+            let index = get_feature_index(&features, feature, span.clone())?;
+            Ok(features[index..=latest].to_vec())
         }
-        VersionType::Range(start, end) => {
+        VersionType::InclusiveRange((start, start_span), (end, end_span)) => {
             let start_feature = f64_to_feature_string(start);
             let end_feature = f64_to_feature_string(end);
-            let start_index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == start_feature)?;
-            let end_index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == end_feature)?;
+            let start_index = get_feature_index(&features, start_feature, start_span.clone())?;
+            let end_index = get_feature_index(&features, end_feature, end_span.clone())?;
             if end_index < start_index {
-                return None;
+                let message = format!("Invalid version range: {} must be greater than or equal to {}", start, end);
+                Err(Error::new(end_span, message))
+            } else {
+                Ok(features[start_index..=end_index].to_vec())
             }
-            Some(&ALL_FEATURE_VERSIONS[start_index..=end_index])
+        }
+        VersionType::ExclusiveRangeToLatest(version, span) => {
+            let feature = f64_to_feature_string(version);
+            let index = get_feature_index(&features, feature, span.clone())?;
+            if latest == index {
+                let message = format!("Invalid version range: {}..latest produces an empty feature set", version);
+                Err(Error::new(span, message))
+            } else {
+                Ok(features[index..latest].to_vec())
+            }
+        }
+        VersionType::ExclusiveRange((start, start_span), (end, end_span)) => {
+            let start_feature = f64_to_feature_string(start);
+            let end_feature = f64_to_feature_string(end);
+            let start_index = get_feature_index(&features, start_feature, start_span.clone())?;
+            let end_index = get_feature_index(&features, end_feature, end_span.clone())?;
+            if end_index == start_index {
+                let message = format!("Invalid version range: {}..{} produces an empty feature set", start, end);
+                Err(Error::new(start_span, message))
+            } else if end_index < start_index {
+                let message = format!("Invalid version range: {} must be greater than {}", start, end);
+                Err(Error::new(end_span, message))
+            } else {
+                Ok(features[start_index..end_index].to_vec())
+            }
         }
     }
 }
 
+// Converts a version number as a float to its feature version 
+// string form (e.g. 8.0 => llvm8-0)
 fn f64_to_feature_string(float: f64) -> String {
     let int = float as u64;
 
     format!("llvm{}-{}", int, (float * 10.) % 10.)
 }
 
+// This struct defines the type of version expressions parsable by `llvm_versions`
 #[derive(Debug)]
 enum VersionType {
-    Specific(f64),
-    RangeToLatest(f64),
-    Range(f64, f64),
+    Specific(f64, Span),
+    InclusiveRange((f64, Span), (f64, Span)),
+    InclusiveRangeToLatest(f64, Span),
+    ExclusiveRange((f64, Span), (f64, Span)),
+    ExclusiveRangeToLatest(f64, Span),
 }
 impl Parse for VersionType {
     fn parse(input: ParseStream) -> Result<Self> {
+        // We use lookahead to produce better syntax errors
         let lookahead = input.lookahead1();
+        // All version specifiers begin with a float
         if lookahead.peek(LitFloat) {
-            let from = input.parse::<LitFloat>().unwrap().value();
+            let from = input.parse::<LitFloat>().unwrap();
+            let from_val = from.value();
+            // If that's the end of the input, this was a specific version string
             if input.is_empty() {
-                return Ok(VersionType::Specific(from));
+                return Ok(VersionType::Specific(from_val, from.span()));
             }
+            // If the next token is ..= it is an inclusive range, .. is exclusive
+            // In both cases the right-hand operand must be either a float or an ident, `latest`
             let lookahead = input.lookahead1();
-            if lookahead.peek(Token![=>]) {
-                let _: Token![=>] = input.parse().unwrap();
+            if lookahead.peek(Token![..=]) {
+                let _: Token![..=] = input.parse().unwrap();
                 let lookahead = input.lookahead1();
                 if lookahead.peek(Ident) {
                     let to = input.parse::<Ident>().unwrap();
                     if to.to_string() == "latest" {
-                        Ok(VersionType::RangeToLatest(from))
+                        Ok(VersionType::InclusiveRangeToLatest(from_val, from.span()))
                     } else {
-                        Err(Error::new(to.span(), "expected `latest`"))
+                        Err(Error::new(to.span(), "expected `latest` or `X.Y`"))
                     }
                 } else if lookahead.peek(LitFloat) {
-                    let to = input.parse::<LitFloat>().unwrap().value();
-                    Ok(VersionType::Range(from, to))
+                    let to = input.parse::<LitFloat>().unwrap();
+                    let to_val = to.value();
+                    Ok(VersionType::InclusiveRange((from_val, from.span()), (to_val, to.span())))
+                } else {
+                    Err(lookahead.error())
+                }
+            } else if lookahead.peek(Token![..]) {
+                let _: Token![..] = input.parse().unwrap();
+                let lookahead = input.lookahead1();
+                if lookahead.peek(Ident) {
+                    let to = input.parse::<Ident>().unwrap();
+                    if to.to_string() == "latest" {
+                        Ok(VersionType::ExclusiveRangeToLatest(from_val, from.span()))
+                    } else {
+                        Err(Error::new(to.span(), "expected `latest` or `X.Y`"))
+                    }
+                } else if lookahead.peek(LitFloat) {
+                    let to = input.parse::<LitFloat>().unwrap();
+                    let to_val = to.value();
+                    Ok(VersionType::ExclusiveRange((from_val, from.span()), (to_val, to.span())))
                 } else {
                     Err(lookahead.error())
                 }
@@ -106,12 +169,27 @@ impl Parse for VersionType {
     }
 }
 
+#[derive(Debug)]
+struct FeatureSet(Vec<&'static str>);
+impl Parse for FeatureSet {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let version_type = input.parse::<VersionType>()?;
+        let features = get_features(version_type)?;
+        Ok(Self(features))
+    }
+}
+impl IntoIterator for FeatureSet {
+    type Item = &'static str;
+    type IntoIter = std::vec::IntoIter<&'static str>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 #[proc_macro_attribute]
 pub fn llvm_versions(attribute_args: TokenStream, attributee: TokenStream) -> TokenStream {
-    let vt = parse_macro_input!(attribute_args as VersionType);
-
-    let features = get_feature_slice(vt)
-        .unwrap_or_else(|| panic_with_usage());
+    let features = parse_macro_input!(attribute_args as FeatureSet);
 
     let attributee: Item = syn::parse(attributee).expect("Could not parse attributed item");
 

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -12,9 +12,11 @@ use std::iter::IntoIterator;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::parse_macro_input;
+use syn::{parse_quote, parse_macro_input, parenthesized};
 use syn::parse::{Parse, ParseStream, Result, Error};
-use syn::{Token, LitFloat, Ident, Item};
+use syn::fold::Fold;
+use syn::spanned::Spanned;
+use syn::{Token, LitFloat, Ident, Item, Field, Variant, Attribute};
 
 const FEATURES_ENV: &'static str = env!("INKWELL_FEATURES");
 
@@ -102,7 +104,7 @@ fn f64_to_feature_string(float: f64) -> String {
     format!("llvm{}-{}", int, (float * 10.) % 10.)
 }
 
-// This struct defines the type of version expressions parsable by `llvm_versions`
+/// This struct defines the type of version expressions parsable by `llvm_versions`
 #[derive(Debug)]
 enum VersionType {
     Specific(f64, Span),
@@ -169,13 +171,32 @@ impl Parse for VersionType {
     }
 }
 
+/// Handler for parsing of TokenStreams contained in item attributes
 #[derive(Debug)]
-struct FeatureSet(Vec<&'static str>);
+struct ParenthesizedFeatureSet(FeatureSet);
+impl Parse for ParenthesizedFeatureSet {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let _ = parenthesized!(content in input);
+        let features = content.parse::<FeatureSet>()?;
+        Ok(Self(features))
+    }
+}
+
+/// Handler for parsing of TokenStreams from macro input
+#[derive(Debug)]
+struct FeatureSet(Vec<&'static str>, Option<Error>);
+impl Default for FeatureSet {
+    fn default() -> Self {
+        // Default to all versions
+        Self(get_feature_versions(), None)
+    }
+}
 impl Parse for FeatureSet {
     fn parse(input: ParseStream) -> Result<Self> {
         let version_type = input.parse::<VersionType>()?;
         let features = get_features(version_type)?;
-        Ok(Self(features))
+        Ok(Self(features, None))
     }
 }
 impl IntoIterator for FeatureSet {
@@ -186,17 +207,382 @@ impl IntoIterator for FeatureSet {
         self.0.into_iter()
     }
 }
+impl FeatureSet {
+    #[inline]
+    fn has_error(&self) -> bool {
+        self.1.is_some()
+    }
 
+    #[inline]
+    fn set_error(&mut self, err: Error) {
+        self.1 = Some(err);
+    }
+
+    fn to_error(self) -> Error {
+        self.1.unwrap()
+    }
+
+    fn to_compile_error(self) -> TokenStream {
+        TokenStream::from(self.1.unwrap().to_compile_error())
+    }
+
+    fn expand_llvm_versions_attr(&mut self, attr: &Attribute) -> Attribute {
+        // Make no modifications if we've generated an error
+        if self.has_error() {
+            return attr.clone();
+        }
+
+        // If this isn't an llvm_versions attribute, skip it
+        if !attr.path.is_ident("llvm_versions") {
+            return attr.clone();
+        }
+
+        // Expand from llvm_versions to raw cfg attribute
+        match syn::parse2::<ParenthesizedFeatureSet>(attr.tts.clone()) {
+            Ok(ParenthesizedFeatureSet(features)) => {
+                parse_quote! {
+                    #[cfg(any(#(feature = #features),*))]
+                }
+            }
+            Err(err) => {
+                // We've hit an error, but we can't break out yet, 
+                // so we set the error in the FeatureSet state and
+                // avoid any further modifications until we can produce 
+                // the error
+                self.set_error(err);
+                attr.clone()
+            }
+        }
+    }
+}
+impl Fold for FeatureSet {
+    fn fold_variant(&mut self, mut variant: Variant) -> Variant {
+        if self.has_error() {
+            return variant;
+        }
+
+        let attrs = variant.attrs
+            .iter()
+            .map(|attr| self.expand_llvm_versions_attr(attr))
+            .collect::<Vec<_>>();
+        variant.attrs = attrs;
+        variant
+    }
+
+    fn fold_field(&mut self, mut field: Field) -> Field {
+        if self.has_error() {
+            return field;
+        }
+
+        let attrs = field.attrs
+            .iter()
+            .map(|attr| self.expand_llvm_versions_attr(attr))
+            .collect::<Vec<_>>();
+        field.attrs = attrs;
+        field
+    }
+}
+
+/// This macro can be used to specify version constraints for an enum/struct/union or
+/// other item which can be decorated with an attribute.
+/// 
+/// To use with enum variants or struct fields, you need to decorate the parent item with
+/// the `#[llvm_versioned_item]` attribute, as this is the hook we need to modify the AST
+/// of those items
+/// 
+/// # Examples
+/// 
+/// ```ignore
+/// // Inclusive range from 3.6 up to and including 3.9
+/// #[llvm_versions(3.6..=3.9)]
+/// 
+/// // Exclusive range from 3.6 up to but not including 4.0
+/// #[llvm_versions(3.6..4.0)]
+/// 
+/// // Inclusive range from 3.6 up to and including the latest release
+/// #[llvm_versions(3.6..=latest)]
+/// ```
 #[proc_macro_attribute]
 pub fn llvm_versions(attribute_args: TokenStream, attributee: TokenStream) -> TokenStream {
-    let features = parse_macro_input!(attribute_args as FeatureSet);
+    let mut features = parse_macro_input!(attribute_args as FeatureSet);
 
-    let attributee: Item = syn::parse(attributee).expect("Could not parse attributed item");
+    let attributee = parse_macro_input!(attributee as Item);
+    let folded = features.fold_item(attributee);
+
+    if features.has_error() {
+        return features.to_compile_error();
+    }
 
     let q = quote! {
         #[cfg(any(#(feature = #features),*))]
-        #attributee
+        #folded
     };
 
+    q.into()
+}
+
+/// This attribute is used to decorate enums, structs, or unions which may contain
+/// variants/fields which make use of `#[llvm_versions(..)]`
+/// 
+/// # Examples
+/// 
+/// ```ignore
+/// #[llvm_versioned_item]
+/// enum InstructionOpcode {
+///     Call,
+///     #[llvm_versions(3.8..=latest)]
+///     CatchPad,
+///     ...
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn llvm_versioned_item(_attribute_args: TokenStream, attributee: TokenStream) -> TokenStream {
+    let attributee = parse_macro_input!(attributee as Item);
+
+    let mut features = FeatureSet::default();
+    let folded = features.fold_item(attributee);
+
+    if features.has_error() {
+        return features.to_compile_error();
+    }
+
+    quote!(#folded).into()
+}
+
+/// Used to track an enum variant and its corresponding mappings (LLVM <-> Rust),
+/// as well as attributes
+struct EnumVariant {
+    llvm_variant: Ident,
+    rust_variant: Ident,
+    attrs: Vec<Attribute>,
+}
+impl EnumVariant {
+    fn new(variant: &Variant) -> Self {
+        let rust_variant = variant.ident.clone();
+        let llvm_variant = Ident::new(&format!("LLVM{}", rust_variant.to_string()), variant.span());
+        let mut attrs = variant.attrs.clone();
+        attrs.retain(|attr| !attr.path.is_ident("llvm_variant"));
+        Self {
+            llvm_variant,
+            rust_variant,
+            attrs,
+        }
+    }
+
+    fn with_name(variant: &Variant, mut llvm_variant: Ident) -> Self {
+        let rust_variant = variant.ident.clone();
+        llvm_variant.set_span(rust_variant.span());
+        let mut attrs = variant.attrs.clone();
+        attrs.retain(|attr| !attr.path.is_ident("llvm_variant"));
+        Self {
+            llvm_variant,
+            rust_variant,
+            attrs,
+        }
+    }
+}
+
+/// Used when constructing the variants of an enum declaration.
+#[derive(Default)]
+struct EnumVariants {
+    variants: Vec<EnumVariant>,
+    error: Option<Error>,
+}
+impl EnumVariants {
+    #[inline]
+    fn len(&self) -> usize {
+        self.variants.len()
+    }
+
+    #[inline]
+    fn iter(&self) -> core::slice::Iter<'_, EnumVariant> {
+        self.variants.iter()
+    }
+
+    #[inline]
+    fn has_error(&self) -> bool {
+        self.error.is_some()
+    }
+
+    #[inline]
+    fn set_error(&mut self, err: &str, span: Span) {
+        self.error = Some(Error::new(span, err));
+    }
+
+    fn to_error(self) -> Error {
+        self.error.unwrap()
+    }
+}
+impl Fold for EnumVariants {
+    fn fold_variant(&mut self, mut variant: Variant) -> Variant {
+        use syn::{Meta, NestedMeta};
+
+        if self.has_error() {
+            return variant;
+        }
+
+        // Check for llvm_variant
+        if let Some(attr) = variant.attrs.iter().find(|attr| attr.path.is_ident("llvm_variant")) {
+            // Extract attribute meta
+            if let Ok(Meta::List(meta)) = attr.parse_meta() {
+                // We should only have one element
+                if meta.nested.len() == 1 {
+                    let variant_meta = meta.nested.first().unwrap();
+                    // The element should be an identifier
+                    if let NestedMeta::Meta(Meta::Word(name)) = variant_meta.value().clone() {
+                        self.variants.push(EnumVariant::with_name(&variant, name.clone()));
+                        // Strip the llvm_variant attribute from the final AST
+                        variant.attrs.retain(|attr| !attr.path.is_ident("llvm_variant"));
+                        return variant;
+                    }
+                }
+            }
+
+            // If at any point we fall through to here, it is the same basic issue, invalid format
+            self.set_error("expected #[llvm_variant(VARIANT_NAME)]", attr.span());
+            return variant;
+        }
+
+        self.variants.push(EnumVariant::new(&variant));
+        variant
+    }
+}
+
+/// Used to parse an enum declaration decorated with `#[llvm_enum(..)]`
+struct LLVMEnumType {
+    name: Ident,
+    decl: syn::ItemEnum,
+    variants: EnumVariants,
+}
+impl Parse for LLVMEnumType {
+    fn parse(input: ParseStream) -> Result<Self> {
+        // Parse enum declaration
+        let decl = input.parse::<syn::ItemEnum>()?;
+        let name = decl.ident.clone();
+        // Fold over variants and expand llvm_versions
+        let mut features = FeatureSet::default();
+        let decl = features.fold_item_enum(decl);
+        if features.has_error() {
+            return Err(features.to_error());
+        }
+
+        let mut variants = EnumVariants::default();
+        let decl = variants.fold_item_enum(decl);
+        if variants.has_error() {
+            return Err(variants.to_error());
+        }
+
+        Ok(Self {
+            name,
+            decl,
+            variants,
+        })
+    } 
+}
+
+/// This attribute macro allows you to decorate an enum declaration which represents
+/// an LLVM enum with versioning constraints and/or custom variant names. There are
+/// a few expectations around the LLVM and Rust enums:
+/// 
+/// - Both enums have the same number of variants
+/// - The name of the LLVM variant can be derived by appending 'LLVM' to the Rust variant
+/// 
+/// The latter can be worked around manually with `#[llvm_variant]` if desired.
+/// 
+/// # Examples
+/// 
+/// ```ignore
+/// #[llvm_enum(LLVMOpcode)]
+/// enum InstructionOpcode {
+///     Call,
+///     #[llvm_versions(3.8..=latest)]
+///     CatchPad,
+///     ...,
+///     #[llvm_variant(LLVMRet)]
+///     Return,
+///     ...
+/// }
+/// ```
+/// 
+/// The use of `#[llvm_variant(NAME)]` allows you to override the default
+/// naming scheme by providing the variant name which the source enum maps
+/// to. In the above example, `Ret` was deemed unnecessarily concise, so the
+/// source variant is named `Return` and mapped manually to `LLVMRet`.
+#[proc_macro_attribute]
+pub fn llvm_enum(attribute_args: TokenStream, attributee: TokenStream) -> TokenStream {
+    use syn::{Path, PatPath, Arm};
+
+    // Expect something like #[llvm_enum(LLVMOpcode)]
+    let llvm_ty = parse_macro_input!(attribute_args as Path);
+    let llvm_enum_type = parse_macro_input!(attributee as LLVMEnumType);
+
+    // Construct match arms for LLVM -> Rust enum conversion
+    let mut from_arms = Vec::with_capacity(llvm_enum_type.variants.len());
+    for variant in llvm_enum_type.variants.iter() {
+        let src_variant = variant.llvm_variant.clone();
+        let src_attrs = variant.attrs.clone();
+        let src_ty = llvm_ty.clone();
+        let dst_variant = variant.rust_variant.clone();
+        let dst_ty = llvm_enum_type.name.clone();
+
+        let pat = PatPath {
+            qself: None,
+            path: parse_quote!(#src_ty::#src_variant),
+        };
+
+        let arm: Arm = parse_quote! {
+            #(#src_attrs)*
+            #pat => { #dst_ty::#dst_variant }
+        };
+        from_arms.push(arm);
+    }
+
+    // Construct match arms for Rust -> LLVM enum conversion
+    let mut to_arms = Vec::with_capacity(llvm_enum_type.variants.len());
+    for variant in llvm_enum_type.variants.iter() {
+        let src_variant = variant.rust_variant.clone();
+        let src_attrs = variant.attrs.clone();
+        let src_ty = llvm_enum_type.name.clone();
+        let dst_variant = variant.llvm_variant.clone();
+        let dst_ty = llvm_ty.clone();
+
+        let pat = PatPath {
+            qself: None,
+            path: parse_quote!(#src_ty::#src_variant),
+        };
+
+        let arm: Arm = parse_quote! {
+            #(#src_attrs)*
+            #pat => { #dst_ty::#dst_variant }
+        };
+        to_arms.push(arm);
+    }
+
+    let enum_ty = llvm_enum_type.name.clone();
+    let enum_decl = llvm_enum_type.decl.clone();
+
+    let q = quote! {
+        #enum_decl
+
+        impl #enum_ty {
+            fn new(src: #llvm_ty) -> Self {
+                match src {
+                    #(#from_arms)*
+                }
+            }
+        }
+        impl From<#llvm_ty> for #enum_ty {
+            fn from(src: #llvm_ty) -> Self {
+                Self::new(src)
+            }
+        }
+        impl Into<#llvm_ty> for #enum_ty {
+            fn into(self) -> #llvm_ty {
+                match self {
+                    #(#to_arms),*
+                }
+            }
+        }
+    };
     q.into()
 }

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -39,7 +39,7 @@ fn get_feature_slice(vt: VersionType) -> Option<&'static [&'static str]> {
         VersionType::Specific(version) => {
             let feature = f64_to_feature_string(version);
             let index = ALL_FEATURE_VERSIONS.iter().position(|&s| s == feature)?;
-            Some(&ALL_FEATURE_VERSIONS[index..index])
+            Some(&ALL_FEATURE_VERSIONS[index..=index])
         }
         VersionType::RangeToLatest(version) => {
             let latest = get_latest_feature_index();
@@ -66,6 +66,7 @@ fn f64_to_feature_string(float: f64) -> String {
     format!("llvm{}-{}", int, (float * 10.) % 10.)
 }
 
+#[derive(Debug)]
 enum VersionType {
     Specific(f64),
     RangeToLatest(f64),

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,7 +1,7 @@
 //! A `BasicBlock` is a container of instructions.
 
 use llvm_sys::core::{LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator, LLVMGetNextBasicBlock, LLVMInsertBasicBlock, LLVMIsABasicBlock, LLVMIsConstant, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDeleteBasicBlock, LLVMGetPreviousBasicBlock, LLVMRemoveBasicBlockFromParent, LLVMGetFirstInstruction, LLVMGetLastInstruction, LLVMGetTypeContext, LLVMBasicBlockAsValue};
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMGetBasicBlockName;
 use llvm_sys::prelude::{LLVMValueRef, LLVMBasicBlockRef};
 
@@ -436,7 +436,7 @@ impl BasicBlock {
     ///
     /// assert_eq!(*bb.get_name(), *CString::new("entry").unwrap());
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_name(&self) -> &CStr {
         let ptr = unsafe {
             LLVMGetBasicBlockName(self.basic_block)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -67,7 +67,7 @@ impl Builder {
     /// builder.position_at_end(&entry);
     /// builder.build_return(Some(&i32_arg));
     /// ```
-    pub fn build_return(&self, value: Option<&BasicValue>) -> InstructionValue {
+    pub fn build_return(&self, value: Option<&dyn BasicValue>) -> InstructionValue {
         let value = unsafe {
             value.map_or_else(|| LLVMBuildRetVoid(self.builder), |value| LLVMBuildRet(self.builder, value.as_value_ref()))
         };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -993,7 +993,7 @@ impl Builder {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {
-            LLVMBuildCast(self.builder, op.as_llvm_opcode(), from_value.as_value_ref(), to_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildCast(self.builder, op.into(), from_value.as_value_ref(), to_type.as_type_ref(), c_string.as_ptr())
         };
 
         BasicValueEnum::new(value)

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,13 +1,13 @@
 //! A `Context` is an opaque owner and manager of core global data.
 
 use llvm_sys::core::{LLVMAppendBasicBlockInContext, LLVMContextCreate, LLVMContextDispose, LLVMCreateBuilderInContext, LLVMDoubleTypeInContext, LLVMFloatTypeInContext, LLVMFP128TypeInContext, LLVMInsertBasicBlockInContext, LLVMInt16TypeInContext, LLVMInt1TypeInContext, LLVMInt32TypeInContext, LLVMInt64TypeInContext, LLVMInt8TypeInContext, LLVMIntTypeInContext, LLVMModuleCreateWithNameInContext, LLVMStructCreateNamed, LLVMStructTypeInContext, LLVMVoidTypeInContext, LLVMHalfTypeInContext, LLVMGetGlobalContext, LLVMPPCFP128TypeInContext, LLVMConstStructInContext, LLVMMDNodeInContext, LLVMMDStringInContext, LLVMGetMDKindIDInContext, LLVMX86FP80TypeInContext, LLVMConstStringInContext, LLVMContextSetDiagnosticHandler};
-#[llvm_versions(4.0 => latest)]
+#[llvm_versions(4.0..=latest)]
 use llvm_sys::core::{LLVMCreateEnumAttribute, LLVMCreateStringAttribute};
 use llvm_sys::prelude::{LLVMContextRef, LLVMTypeRef, LLVMValueRef, LLVMDiagnosticInfoRef};
 use llvm_sys::ir_reader::LLVMParseIRInContext;
 use libc::c_void;
 
-#[llvm_versions(4.0 => latest)]
+#[llvm_versions(4.0..=latest)]
 use crate::attributes::Attribute;
 use crate::basic_block::BasicBlock;
 use crate::builder::Builder;
@@ -740,7 +740,7 @@ impl Context {
     ///
     /// assert!(enum_attribute.is_enum());
     /// ```
-    #[llvm_versions(4.0 => latest)]
+    #[llvm_versions(4.0..=latest)]
     pub fn create_enum_attribute(&self, kind_id: u32, val: u64) -> Attribute {
         let attribute = unsafe {
             LLVMCreateEnumAttribute(*self.context, kind_id, val)
@@ -761,7 +761,7 @@ impl Context {
     ///
     /// assert!(string_attribute.is_string());
     /// ```
-    #[llvm_versions(4.0 => latest)]
+    #[llvm_versions(4.0..=latest)]
     pub fn create_string_attribute(&self, key: &str, val: &str) -> Attribute {
         let attribute = unsafe {
             LLVMCreateStringAttribute(*self.context, key.as_ptr() as *const _, key.len() as u32, val.as_ptr() as *const _, val.len() as u32)

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -29,7 +29,7 @@ impl Error for FunctionLookupError {
         self.as_str()
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -63,7 +63,7 @@ impl Error for RemoveModuleError {
         self.as_str()
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -189,7 +189,7 @@ impl ExecutionEngine {
     ///
     /// assert_eq!(result, 128.);
     /// ```
-    pub fn add_global_mapping(&self, value: &AnyValue, addr: usize) {
+    pub fn add_global_mapping(&self, value: &dyn AnyValue, addr: usize) {
         unsafe {
             LLVMAddGlobalMapping(self.execution_engine_inner(), value.as_value_ref(), addr as *mut _)
         }
@@ -318,7 +318,7 @@ impl ExecutionEngine {
 
         // LLVMGetFunctionAddress segfaults in llvm 5.0 -> 7.0 when fn_name doesn't exist. This is a workaround
         // to see if it exists and avoid the segfault when it doesn't
-        #[cfg(any(feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0"))]
+        #[cfg(any(feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
         self.get_function_value(fn_name)?;
 
         let c_string = CString::new(fn_name).expect("Conversion to CString failed unexpectedly");

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -316,7 +316,7 @@ impl ExecutionEngine {
             return Err(FunctionLookupError::JITNotEnabled);
         }
 
-        // LLVMGetFunctionAddress segfaults in llvm 5.0 -> 7.0 when fn_name doesn't exist. This is a workaround
+         // LLVMGetFunctionAddress segfaults in llvm 5.0 -> 8.0 when fn_name doesn't exist. This is a workaround
         // to see if it exists and avoid the segfault when it doesn't
         #[cfg(any(feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
         self.get_function_value(fn_name)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0"}
+assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///

--- a/src/module.rs
+++ b/src/module.rs
@@ -5,18 +5,18 @@ use llvm_sys::analysis::{LLVMVerifyModule, LLVMVerifierFailureAction};
 use llvm_sys::bit_reader::{LLVMParseBitcode, LLVMParseBitcodeInContext};
 use llvm_sys::bit_writer::{LLVMWriteBitcodeToFile, LLVMWriteBitcodeToMemoryBuffer};
 use llvm_sys::core::{LLVMAddFunction, LLVMAddGlobal, LLVMDumpModule, LLVMGetNamedFunction, LLVMGetTypeByName, LLVMSetDataLayout, LLVMSetTarget, LLVMCloneModule, LLVMDisposeModule, LLVMGetTarget, LLVMModuleCreateWithName, LLVMGetModuleContext, LLVMGetFirstFunction, LLVMGetLastFunction, LLVMAddGlobalInAddressSpace, LLVMPrintModuleToString, LLVMGetNamedMetadataNumOperands, LLVMAddNamedMetadataOperand, LLVMGetNamedMetadataOperands, LLVMGetFirstGlobal, LLVMGetLastGlobal, LLVMGetNamedGlobal, LLVMPrintModuleToFile};
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use llvm_sys::core::{LLVMGetModuleIdentifier, LLVMSetModuleIdentifier};
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use llvm_sys::core::{LLVMGetModuleFlag, LLVMAddModuleFlag};
 use llvm_sys::execution_engine::{LLVMCreateInterpreterForModule, LLVMCreateJITCompilerForModule, LLVMCreateExecutionEngineForModule};
 use llvm_sys::prelude::{LLVMValueRef, LLVMModuleRef};
 use llvm_sys::LLVMLinkage;
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMModuleFlagBehavior;
 
 use std::cell::{Cell, RefCell, Ref};
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::fs::File;
@@ -27,7 +27,7 @@ use std::rc::Rc;
 use std::slice::from_raw_parts;
 
 use crate::{AddressSpace, OptimizationLevel};
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::context::{Context, ContextRef};
 use crate::data_layout::DataLayout;
@@ -37,7 +37,7 @@ use crate::support::LLVMString;
 use crate::targets::{Target, InitializationConfig};
 use crate::types::{AsTypeRef, BasicType, FunctionType, BasicTypeEnum};
 use crate::values::{AsValueRef, FunctionValue, GlobalValue, MetadataValue};
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use crate::values::BasicValue;
 
 enum_rename!{
@@ -1178,7 +1178,7 @@ impl Module {
     ///
     /// assert_eq!(*module.get_name(), *CString::new("my_mdoule").unwrap());
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_name(&self) -> &CStr {
         let mut length = 0;
         let cstr_ptr = unsafe {
@@ -1205,7 +1205,7 @@ impl Module {
     ///
     /// assert_eq!(*module.get_name(), *CString::new("my_module2").unwrap());
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn set_name(&self, name: &str) {
         unsafe {
             LLVMSetModuleIdentifier(self.module.get(), name.as_ptr() as *const i8, name.len())
@@ -1230,7 +1230,7 @@ impl Module {
     /// assert_eq!(*module.get_name(), *CString::new("my_mod").unwrap());
     /// assert_eq!(*module.get_source_file_name(), *CString::new("my_mod.rs").unwrap());
     /// ```
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_source_file_name(&self) -> &CStr {
         use llvm_sys::core::LLVMGetSourceFileName;
 
@@ -1262,7 +1262,7 @@ impl Module {
     /// assert_eq!(*module.get_name(), *CString::new("my_mod").unwrap());
     /// assert_eq!(*module.get_source_file_name(), *CString::new("my_mod.rs").unwrap());
     /// ```
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn set_source_file_name(&self, file_name: &str) {
         use llvm_sys::core::LLVMSetSourceFileName;
 
@@ -1338,7 +1338,7 @@ impl Module {
 
     /// Gets the `Comdat` associated with a particular name. If it does not exist, it will be created.
     /// A new `Comdat` defaults to a kind of `ComdatSelectionKind::Any`.
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_or_insert_comdat(&self, name: &str) -> Comdat {
         use llvm_sys::comdat::LLVMGetOrInsertComdat;
 
@@ -1354,7 +1354,7 @@ impl Module {
     /// If a `BasicValue` was used to create this flag, it will be wrapped in a `MetadataValue`
     /// when returned from this function.
     // SubTypes: Might need to return Option<BVE, MV<Enum>, or MV<String>>
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_flag(&self, key: &str) -> Option<MetadataValue> {
         use llvm_sys::core::LLVMMetadataAsValue;
 
@@ -1378,7 +1378,7 @@ impl Module {
 
     /// Append a `MetadataValue` as a module wide flag. Note that using the same key twice
     /// will likely invalidate the module.
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn add_metadata_flag(&self, key: &str, behavior: FlagBehavior, flag: MetadataValue) {
         let md = flag.as_metadata_ref();
 
@@ -1390,7 +1390,7 @@ impl Module {
     /// Append a `BasicValue` as a module wide flag. Note that using the same key twice
     /// will likely invalidate the module.
     // REVIEW: What happens if value is not const?
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn add_basic_value_flag<BV: BasicValue>(&self, key: &str, behavior: FlagBehavior, flag: BV) {
         use llvm_sys::core::LLVMValueAsMetadata;
 
@@ -1433,7 +1433,7 @@ impl Drop for Module {
     }
 }
 
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 enum_rename!{
     /// Defines the operational behavior for a module wide flag. This documenation comes directly
     /// from the LLVM docs

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -4,13 +4,13 @@ use llvm_sys::prelude::{LLVMPassManagerRef, LLVMPassRegistryRef};
 use llvm_sys::transforms::ipo::{LLVMAddArgumentPromotionPass, LLVMAddConstantMergePass, LLVMAddDeadArgEliminationPass, LLVMAddFunctionAttrsPass, LLVMAddFunctionInliningPass, LLVMAddAlwaysInlinerPass, LLVMAddGlobalDCEPass, LLVMAddGlobalOptimizerPass, LLVMAddIPConstantPropagationPass, LLVMAddIPSCCPPass, LLVMAddInternalizePass, LLVMAddStripDeadPrototypesPass, LLVMAddPruneEHPass, LLVMAddStripSymbolsPass};
 use llvm_sys::transforms::pass_manager_builder::{LLVMPassManagerBuilderRef, LLVMPassManagerBuilderCreate, LLVMPassManagerBuilderDispose, LLVMPassManagerBuilderSetOptLevel, LLVMPassManagerBuilderSetSizeLevel, LLVMPassManagerBuilderSetDisableUnitAtATime, LLVMPassManagerBuilderSetDisableUnrollLoops, LLVMPassManagerBuilderSetDisableSimplifyLibCalls, LLVMPassManagerBuilderUseInlinerWithThreshold, LLVMPassManagerBuilderPopulateFunctionPassManager, LLVMPassManagerBuilderPopulateModulePassManager, LLVMPassManagerBuilderPopulateLTOPassManager};
 use llvm_sys::transforms::scalar::{LLVMAddAggressiveDCEPass, LLVMAddMemCpyOptPass, LLVMAddAlignmentFromAssumptionsPass, LLVMAddCFGSimplificationPass, LLVMAddDeadStoreEliminationPass, LLVMAddScalarizerPass, LLVMAddMergedLoadStoreMotionPass, LLVMAddGVNPass, LLVMAddIndVarSimplifyPass, LLVMAddInstructionCombiningPass, LLVMAddJumpThreadingPass, LLVMAddLICMPass, LLVMAddLoopDeletionPass, LLVMAddLoopIdiomPass, LLVMAddLoopRotatePass, LLVMAddLoopRerollPass, LLVMAddLoopUnrollPass, LLVMAddLoopUnswitchPass, LLVMAddPartiallyInlineLibCallsPass, LLVMAddSCCPPass, LLVMAddScalarReplAggregatesPass, LLVMAddScalarReplAggregatesPassSSA, LLVMAddScalarReplAggregatesPassWithThreshold, LLVMAddSimplifyLibCallsPass, LLVMAddTailCallEliminationPass, LLVMAddConstantPropagationPass, LLVMAddDemoteMemoryToRegisterPass, LLVMAddVerifierPass, LLVMAddCorrelatedValuePropagationPass, LLVMAddEarlyCSEPass, LLVMAddLowerExpectIntrinsicPass, LLVMAddTypeBasedAliasAnalysisPass, LLVMAddScopedNoAliasAAPass, LLVMAddBasicAliasAnalysisPass, LLVMAddReassociatePass};
-#[llvm_versions(3.7 => latest)]
+#[llvm_versions(3.7..=latest)]
 use llvm_sys::transforms::scalar::LLVMAddBitTrackingDCEPass;
 use llvm_sys::transforms::vectorize::{LLVMAddLoopVectorizePass, LLVMAddSLPVectorizePass};
 
 use crate::OptimizationLevel;
 use crate::module::Module;
-#[llvm_versions(3.6 => 3.8)]
+#[llvm_versions(3.6..=3.8)]
 use crate::targets::TargetData;
 use crate::values::{AsValueRef, FunctionValue};
 
@@ -248,7 +248,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         }
     }
 
-    #[llvm_versions(3.6 => 3.8)]
+    #[llvm_versions(3.6..=3.8)]
     pub fn add_target_data(&self, target_data: &TargetData) {
         use llvm_sys::target::LLVMAddTargetData;
 
@@ -433,7 +433,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// for each pair of compatible instructions. These heuristics
     /// are intended to prevent vectorization in cases where it would
     /// not yield a performance increase of the resulting code.
-    #[llvm_versions(3.6 => 6.0)]
+    #[llvm_versions(3.6..=6.0)]
     pub fn add_bb_vectorize_pass(&self) {
         use llvm_sys::transforms::vectorize::LLVMAddBBVectorizePass;
 
@@ -467,7 +467,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         }
     }
 
-    #[llvm_versions(3.7 => latest)]
+    #[llvm_versions(3.7..=latest)]
     /// No LLVM documentation is available at this time.
     pub fn add_bit_tracking_dce_pass(&self) {
         unsafe {
@@ -529,7 +529,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// performs redundant load elimination.
     // REVIEW: Is `LLVMAddGVNPass` deprecated? Should we just seemlessly replace
     // the old one with this one in 4.0+?
-    #[llvm_versions(4.0 => latest)]
+    #[llvm_versions(4.0..=latest)]
     pub fn add_new_gvn_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddNewGVNPass;
 
@@ -784,9 +784,9 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// which allows targets to get away with not implementing the
     /// switch instruction until it is convenient.
     pub fn add_lower_switch_pass(&self) {
-        #[llvm_versions(3.6 => 6.0)]
+        #[llvm_versions(3.6..=6.0)]
         use llvm_sys::transforms::scalar::LLVMAddLowerSwitchPass;
-        #[llvm_versions(7.0 => latest)]
+        #[llvm_versions(7.0..=latest)]
         use llvm_sys::transforms::util::LLVMAddLowerSwitchPass;
 
         unsafe {
@@ -801,9 +801,9 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// order to rewrite loads and stores as appropriate. This is just
     /// the standard SSA construction algorithm to construct "pruned" SSA form.
     pub fn add_promote_memory_to_register_pass(&self) {
-        #[llvm_versions(3.6 => 6.0)]
+        #[llvm_versions(3.6..7.0)]
         use llvm_sys::transforms::scalar::LLVMAddPromoteMemoryToRegisterPass;
-        #[llvm_versions(7.0 => latest)]
+        #[llvm_versions(7.0..=latest)]
         use llvm_sys::transforms::util::LLVMAddPromoteMemoryToRegisterPass;
 
         unsafe {
@@ -1006,7 +1006,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         }
     }
 
-    #[llvm_versions(4.0 => latest)]
+    #[llvm_versions(4.0..=latest)]
     /// No LLVM documentation is available at this time.
     pub fn add_early_cse_mem_ssa_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddEarlyCSEMemSSAPass;
@@ -1054,7 +1054,7 @@ impl<T: PassManagerSubType> PassManager<T> {
             LLVMAddAggressiveInstCombinerPass(self.pass_manager)
         }
     }
-    #[llvm_versions(8.0 => latest)]
+    #[llvm_versions(8.0..=latest)]
     pub fn add_aggressive_inst_combiner_pass(&self) {
         use llvm_sys::transforms::aggressive_instcombine::LLVMAddAggressiveInstCombinerPass;
 
@@ -1064,7 +1064,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     }
 
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn add_loop_unroll_and_jam_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddLoopUnrollAndJamPass;
 
@@ -1177,7 +1177,7 @@ impl PassRegistry {
         }
     }
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn initialize_aggressive_inst_combiner(&self) {
         use llvm_sys::initialization::LLVMInitializeAggressiveInstCombiner;
 

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -110,7 +110,10 @@ impl PassManagerBuilder {
     /// ```
     /// use inkwell::OptimizationLevel::Aggressive;
     /// use inkwell::passes::{PassManager, PassManagerBuilder};
+    /// use inkwell::targets::{InitializationConfig, Target};
     ///
+    /// let config = InitializationConfig::default();
+    /// Target::initialize_native(&config).unwrap();
     /// let pass_manager_builder = PassManagerBuilder::create();
     ///
     /// pass_manager_builder.set_optimization_level(Aggressive);
@@ -133,7 +136,10 @@ impl PassManagerBuilder {
     /// ```
     /// use inkwell::OptimizationLevel::Aggressive;
     /// use inkwell::passes::{PassManager, PassManagerBuilder};
+    /// use inkwell::targets::{InitializationConfig, Target};
     ///
+    /// let config = InitializationConfig::default();
+    /// Target::initialize_native(&config).unwrap();
     /// let pass_manager_builder = PassManagerBuilder::create();
     ///
     /// pass_manager_builder.set_optimization_level(Aggressive);
@@ -1040,7 +1046,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         }
     }
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0)]
     pub fn add_aggressive_inst_combiner_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddAggressiveInstCombinerPass;
 
@@ -1048,6 +1054,15 @@ impl<T: PassManagerSubType> PassManager<T> {
             LLVMAddAggressiveInstCombinerPass(self.pass_manager)
         }
     }
+    #[llvm_versions(8.0 => latest)]
+    pub fn add_aggressive_inst_combiner_pass(&self) {
+        use llvm_sys::transforms::aggressive_instcombine::LLVMAddAggressiveInstCombinerPass;
+
+        unsafe {
+            LLVMAddAggressiveInstCombinerPass(self.pass_manager)
+        }
+    }
+
 
     #[llvm_versions(7.0 => latest)]
     pub fn add_loop_unroll_and_jam_pass(&self) {

--- a/src/support/error_handling.rs
+++ b/src/support/error_handling.rs
@@ -1,8 +1,8 @@
 //! This module contains some supplemental functions for dealing with errors.
 
-#[llvm_versions(3.6 => 3.7)]
+#[llvm_versions(3.6..3.8)]
 use llvm_sys::core::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler};
-#[llvm_versions(3.8 => latest)]
+#[llvm_versions(3.8..=latest)]
 use llvm_sys::error_handling::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler};
 use llvm_sys::core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity};
 use llvm_sys::prelude::LLVMDiagnosticInfoRef;

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -144,9 +144,9 @@ pub fn is_multithreaded() -> bool {
 }
 
 pub fn enable_llvm_pretty_stack_trace() {
-    #[llvm_versions(3.6 => 3.7)]
+    #[llvm_versions(3.6..=3.7)]
     use llvm_sys::core::LLVMEnablePrettyStackTrace;
-    #[llvm_versions(3.8 => latest)]
+    #[llvm_versions(3.8..=latest)]
     use llvm_sys::error_handling::LLVMEnablePrettyStackTrace;
 
     unsafe {

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -77,7 +77,7 @@ impl Error for LLVMString {
         self.to_str().expect("Could not convert LLVMString to str (likely invalid unicode)")
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,4 +1,4 @@
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use either::Either;
 use llvm_sys::target::{LLVMTargetDataRef, LLVMCopyStringRepOfTargetData, LLVMSizeOfTypeInBits, LLVMCreateTargetData, LLVMByteOrder, LLVMPointerSize, LLVMByteOrdering, LLVMStoreSizeOfType, LLVMABISizeOfType, LLVMABIAlignmentOfType, LLVMCallFrameAlignmentOfType, LLVMPreferredAlignmentOfType, LLVMPreferredAlignmentOfGlobal, LLVMElementAtOffset, LLVMOffsetOfElement, LLVMDisposeTargetData, LLVMPointerSizeForAS, LLVMIntPtrType, LLVMIntPtrTypeForAS, LLVMIntPtrTypeInContext, LLVMIntPtrTypeForASInContext};
 use llvm_sys::target_machine::{LLVMGetFirstTarget, LLVMTargetRef, LLVMGetNextTarget, LLVMGetTargetFromName, LLVMGetTargetFromTriple, LLVMGetTargetName, LLVMGetTargetDescription, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetHasAsmBackend, LLVMTargetMachineRef, LLVMDisposeTargetMachine, LLVMGetTargetMachineTarget, LLVMGetTargetMachineTriple, LLVMSetTargetMachineAsmVerbosity, LLVMCreateTargetMachine, LLVMGetTargetMachineCPU, LLVMGetTargetMachineFeatureString, LLVMGetDefaultTargetTriple, LLVMAddAnalysisPasses, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMRelocMode, LLVMCodeGenFileType, LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineEmitToFile};
@@ -244,7 +244,7 @@ impl Target {
     }
 
     // TODOC: Called R600 in 3.6
-    #[llvm_versions(3.7 => latest)]
+    #[llvm_versions(3.7..=latest)]
     pub fn initialize_amd_gpu(config: &InitializationConfig) {
         use llvm_sys::target::{LLVMInitializeAMDGPUTarget, LLVMInitializeAMDGPUTargetInfo, LLVMInitializeAMDGPUTargetMC, LLVMInitializeAMDGPUAsmPrinter, LLVMInitializeAMDGPUAsmParser};
 
@@ -357,7 +357,7 @@ impl Target {
         }
     }
 
-    #[llvm_versions(3.6 => 3.8)]
+    #[llvm_versions(3.6..=3.8)]
     pub fn initialize_cpp_backend(config: &InitializationConfig) {
         use llvm_sys::target::{LLVMInitializeCppBackendTarget, LLVMInitializeCppBackendTargetInfo, LLVMInitializeCppBackendTargetMC};
 
@@ -491,7 +491,7 @@ impl Target {
     }
 
     // TODOC: Disassembler only supported in LLVM 4.0+
-    #[llvm_versions(3.7 => latest)]
+    #[llvm_versions(3.7..=latest)]
     pub fn initialize_bpf(config: &InitializationConfig) {
         use llvm_sys::target::{LLVMInitializeBPFTarget, LLVMInitializeBPFTargetInfo, LLVMInitializeBPFTargetMC, LLVMInitializeBPFAsmPrinter};
 
@@ -525,7 +525,7 @@ impl Target {
         }
     }
 
-    #[llvm_versions(4.0 => latest)]
+    #[llvm_versions(4.0..=latest)]
     pub fn initialize_lanai(config: &InitializationConfig) {
         use llvm_sys::target::{LLVMInitializeLanaiTargetInfo, LLVMInitializeLanaiTarget, LLVMInitializeLanaiTargetMC, LLVMInitializeLanaiAsmPrinter, LLVMInitializeLanaiAsmParser, LLVMInitializeLanaiDisassembler};
 
@@ -839,7 +839,7 @@ impl TargetMachine {
         LLVMString::new(llvm_string)
     }
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn normalize_target_triple(triple: Either<&str, &CStr>) -> LLVMString {
         use llvm_sys::target_machine::LLVMNormalizeTargetTriple;
 
@@ -866,7 +866,7 @@ impl TargetMachine {
     /// # Example Output
     ///
     /// `x86_64-pc-linux-gnu`
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_host_cpu_name() -> LLVMString {
         use llvm_sys::target_machine::LLVMGetHostCPUName;
 
@@ -882,7 +882,7 @@ impl TargetMachine {
     /// # Example Output
     ///
     /// `+sse2,+cx16,+sahf,-tbm`
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_host_cpu_features() -> LLVMString {
         use llvm_sys::target_machine::LLVMGetHostCPUFeatures;
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -563,7 +563,7 @@ impl Target {
     // We can revisit this issue if someone wants RISCV support in inkwell, or if
     // llvm-sys starts supporting expiramental llvm targets. See
     // https://lists.llvm.org/pipermail/llvm-dev/2017-August/116347.html for more info
-    #[cfg(feature = "llvm4-0")]
+    #[llvm_versions(4.0)]
     pub fn initialize_riscv(config: &InitializationConfig) {
         use llvm_sys::target::{LLVMInitializeRISCVTargetInfo, LLVMInitializeRISCVTarget, LLVMInitializeRISCVTargetMC};
 
@@ -584,6 +584,37 @@ impl Target {
 
             if config.machine_code {
                 LLVMInitializeRISCVTargetMC()
+            }
+        }
+    }
+
+    #[llvm_versions(8.0..=latest)]
+    pub fn initialize_webassembly(config: &InitializationConfig) {
+        use llvm_sys::target::{LLVMInitializeWebAssemblyTargetInfo, LLVMInitializeWebAssemblyTarget, LLVMInitializeWebAssemblyTargetMC, LLVMInitializeWebAssemblyAsmPrinter, LLVMInitializeWebAssemblyAsmParser, LLVMInitializeWebAssemblyDisassembler};
+
+        unsafe {
+            if config.base {
+                LLVMInitializeWebAssemblyTarget()
+            }
+
+            if config.info {
+                LLVMInitializeWebAssemblyTargetInfo()
+            }
+
+            if config.asm_printer {
+                LLVMInitializeWebAssemblyAsmPrinter()
+            }
+
+            if config.asm_parser {
+                LLVMInitializeWebAssemblyAsmParser()
+            }
+
+            if config.disassembler {
+                LLVMInitializeWebAssemblyDisassembler()
+            }
+
+            if config.machine_code {
+                LLVMInitializeWebAssemblyTargetMC()
             }
         }
     }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1102,7 +1102,7 @@ impl TargetData {
     }
 
     // REVIEW: Does this only work if Sized?
-    pub fn get_bit_size(&self, type_: &AnyType) -> u64 {
+    pub fn get_bit_size(&self, type_: &dyn AnyType) -> u64 {
         unsafe {
             LLVMSizeOfTypeInBits(self.target_data, type_.as_type_ref())
         }
@@ -1137,31 +1137,31 @@ impl TargetData {
         }
     }
 
-    pub fn get_store_size(&self, type_: &AnyType) -> u64 {
+    pub fn get_store_size(&self, type_: &dyn AnyType) -> u64 {
         unsafe {
             LLVMStoreSizeOfType(self.target_data, type_.as_type_ref())
         }
     }
 
-    pub fn get_abi_size(&self, type_: &AnyType) -> u64 {
+    pub fn get_abi_size(&self, type_: &dyn AnyType) -> u64 {
         unsafe {
             LLVMABISizeOfType(self.target_data, type_.as_type_ref())
         }
     }
 
-    pub fn get_abi_alignment(&self, type_: &AnyType) -> u32 {
+    pub fn get_abi_alignment(&self, type_: &dyn AnyType) -> u32 {
         unsafe {
             LLVMABIAlignmentOfType(self.target_data, type_.as_type_ref())
         }
     }
 
-    pub fn get_call_frame_alignment(&self, type_: &AnyType) -> u32 {
+    pub fn get_call_frame_alignment(&self, type_: &dyn AnyType) -> u32 {
         unsafe {
             LLVMCallFrameAlignmentOfType(self.target_data, type_.as_type_ref())
         }
     }
 
-    pub fn get_preferred_alignment(&self, type_: &AnyType) -> u32 {
+    pub fn get_preferred_alignment(&self, type_: &dyn AnyType) -> u32 {
         unsafe {
             LLVMPreferredAlignmentOfType(self.target_data, type_.as_type_ref())
         }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,7 +1,7 @@
 #[llvm_versions(7.0..=latest)]
 use either::Either;
 use llvm_sys::target::{LLVMTargetDataRef, LLVMCopyStringRepOfTargetData, LLVMSizeOfTypeInBits, LLVMCreateTargetData, LLVMByteOrder, LLVMPointerSize, LLVMByteOrdering, LLVMStoreSizeOfType, LLVMABISizeOfType, LLVMABIAlignmentOfType, LLVMCallFrameAlignmentOfType, LLVMPreferredAlignmentOfType, LLVMPreferredAlignmentOfGlobal, LLVMElementAtOffset, LLVMOffsetOfElement, LLVMDisposeTargetData, LLVMPointerSizeForAS, LLVMIntPtrType, LLVMIntPtrTypeForAS, LLVMIntPtrTypeInContext, LLVMIntPtrTypeForASInContext};
-use llvm_sys::target_machine::{LLVMGetFirstTarget, LLVMTargetRef, LLVMGetNextTarget, LLVMGetTargetFromName, LLVMGetTargetFromTriple, LLVMGetTargetName, LLVMGetTargetDescription, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetHasAsmBackend, LLVMTargetMachineRef, LLVMDisposeTargetMachine, LLVMGetTargetMachineTarget, LLVMGetTargetMachineTriple, LLVMSetTargetMachineAsmVerbosity, LLVMCreateTargetMachine, LLVMGetTargetMachineCPU, LLVMGetTargetMachineFeatureString, LLVMGetDefaultTargetTriple, LLVMAddAnalysisPasses, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMRelocMode, LLVMCodeGenFileType, LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineEmitToFile};
+use llvm_sys::target_machine::{LLVMGetFirstTarget, LLVMTargetRef, LLVMGetNextTarget, LLVMGetTargetFromName, LLVMGetTargetFromTriple, LLVMGetTargetName, LLVMGetTargetDescription, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetHasAsmBackend, LLVMTargetMachineRef, LLVMDisposeTargetMachine, LLVMGetTargetMachineTarget, LLVMGetTargetMachineTriple, LLVMSetTargetMachineAsmVerbosity, LLVMCreateTargetMachine, LLVMGetTargetMachineCPU, LLVMGetTargetMachineFeatureString, LLVMGetDefaultTargetTriple, LLVMAddAnalysisPasses, LLVMCreateTargetDataLayout, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMRelocMode, LLVMCodeGenFileType, LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineEmitToFile};
 
 use crate::{AddressSpace, OptimizationLevel};
 use crate::context::Context;
@@ -936,6 +936,15 @@ impl TargetMachine {
         unsafe {
             CStr::from_ptr(LLVMGetTargetMachineFeatureString(self.target_machine))
         }
+    }
+
+    /// Create a DataLayout based on the target machine
+    pub fn get_target_data(&self) -> TargetData {
+        let data_layout = unsafe {
+            LLVMCreateTargetDataLayout(self.target_machine)
+        };
+
+        TargetData::new(data_layout)
     }
 
     pub fn set_asm_verbosity(&self, verbosity: bool) {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,7 +1,9 @@
 #[llvm_versions(7.0..=latest)]
 use either::Either;
 use llvm_sys::target::{LLVMTargetDataRef, LLVMCopyStringRepOfTargetData, LLVMSizeOfTypeInBits, LLVMCreateTargetData, LLVMByteOrder, LLVMPointerSize, LLVMByteOrdering, LLVMStoreSizeOfType, LLVMABISizeOfType, LLVMABIAlignmentOfType, LLVMCallFrameAlignmentOfType, LLVMPreferredAlignmentOfType, LLVMPreferredAlignmentOfGlobal, LLVMElementAtOffset, LLVMOffsetOfElement, LLVMDisposeTargetData, LLVMPointerSizeForAS, LLVMIntPtrType, LLVMIntPtrTypeForAS, LLVMIntPtrTypeInContext, LLVMIntPtrTypeForASInContext};
-use llvm_sys::target_machine::{LLVMGetFirstTarget, LLVMTargetRef, LLVMGetNextTarget, LLVMGetTargetFromName, LLVMGetTargetFromTriple, LLVMGetTargetName, LLVMGetTargetDescription, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetHasAsmBackend, LLVMTargetMachineRef, LLVMDisposeTargetMachine, LLVMGetTargetMachineTarget, LLVMGetTargetMachineTriple, LLVMSetTargetMachineAsmVerbosity, LLVMCreateTargetMachine, LLVMGetTargetMachineCPU, LLVMGetTargetMachineFeatureString, LLVMGetDefaultTargetTriple, LLVMAddAnalysisPasses, LLVMCreateTargetDataLayout, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMRelocMode, LLVMCodeGenFileType, LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineEmitToFile};
+use llvm_sys::target_machine::{LLVMGetFirstTarget, LLVMTargetRef, LLVMGetNextTarget, LLVMGetTargetFromName, LLVMGetTargetFromTriple, LLVMGetTargetName, LLVMGetTargetDescription, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetHasAsmBackend, LLVMTargetMachineRef, LLVMDisposeTargetMachine, LLVMGetTargetMachineTarget, LLVMGetTargetMachineTriple, LLVMSetTargetMachineAsmVerbosity, LLVMCreateTargetMachine, LLVMGetTargetMachineCPU, LLVMGetTargetMachineFeatureString, LLVMGetDefaultTargetTriple, LLVMAddAnalysisPasses, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMRelocMode, LLVMCodeGenFileType, LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineEmitToFile};
+#[llvm_versions(4.0..=latest)]
+use llvm_sys::target_machine::LLVMCreateTargetDataLayout;
 
 use crate::{AddressSpace, OptimizationLevel};
 use crate::context::Context;
@@ -938,7 +940,8 @@ impl TargetMachine {
         }
     }
 
-    /// Create a DataLayout based on the target machine
+    /// Create TargetData from this target machine
+    #[llvm_versions(4.0..=latest)]
     pub fn get_target_data(&self) -> TargetData {
         let data_layout = unsafe {
             LLVMCreateTargetDataLayout(self.target_machine)

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -244,7 +244,7 @@ impl ArrayType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `ArrayType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.array_type.print_to_stderr()
     }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -387,7 +387,7 @@ impl FloatType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.float_type.print_to_stderr()
     }

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -162,7 +162,7 @@ impl FunctionType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.fn_type.print_to_stderr()
     }

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -473,7 +473,7 @@ impl IntType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.int_type.print_to_stderr()
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -32,7 +32,7 @@ pub use crate::types::vec_type::VectorType;
 pub use crate::types::void_type::VoidType;
 pub(crate) use crate::types::traits::AsTypeRef;
 
-#[llvm_versions(3.7 => 4.0)]
+#[llvm_versions(3.7..=4.0)]
 use llvm_sys::core::LLVMDumpType;
 use llvm_sys::core::{LLVMAlignOf, LLVMGetTypeContext, LLVMFunctionType, LLVMArrayType, LLVMGetUndef, LLVMPointerType, LLVMPrintTypeToString, LLVMTypeIsSized, LLVMSizeOf, LLVMVectorType, LLVMConstPointerNull, LLVMGetElementType, LLVMConstNull};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
@@ -65,7 +65,7 @@ impl Type {
     // and so will fail to link when used. I've decided to remove it from 5.0+
     // for now. We should consider removing it altogether since print_to_string
     // could be used and manually written to stderr in rust...
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     fn print_to_stderr(&self) {
         unsafe {
             LLVMDumpType(self.type_);

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -178,7 +178,7 @@ impl PointerType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.ptr_type.print_to_stderr()
     }

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -1,5 +1,5 @@
 use llvm_sys::core::{LLVMConstNamedStruct, LLVMConstStruct, LLVMStructType, LLVMCountStructElementTypes, LLVMGetStructElementTypes, LLVMGetStructName, LLVMIsPackedStruct, LLVMIsOpaqueStruct, LLVMStructSetBody, LLVMConstArray};
-#[llvm_versions(3.7 => latest)]
+#[llvm_versions(3.7..=latest)]
 use llvm_sys::core::LLVMStructGetTypeAtIndex;
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
@@ -41,7 +41,7 @@ impl StructType {
     ///
     /// assert_eq!(struct_type.get_field_type_at_index(0).unwrap().into_float_type(), f32_type);
     /// ```
-    #[llvm_versions(3.7 => latest)]
+    #[llvm_versions(3.7..=latest)]
     pub fn get_field_type_at_index(&self, index: u32) -> Option<BasicTypeEnum> {
         // LLVM doesn't seem to just return null if opaque.
         // TODO: One day, with SubTypes (& maybe specialization?) we could just
@@ -429,7 +429,7 @@ impl StructType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `StructType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.struct_type.print_to_stderr()
     }

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -183,7 +183,7 @@ impl VectorType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.vec_type.print_to_stderr()
     }

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -118,7 +118,7 @@ impl VoidType {
 
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of a `VoidType` to stderr. Not available in newer LLVM versions.
-    #[llvm_versions(3.7 => 4.0)]
+    #[llvm_versions(3.7..=4.0)]
     pub fn print_to_stderr(&self) {
         self.void_type.print_to_stderr()
     }

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -3,11 +3,11 @@ use llvm_sys::LLVMTypeKind;
 use llvm_sys::core::{LLVMIsTailCall, LLVMSetTailCall, LLVMGetTypeKind, LLVMTypeOf, LLVMSetInstructionCallConv, LLVMGetInstructionCallConv, LLVMSetInstrParamAlignment};
 use llvm_sys::prelude::LLVMValueRef;
 
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use crate::attributes::Attribute;
 use crate::support::LLVMString;
 use crate::values::{AsValueRef, BasicValueEnum, InstructionValue, Value};
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use crate::values::FunctionValue;
 
 /// A value resulting from a function call. It may have function attributes applied to it.
@@ -131,7 +131,7 @@ impl CallSiteValue {
     /// call_site_value.add_attribute(0, string_attribute);
     /// call_site_value.add_attribute(0, enum_attribute);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn add_attribute(&self, index: u32, attribute: Attribute) {
         use llvm_sys::core::LLVMAddCallSiteAttribute;
 
@@ -163,7 +163,7 @@ impl CallSiteValue {
     ///
     /// assert_eq!(call_site_value.get_called_fn_value(), fn_value);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_called_fn_value(&self) -> FunctionValue {
         use llvm_sys::core::LLVMGetCalledValue;
 
@@ -200,7 +200,7 @@ impl CallSiteValue {
     ///
     /// assert_eq!(call_site_value.count_attributes(0), 2);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn count_attributes(&self, index: u32) -> u32 {
         use llvm_sys::core::LLVMGetCallSiteAttributeCount;
 
@@ -236,7 +236,7 @@ impl CallSiteValue {
     /// assert_eq!(call_site_value.get_enum_attribute(0, 1).unwrap(), enum_attribute);
     /// ```
     // SubTypes: -> Attribute<Enum>
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_enum_attribute(&self, index: u32, kind_id: u32) -> Option<Attribute> {
         use llvm_sys::core::LLVMGetCallSiteEnumAttribute;
 
@@ -278,7 +278,7 @@ impl CallSiteValue {
     /// assert_eq!(call_site_value.get_string_attribute(0, "my_key").unwrap(), string_attribute);
     /// ```
     // SubTypes: -> Attribute<String>
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_string_attribute(&self, index: u32, key: &str) -> Option<Attribute> {
         use llvm_sys::core::LLVMGetCallSiteStringAttribute;
 
@@ -320,7 +320,7 @@ impl CallSiteValue {
     ///
     /// assert_eq!(call_site_value.get_enum_attribute(0, 1), None);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn remove_enum_attribute(&self, index: u32, kind_id: u32) {
         use llvm_sys::core::LLVMRemoveCallSiteEnumAttribute;
 
@@ -356,7 +356,7 @@ impl CallSiteValue {
     ///
     /// assert_eq!(call_site_value.get_string_attribute(0, "my_key"), None);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn remove_string_attribute(&self, index: u32, key: &str) {
         use llvm_sys::core::LLVMRemoveCallSiteStringAttribute;
 
@@ -388,7 +388,7 @@ impl CallSiteValue {
     ///
     /// assert_eq!(call_site_value.count_arguments(), 0);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn count_arguments(&self) -> u32 {
         use llvm_sys::core::LLVMGetNumArgOperands;
 

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -1,8 +1,8 @@
 use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyFunction, LLVMViewFunctionCFG, LLVMViewFunctionCFGOnly};
 use llvm_sys::core::{LLVMIsAFunction, LLVMIsConstant, LLVMGetLinkage, LLVMGetPreviousFunction, LLVMGetNextFunction, LLVMGetParam, LLVMCountParams, LLVMGetLastParam, LLVMCountBasicBlocks, LLVMGetFirstParam, LLVMGetNextParam, LLVMGetBasicBlocks, LLVMAppendBasicBlock, LLVMDeleteFunction, LLVMGetLastBasicBlock, LLVMGetFirstBasicBlock, LLVMGetEntryBasicBlock, LLVMGetIntrinsicID, LLVMGetFunctionCallConv, LLVMSetFunctionCallConv, LLVMGetGC, LLVMSetGC, LLVMSetLinkage, LLVMSetParamAlignment, LLVMGetParams};
-#[llvm_versions(3.7 => latest)]
+#[llvm_versions(3.7..=latest)]
 use llvm_sys::core::{LLVMGetPersonalityFn, LLVMSetPersonalityFn};
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use llvm_sys::core::{LLVMAddAttributeAtIndex, LLVMGetAttributeCountAtIndex, LLVMGetEnumAttributeAtIndex, LLVMGetStringAttributeAtIndex, LLVMRemoveEnumAttributeAtIndex, LLVMRemoveStringAttributeAtIndex};
 use llvm_sys::prelude::{LLVMValueRef, LLVMBasicBlockRef};
 
@@ -10,7 +10,7 @@ use std::ffi::{CStr, CString};
 use std::mem::forget;
 use std::fmt;
 
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use crate::attributes::Attribute;
 use crate::basic_block::BasicBlock;
 use crate::module::Linkage;
@@ -272,7 +272,7 @@ impl FunctionValue {
     }
 
     // TODOC: How this works as an exception handler
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn has_personality_function(&self) -> bool {
         use llvm_sys::core::LLVMHasPersonalityFn;
 
@@ -313,7 +313,7 @@ impl FunctionValue {
         FunctionValue::new(value)
     }
 
-    #[llvm_versions(3.7 => latest)]
+    #[llvm_versions(3.7..=latest)]
     pub fn set_personality_function(&self, personality_fn: FunctionValue) {
         unsafe {
             LLVMSetPersonalityFn(self.as_value_ref(), personality_fn.as_value_ref())
@@ -375,7 +375,7 @@ impl FunctionValue {
     /// fn_value.add_attribute(0, string_attribute);
     /// fn_value.add_attribute(0, enum_attribute);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn add_attribute(&self, index: u32, attribute: Attribute) {
         unsafe {
             LLVMAddAttributeAtIndex(self.as_value_ref(), index, attribute.attribute)
@@ -403,7 +403,7 @@ impl FunctionValue {
     ///
     /// assert_eq!(fn_value.count_attributes(0), 2);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn count_attributes(&self, index: u32) -> u32 {
         unsafe {
             LLVMGetAttributeCountAtIndex(self.as_value_ref(), index)
@@ -428,7 +428,7 @@ impl FunctionValue {
     /// fn_value.add_attribute(0, string_attribute);
     /// fn_value.remove_string_attribute(0, "my_key");
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn remove_string_attribute(&self, index: u32, key: &str) {
         unsafe {
             LLVMRemoveStringAttributeAtIndex(self.as_value_ref(), index, key.as_ptr() as *const i8, key.len() as u32)
@@ -453,7 +453,7 @@ impl FunctionValue {
     /// fn_value.add_attribute(0, enum_attribute);
     /// fn_value.remove_enum_attribute(0, 1);
     /// ```
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn remove_enum_attribute(&self, index: u32, kind_id: u32) {
         unsafe {
             LLVMRemoveEnumAttributeAtIndex(self.as_value_ref(), index, kind_id)
@@ -480,7 +480,7 @@ impl FunctionValue {
     /// assert_eq!(fn_value.get_enum_attribute(0, 1), Some(enum_attribute));
     /// ```
     // SubTypes: -> Option<Attribute<Enum>>
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_enum_attribute(&self, index: u32, kind_id: u32) -> Option<Attribute> {
         let ptr = unsafe {
             LLVMGetEnumAttributeAtIndex(self.as_value_ref(), index, kind_id)
@@ -513,7 +513,7 @@ impl FunctionValue {
     /// assert_eq!(fn_value.get_string_attribute(0, "my_key"), Some(string_attribute));
     /// ```
     // SubTypes: -> Option<Attribute<String>>
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn get_string_attribute(&self, index: u32, key: &str) -> Option<Attribute> {
         let ptr = unsafe {
             LLVMGetStringAttributeAtIndex(self.as_value_ref(), index, key.as_ptr() as *const i8, key.len() as u32)

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -1,5 +1,8 @@
 use llvm_sys::LLVMThreadLocalMode;
+#[llvm_versions(3.6 => 7.0)]
 use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMHasUnnamedAddr, LLVMSetUnnamedAddr, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
+#[llvm_versions(8.0 => latest)]
+use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMGetUnnamedAddress, LLVMSetUnnamedAddress, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
 #[llvm_versions(7.0 => latest)]
 use llvm_sys::LLVMUnnamedAddr;
 use llvm_sys::prelude::LLVMValueRef;
@@ -81,7 +84,7 @@ impl GlobalValue {
     }
 
     // SubType: This input type should be tied to the BasicType
-    pub fn set_initializer(&self, value: &BasicValue) {
+    pub fn set_initializer(&self, value: &dyn BasicValue) {
         unsafe {
             LLVMSetInitializer(self.as_value_ref(), value.as_value_ref())
         }
@@ -148,15 +151,36 @@ impl GlobalValue {
         }
     }
 
+    #[llvm_versions(3.6 => 7.0)]
     pub fn has_unnamed_addr(&self) -> bool {
         unsafe {
             LLVMHasUnnamedAddr(self.as_value_ref()) == 1
         }
     }
 
+    #[llvm_versions(8.0 => latest)]
+    pub fn has_unnamed_addr(&self) -> bool {
+        unsafe {
+            LLVMGetUnnamedAddress(self.as_value_ref()) == LLVMUnnamedAddr::LLVMGlobalUnnamedAddr
+        }
+    }
+
+
+    #[llvm_versions(3.6 => 7.0)]
     pub fn set_unnamed_addr(&self, has_unnamed_addr: bool) {
         unsafe {
             LLVMSetUnnamedAddr(self.as_value_ref(), has_unnamed_addr as i32)
+        }
+    }
+
+    #[llvm_versions(8.0 => latest)]
+    pub fn set_unnamed_addr(&self, has_unnamed_addr: bool) {
+        unsafe {
+            if has_unnamed_addr {
+                LLVMSetUnnamedAddress(self.as_value_ref(), UnnamedAddress::Global.as_llvm_enum())
+            } else {
+                LLVMSetUnnamedAddress(self.as_value_ref(), UnnamedAddress::None.as_llvm_enum())
+            }
         }
     }
 

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -1,9 +1,9 @@
 use llvm_sys::LLVMThreadLocalMode;
-#[llvm_versions(3.6 => 7.0)]
+#[llvm_versions(3.6..8.0)]
 use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMHasUnnamedAddr, LLVMSetUnnamedAddr, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
-#[llvm_versions(8.0 => latest)]
+#[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMGetUnnamedAddress, LLVMSetUnnamedAddress, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMUnnamedAddr;
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -12,7 +12,7 @@ use std::ffi::{CString, CStr};
 use crate::{GlobalVisibility, ThreadLocalMode, DLLStorageClass};
 use crate::module::Linkage;
 use crate::support::LLVMString;
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value};
@@ -151,14 +151,14 @@ impl GlobalValue {
         }
     }
 
-    #[llvm_versions(3.6 => 7.0)]
+    #[llvm_versions(3.6..8.0)]
     pub fn has_unnamed_addr(&self) -> bool {
         unsafe {
             LLVMHasUnnamedAddr(self.as_value_ref()) == 1
         }
     }
 
-    #[llvm_versions(8.0 => latest)]
+    #[llvm_versions(8.0..=latest)]
     pub fn has_unnamed_addr(&self) -> bool {
         unsafe {
             LLVMGetUnnamedAddress(self.as_value_ref()) == LLVMUnnamedAddr::LLVMGlobalUnnamedAddr
@@ -166,14 +166,14 @@ impl GlobalValue {
     }
 
 
-    #[llvm_versions(3.6 => 7.0)]
+    #[llvm_versions(3.6..8.0)]
     pub fn set_unnamed_addr(&self, has_unnamed_addr: bool) {
         unsafe {
             LLVMSetUnnamedAddr(self.as_value_ref(), has_unnamed_addr as i32)
         }
     }
 
-    #[llvm_versions(8.0 => latest)]
+    #[llvm_versions(8.0..=latest)]
     pub fn set_unnamed_addr(&self, has_unnamed_addr: bool) {
         unsafe {
             if has_unnamed_addr {
@@ -257,7 +257,7 @@ impl GlobalValue {
     }
 
     /// Gets a `Comdat` assigned to this `GlobalValue`, if any.
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_comdat(&self) -> Option<Comdat> {
         use llvm_sys::comdat::LLVMGetComdat;
 
@@ -273,7 +273,7 @@ impl GlobalValue {
     }
 
     /// Assigns a `Comdat` to this `GlobalValue`.
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn set_comdat(&self, comdat: Comdat) {
         use llvm_sys::comdat::LLVMSetComdat;
 
@@ -282,7 +282,7 @@ impl GlobalValue {
         }
     }
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn get_unnamed_address(&self) -> UnnamedAddress {
         use llvm_sys::core::LLVMGetUnnamedAddress;
 
@@ -293,7 +293,7 @@ impl GlobalValue {
         UnnamedAddress::new(unnamed_address)
     }
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn set_unnamed_address(&self, address: UnnamedAddress) {
         use llvm_sys::core::LLVMSetUnnamedAddress;
 
@@ -327,7 +327,7 @@ impl AsValueRef for GlobalValue {
     }
 }
 
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 enum_rename! {
     /// This enum determines the significance of a `GlobalValue`'s address.
     UnnamedAddress <=> LLVMUnnamedAddr {

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -13,7 +13,8 @@ use crate::{IntPredicate, FloatPredicate};
 // REVIEW: Split up into structs for SubTypes on InstructionValues?
 // REVIEW: This should maybe be split up into InstructionOpcode and ConstOpcode?
 // see LLVMGetConstOpcode
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[llvm_enum(LLVMOpcode)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InstructionOpcode {
     // Actual Instructions:
     Add,
@@ -26,19 +27,19 @@ pub enum InstructionOpcode {
     BitCast,
     Br,
     Call,
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
+    #[llvm_versions(3.8..=latest)]
     CatchPad,
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
+    #[llvm_versions(3.8..=latest)]
     CatchRet,
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
+    #[llvm_versions(3.8..=latest)]
     CatchSwitch,
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
+    #[llvm_versions(3.8..=latest)]
     CleanupPad,
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
+    #[llvm_versions(3.8..=latest)]
     CleanupRet,
     ExtractElement,
     ExtractValue,
-    #[cfg(any(feature = "llvm8-0"))]
+    #[llvm_versions(8.0..=latest)]
     FNeg,
     FAdd,
     FCmp,
@@ -63,9 +64,11 @@ pub enum InstructionOpcode {
     LShr,
     Mul,
     Or,
+    #[llvm_variant(LLVMPHI)]
     Phi,
     PtrToInt,
     Resume,
+    #[llvm_variant(LLVMRet)]
     Return,
     SDiv,
     Select,
@@ -87,160 +90,6 @@ pub enum InstructionOpcode {
     VAArg,
     Xor,
     ZExt,
-}
-
-impl InstructionOpcode {
-    fn new(opcode: LLVMOpcode) -> Self {
-        match opcode {
-            LLVMOpcode::LLVMAdd => InstructionOpcode::Add,
-            LLVMOpcode::LLVMAddrSpaceCast => InstructionOpcode::AddrSpaceCast,
-            LLVMOpcode::LLVMAlloca => InstructionOpcode::Alloca,
-            LLVMOpcode::LLVMAnd => InstructionOpcode::And,
-            LLVMOpcode::LLVMAShr => InstructionOpcode::AShr,
-            LLVMOpcode::LLVMAtomicCmpXchg => InstructionOpcode::AtomicCmpXchg,
-            LLVMOpcode::LLVMAtomicRMW => InstructionOpcode::AtomicRMW,
-            LLVMOpcode::LLVMBitCast => InstructionOpcode::BitCast,
-            LLVMOpcode::LLVMBr => InstructionOpcode::Br,
-            LLVMOpcode::LLVMCall => InstructionOpcode::Call,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            LLVMOpcode::LLVMCatchPad => InstructionOpcode::CatchPad,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            LLVMOpcode::LLVMCatchRet => InstructionOpcode::CatchRet,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            LLVMOpcode::LLVMCatchSwitch => InstructionOpcode::CatchSwitch,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            LLVMOpcode::LLVMCleanupPad => InstructionOpcode::CleanupPad,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            LLVMOpcode::LLVMCleanupRet => InstructionOpcode::CleanupRet,
-            LLVMOpcode::LLVMExtractElement => InstructionOpcode::ExtractElement,
-            LLVMOpcode::LLVMExtractValue => InstructionOpcode::ExtractValue,
-            #[cfg(any(feature = "llvm8-0"))]
-            LLVMOpcode::LLVMFNeg => InstructionOpcode::FNeg,
-            LLVMOpcode::LLVMFAdd => InstructionOpcode::FAdd,
-            LLVMOpcode::LLVMFCmp => InstructionOpcode::FCmp,
-            LLVMOpcode::LLVMFDiv => InstructionOpcode::FDiv,
-            LLVMOpcode::LLVMFence => InstructionOpcode::Fence,
-            LLVMOpcode::LLVMFMul => InstructionOpcode::FMul,
-            LLVMOpcode::LLVMFPExt => InstructionOpcode::FPExt,
-            LLVMOpcode::LLVMFPToSI => InstructionOpcode::FPToSI,
-            LLVMOpcode::LLVMFPToUI => InstructionOpcode::FPToUI,
-            LLVMOpcode::LLVMFPTrunc => InstructionOpcode::FPTrunc,
-            LLVMOpcode::LLVMFRem => InstructionOpcode::FRem,
-            LLVMOpcode::LLVMFSub => InstructionOpcode::FSub,
-            LLVMOpcode::LLVMGetElementPtr => InstructionOpcode::GetElementPtr,
-            LLVMOpcode::LLVMICmp => InstructionOpcode::ICmp,
-            LLVMOpcode::LLVMIndirectBr => InstructionOpcode::IndirectBr,
-            LLVMOpcode::LLVMInsertElement => InstructionOpcode::InsertElement,
-            LLVMOpcode::LLVMInsertValue => InstructionOpcode::InsertValue,
-            LLVMOpcode::LLVMIntToPtr => InstructionOpcode::IntToPtr,
-            LLVMOpcode::LLVMInvoke => InstructionOpcode::Invoke,
-            LLVMOpcode::LLVMLandingPad => InstructionOpcode::LandingPad,
-            LLVMOpcode::LLVMLoad => InstructionOpcode::Load,
-            LLVMOpcode::LLVMLShr => InstructionOpcode::LShr,
-            LLVMOpcode::LLVMMul => InstructionOpcode::Mul,
-            LLVMOpcode::LLVMOr => InstructionOpcode::Or,
-            LLVMOpcode::LLVMPHI => InstructionOpcode::Phi,
-            LLVMOpcode::LLVMPtrToInt => InstructionOpcode::PtrToInt,
-            LLVMOpcode::LLVMResume => InstructionOpcode::Resume,
-            LLVMOpcode::LLVMRet => InstructionOpcode::Return,
-            LLVMOpcode::LLVMSDiv => InstructionOpcode::SDiv,
-            LLVMOpcode::LLVMSelect => InstructionOpcode::Select,
-            LLVMOpcode::LLVMSExt => InstructionOpcode::SExt,
-            LLVMOpcode::LLVMShl => InstructionOpcode::Shl,
-            LLVMOpcode::LLVMShuffleVector => InstructionOpcode::ShuffleVector,
-            LLVMOpcode::LLVMSIToFP => InstructionOpcode::SIToFP,
-            LLVMOpcode::LLVMSRem => InstructionOpcode::SRem,
-            LLVMOpcode::LLVMStore => InstructionOpcode::Store,
-            LLVMOpcode::LLVMSub => InstructionOpcode::Sub,
-            LLVMOpcode::LLVMSwitch => InstructionOpcode::Switch,
-            LLVMOpcode::LLVMTrunc => InstructionOpcode::Trunc,
-            LLVMOpcode::LLVMUDiv => InstructionOpcode::UDiv,
-            LLVMOpcode::LLVMUIToFP => InstructionOpcode::UIToFP,
-            LLVMOpcode::LLVMUnreachable => InstructionOpcode::Unreachable,
-            LLVMOpcode::LLVMURem => InstructionOpcode::URem,
-            LLVMOpcode::LLVMUserOp1 => InstructionOpcode::UserOp1,
-            LLVMOpcode::LLVMUserOp2 => InstructionOpcode::UserOp2,
-            LLVMOpcode::LLVMVAArg => InstructionOpcode::VAArg,
-            LLVMOpcode::LLVMXor => InstructionOpcode::Xor,
-            LLVMOpcode::LLVMZExt => InstructionOpcode::ZExt,
-        }
-    }
-
-    pub(crate) fn as_llvm_opcode(&self) -> LLVMOpcode {
-        match *self {
-            InstructionOpcode::Add => LLVMOpcode::LLVMAdd,
-            InstructionOpcode::AddrSpaceCast => LLVMOpcode::LLVMAddrSpaceCast,
-            InstructionOpcode::Alloca => LLVMOpcode::LLVMAlloca,
-            InstructionOpcode::And => LLVMOpcode::LLVMAnd,
-            InstructionOpcode::AShr => LLVMOpcode::LLVMAShr,
-            InstructionOpcode::AtomicCmpXchg => LLVMOpcode::LLVMAtomicCmpXchg,
-            InstructionOpcode::AtomicRMW => LLVMOpcode::LLVMAtomicRMW,
-            InstructionOpcode::BitCast => LLVMOpcode::LLVMBitCast,
-            InstructionOpcode::Br => LLVMOpcode::LLVMBr,
-            InstructionOpcode::Call => LLVMOpcode::LLVMCall,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            InstructionOpcode::CatchPad => LLVMOpcode::LLVMCatchPad,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            InstructionOpcode::CatchRet => LLVMOpcode::LLVMCatchRet,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            InstructionOpcode::CatchSwitch => LLVMOpcode::LLVMCatchSwitch,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            InstructionOpcode::CleanupPad => LLVMOpcode::LLVMCleanupPad,
-            #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
-            InstructionOpcode::CleanupRet => LLVMOpcode::LLVMCleanupRet,
-            InstructionOpcode::ExtractElement => LLVMOpcode::LLVMExtractElement,
-            InstructionOpcode::ExtractValue => LLVMOpcode::LLVMExtractValue,
-            #[cfg(any(feature = "llvm8-0"))]
-            InstructionOpcode::FNeg => LLVMOpcode::LLVMFNeg,
-            InstructionOpcode::FAdd => LLVMOpcode::LLVMFAdd,
-            InstructionOpcode::FCmp => LLVMOpcode::LLVMFCmp,
-            InstructionOpcode::FDiv => LLVMOpcode::LLVMFDiv,
-            InstructionOpcode::Fence => LLVMOpcode::LLVMFence,
-            InstructionOpcode::FMul => LLVMOpcode::LLVMFMul,
-            InstructionOpcode::FPExt => LLVMOpcode::LLVMFPExt,
-            InstructionOpcode::FPToSI => LLVMOpcode::LLVMFPToSI,
-            InstructionOpcode::FPToUI => LLVMOpcode::LLVMFPToUI,
-            InstructionOpcode::FPTrunc => LLVMOpcode::LLVMFPTrunc,
-            InstructionOpcode::FRem => LLVMOpcode::LLVMFRem,
-            InstructionOpcode::FSub => LLVMOpcode::LLVMFSub,
-            InstructionOpcode::GetElementPtr => LLVMOpcode::LLVMGetElementPtr,
-            InstructionOpcode::ICmp => LLVMOpcode::LLVMICmp,
-            InstructionOpcode::IndirectBr => LLVMOpcode::LLVMIndirectBr,
-            InstructionOpcode::InsertElement => LLVMOpcode::LLVMInsertElement,
-            InstructionOpcode::InsertValue => LLVMOpcode::LLVMInsertValue,
-            InstructionOpcode::IntToPtr => LLVMOpcode::LLVMIntToPtr,
-            InstructionOpcode::Invoke => LLVMOpcode::LLVMInvoke,
-            InstructionOpcode::LandingPad => LLVMOpcode::LLVMLandingPad,
-            InstructionOpcode::Load => LLVMOpcode::LLVMLoad,
-            InstructionOpcode::LShr => LLVMOpcode::LLVMLShr,
-            InstructionOpcode::Mul => LLVMOpcode::LLVMMul,
-            InstructionOpcode::Or => LLVMOpcode::LLVMOr,
-            InstructionOpcode::Phi => LLVMOpcode::LLVMPHI,
-            InstructionOpcode::PtrToInt => LLVMOpcode::LLVMPtrToInt,
-            InstructionOpcode::Resume => LLVMOpcode::LLVMResume,
-            InstructionOpcode::Return => LLVMOpcode::LLVMRet,
-            InstructionOpcode::SDiv => LLVMOpcode::LLVMSDiv,
-            InstructionOpcode::Select => LLVMOpcode::LLVMSelect,
-            InstructionOpcode::SExt => LLVMOpcode::LLVMSExt,
-            InstructionOpcode::Shl => LLVMOpcode::LLVMShl,
-            InstructionOpcode::ShuffleVector => LLVMOpcode::LLVMShuffleVector,
-            InstructionOpcode::SIToFP => LLVMOpcode::LLVMSIToFP,
-            InstructionOpcode::SRem => LLVMOpcode::LLVMSRem,
-            InstructionOpcode::Store => LLVMOpcode::LLVMStore,
-            InstructionOpcode::Sub => LLVMOpcode::LLVMSub,
-            InstructionOpcode::Switch => LLVMOpcode::LLVMSwitch,
-            InstructionOpcode::Trunc => LLVMOpcode::LLVMTrunc,
-            InstructionOpcode::UDiv => LLVMOpcode::LLVMUDiv,
-            InstructionOpcode::UIToFP => LLVMOpcode::LLVMUIToFP,
-            InstructionOpcode::Unreachable => LLVMOpcode::LLVMUnreachable,
-            InstructionOpcode::URem => LLVMOpcode::LLVMURem,
-            InstructionOpcode::UserOp1 => LLVMOpcode::LLVMUserOp1,
-            InstructionOpcode::UserOp2 => LLVMOpcode::LLVMUserOp2,
-            InstructionOpcode::VAArg => LLVMOpcode::LLVMVAArg,
-            InstructionOpcode::Xor => LLVMOpcode::LLVMXor,
-            InstructionOpcode::ZExt => LLVMOpcode::LLVMZExt,
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Hash)]

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -1,6 +1,6 @@
 use either::{Either, Either::{Left, Right}};
 use llvm_sys::core::{LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate};
-#[llvm_versions(3.9 => latest)]
+#[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMInstructionRemoveFromParent;
 use llvm_sys::LLVMOpcode;
 use llvm_sys::prelude::LLVMValueRef;
@@ -301,7 +301,7 @@ impl InstructionValue {
     }
 
     // REVIEW: Potentially unsafe if parent BB or grandparent fn were removed?
-    #[llvm_versions(3.9 => latest)]
+    #[llvm_versions(3.9..=latest)]
     pub fn remove_from_basic_block(&self) {
         unsafe {
             LLVMInstructionRemoveFromParent(self.as_value_ref())

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -38,6 +38,8 @@ pub enum InstructionOpcode {
     CleanupRet,
     ExtractElement,
     ExtractValue,
+    #[cfg(any(feature = "llvm8-0"))]
+    FNeg,
     FAdd,
     FCmp,
     FDiv,
@@ -112,6 +114,8 @@ impl InstructionOpcode {
             LLVMOpcode::LLVMCleanupRet => InstructionOpcode::CleanupRet,
             LLVMOpcode::LLVMExtractElement => InstructionOpcode::ExtractElement,
             LLVMOpcode::LLVMExtractValue => InstructionOpcode::ExtractValue,
+            #[cfg(any(feature = "llvm8-0"))]
+            LLVMOpcode::LLVMFNeg => InstructionOpcode::FNeg,
             LLVMOpcode::LLVMFAdd => InstructionOpcode::FAdd,
             LLVMOpcode::LLVMFCmp => InstructionOpcode::FCmp,
             LLVMOpcode::LLVMFDiv => InstructionOpcode::FDiv,
@@ -186,6 +190,8 @@ impl InstructionOpcode {
             InstructionOpcode::CleanupRet => LLVMOpcode::LLVMCleanupRet,
             InstructionOpcode::ExtractElement => LLVMOpcode::LLVMExtractElement,
             InstructionOpcode::ExtractValue => LLVMOpcode::LLVMExtractValue,
+            #[cfg(any(feature = "llvm8-0"))]
+            InstructionOpcode::FNeg => LLVMOpcode::LLVMFNeg,
             InstructionOpcode::FAdd => LLVMOpcode::LLVMFAdd,
             InstructionOpcode::FCmp => LLVMOpcode::LLVMFCmp,
             InstructionOpcode::FDiv => LLVMOpcode::LLVMFDiv,

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -1,5 +1,5 @@
 use llvm_sys::core::{LLVMConstNot, LLVMConstNeg, LLVMConstNSWNeg, LLVMConstNUWNeg, LLVMConstAdd, LLVMConstNSWAdd, LLVMConstNUWAdd, LLVMConstSub, LLVMConstNSWSub, LLVMConstNUWSub, LLVMConstMul, LLVMConstNSWMul, LLVMConstNUWMul, LLVMConstUDiv, LLVMConstSDiv, LLVMConstSRem, LLVMConstURem, LLVMConstIntCast, LLVMConstXor, LLVMConstOr, LLVMConstAnd, LLVMConstExactSDiv, LLVMConstShl, LLVMConstLShr, LLVMConstAShr, LLVMConstUIToFP, LLVMConstSIToFP, LLVMConstIntToPtr, LLVMConstTrunc, LLVMConstSExt, LLVMConstZExt, LLVMConstTruncOrBitCast, LLVMConstSExtOrBitCast, LLVMConstZExtOrBitCast, LLVMConstBitCast, LLVMConstICmp, LLVMConstIntGetZExtValue, LLVMConstIntGetSExtValue, LLVMConstSelect};
-#[llvm_versions(4.0 => latest)]
+#[llvm_versions(4.0..=latest)]
 use llvm_sys::core::LLVMConstExactUDiv;
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -186,7 +186,7 @@ impl IntValue {
         IntValue::new(value)
     }
 
-    #[llvm_versions(4.0 => latest)]
+    #[llvm_versions(4.0..=latest)]
     pub fn const_exact_unsigned_div(&self, rhs: IntValue) -> Self {
         let value = unsafe {
             LLVMConstExactUDiv(self.as_value_ref(), rhs.as_value_ref())

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -32,6 +32,8 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 23;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 #[cfg(feature = "llvm7-0")]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
+#[cfg(feature = "llvm8-0")]
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 26;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue {
@@ -72,7 +74,7 @@ impl MetadataValue {
         }
     }
 
-    pub fn create_node(values: &[&BasicValue]) -> Self {
+    pub fn create_node(values: &[&dyn BasicValue]) -> Self {
         let mut tuple_values: Vec<LLVMValueRef> = values.iter()
                                                         .map(|val| val.as_value_ref())
                                                         .collect();

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -1,9 +1,9 @@
 use llvm_sys::core::{LLVMMDNode, LLVMMDString, LLVMIsAMDNode, LLVMIsAMDString, LLVMGetMDString, LLVMGetMDNodeNumOperands, LLVMGetMDNodeOperands, LLVMGetMDKindID};
 use llvm_sys::prelude::LLVMValueRef;
 
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use llvm_sys::prelude::LLVMMetadataRef;
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use llvm_sys::core::LLVMValueAsMetadata;
 
 use crate::support::LLVMString;
@@ -53,7 +53,7 @@ impl MetadataValue {
         }
     }
 
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     pub(crate) fn as_metadata_ref(&self) -> LLVMMetadataRef {
         unsafe {
             LLVMValueAsMetadata(self.as_value_ref())

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -27,7 +27,7 @@ pub use crate::values::float_value::FloatValue;
 pub use crate::values::fn_value::FunctionValue;
 pub use crate::values::generic_value::GenericValue;
 pub use crate::values::global_value::GlobalValue;
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 pub use crate::values::global_value::UnnamedAddress;
 pub use crate::values::instruction_value::{InstructionValue, InstructionOpcode};
 pub use crate::values::int_value::IntValue;

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -25,7 +25,7 @@ impl PhiValue {
         }
     }
 
-    pub fn add_incoming(&self, incoming: &[(&BasicValue, &BasicBlock)]) {
+    pub fn add_incoming(&self, incoming: &[(&dyn BasicValue, &BasicBlock)]) {
         let (mut values, mut basic_blocks): (Vec<LLVMValueRef>, Vec<LLVMBasicBlockRef>) = {
             incoming.iter()
                     .map(|&(v, bb)| (v.as_value_ref(), bb.basic_block))

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -132,9 +132,9 @@ fn test_pass_manager_builder() {
     let module2 = module.clone();
 
     // TODOC: In 3.6, 3.8, & 3.9 it returns false. Seems like a LLVM bug?
-    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0")))]
+    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
     assert!(!module_pass_manager.run_on(&module));
-    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0"))]
+    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
     assert!(module_pass_manager.run_on(&module));
 
     let lto_pass_manager = PassManager::create(());

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -323,7 +323,7 @@ fn test_verify_fn() {
 
     #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
     assert!(!function.verify(false));
-    // REVIEW: Why does 3.9 -> 7.0 return true here? LLVM bug? Bugfix?
+     // REVIEW: Why does 3.9 -> 8.0 return true here? LLVM bug? Bugfix?
     #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
     assert!(function.verify(false));
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -5,7 +5,7 @@ use self::inkwell::context::Context;
 use self::inkwell::module::Linkage::*;
 use self::inkwell::types::{StructType, VectorType};
 use self::inkwell::values::{InstructionOpcode::*, MetadataValue, FIRST_CUSTOM_METADATA_KIND_ID, VectorValue};
-#[llvm_versions(7.0 => latest)]
+#[llvm_versions(7.0..=latest)]
 use self::inkwell::comdat::ComdatSelectionKind;
 
 use std::ffi::CString;
@@ -787,7 +787,7 @@ fn test_global_byte_array() {
 
 #[test]
 fn test_globals() {
-    #[llvm_versions(7.0 => latest)]
+    #[llvm_versions(7.0..=latest)]
     use self::inkwell::values::UnnamedAddress;
 
     let context = Context::create();

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -321,10 +321,10 @@ fn test_verify_fn() {
 
     let function = module.add_function("fn", fn_type, None);
 
-    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0")))]
+    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
     assert!(!function.verify(false));
     // REVIEW: Why does 3.9 -> 7.0 return true here? LLVM bug? Bugfix?
-    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0"))]
+    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
     assert!(function.verify(false));
 
     let basic_block = context.append_basic_block(&function, "entry");
@@ -814,7 +814,7 @@ fn test_globals() {
     assert!(!global.has_unnamed_addr());
     assert!(!global.is_externally_initialized());
     // REVIEW: Segfaults in 4.0 -> 7.0
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0")))]
+    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0")))]
     assert_eq!(global.get_section(), &*CString::new("").unwrap());
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());


### PR DESCRIPTION
## Description

There are two main commits here:

- First, as per the PR title, this adds support for LLVM 8, or more specifically, adds the requisite feature and updates to `llvm-sys` version `80.0`
- Second, a refactoring of the `llvm_versions` procedural macro that adds support for single versions in addition to ranges, and also provides a cleaner path for future extensibility, as well as better error reporting. One such future improvement may be to change the syntax from `X.Y => X.Y` to `X.Y..X.Y` and `X.Y..=X.Y` to allow for both inclusive and exclusive ranges, whereas right now only inclusive ranges are possible.

## Related Issue

There isn't one, but presumably LLVM 8 support is desired, and I was making the changes on my fork anyway for use in my own project, so why not share :)

## How This Has Been Tested

So far I've only made sure that the code compiles and that the test suite passes successfully. I'll be working with the new version heavily in the coming days though, so any bugs that surface I will certainly be implementing fixes for and upstreaming here. For now though, I'm not aware of any breakages.

NOTE: I'm compiling on macOS Mojave, using llvm-sys 80.1.0, against a copy of LLVM that I have built (using the release80 branch). I have not yet tested on other architectures or operating systems. I also compiled using both stable and nighly. toolchains.

The actual changes required were pretty minimal from what I've seen so far, one set of soft deprecations (`LLVM{Has,Set}UnnamedAddr` => `LLVM{Get,Set}UnnamedAddress`), some compiler warnings, and one new addition, the `LLVMFNeg` opcode was added to the `LLVMOpcode` enum.

## Option\<Breaking Changes\>

None that I'm aware of

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
