### PR TITLE
Add support for llvm 8.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,14 @@ llvm4-0 = []
 llvm5-0 = []
 llvm6-0 = []
 llvm7-0 = []
+llvm8-0 = []
 
 [dependencies]
 either = "1.5"
 enum-methods = "0.0.8"
 inkwell_internal_macros = { path = "./internal_macros", version = "0.1.0" }
 libc = "0.2"
-llvm-sys = "70.0"
+llvm-sys = "80.0"
 
 [badges]
 travis-ci = { repository = "TheDan64/inkwell" }

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -12,7 +12,7 @@ use syn::{Arm, Expr, ExprLit, Item, Lit, punctuated::Pair, Pat, PatLit, parse_ma
 
 // We could include_str! inkwell's Cargo.toml and extract these features
 // so that they don't need to also be managed here...
-const ALL_FEATURE_VERSIONS: [&str; 8] = [
+const ALL_FEATURE_VERSIONS: [&str; 9] = [
     "llvm3-6",
     "llvm3-7",
     "llvm3-8",
@@ -21,6 +21,7 @@ const ALL_FEATURE_VERSIONS: [&str; 8] = [
     "llvm5-0",
     "llvm6-0",
     "llvm7-0",
+    "llvm8-0",
 ];
 
 fn panic_with_usage() -> ! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0"}
+assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -1042,7 +1042,10 @@ impl<T: PassManagerSubType> PassManager<T> {
 
     #[llvm_versions(7.0 => latest)]
     pub fn add_aggressive_inst_combiner_pass(&self) {
+        #[llvm_versions(7.0 => 7.0)]
         use llvm_sys::transforms::scalar::LLVMAddAggressiveInstCombinerPass;
+        #[llvm_versions(8.0 => latest)]
+        use llvm_sys::transforms::aggressive_instcombine::LLVMAddAggressiveInstCombinerPass;
 
         unsafe {
             LLVMAddAggressiveInstCombinerPass(self.pass_manager)

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -38,6 +38,8 @@ pub enum InstructionOpcode {
     CleanupRet,
     ExtractElement,
     ExtractValue,
+    #[cfg(feature = "llvm8-0")]
+    FNeg,
     FAdd,
     FCmp,
     FDiv,
@@ -112,6 +114,8 @@ impl InstructionOpcode {
             LLVMOpcode::LLVMCleanupRet => InstructionOpcode::CleanupRet,
             LLVMOpcode::LLVMExtractElement => InstructionOpcode::ExtractElement,
             LLVMOpcode::LLVMExtractValue => InstructionOpcode::ExtractValue,
+            #[cfg(feature = "llvm8-0")]
+            LLVMOpcode::LLVMFNeg => InstructionOpcode::FNeg,
             LLVMOpcode::LLVMFAdd => InstructionOpcode::FAdd,
             LLVMOpcode::LLVMFCmp => InstructionOpcode::FCmp,
             LLVMOpcode::LLVMFDiv => InstructionOpcode::FDiv,
@@ -186,6 +190,8 @@ impl InstructionOpcode {
             InstructionOpcode::CleanupRet => LLVMOpcode::LLVMCleanupRet,
             InstructionOpcode::ExtractElement => LLVMOpcode::LLVMExtractElement,
             InstructionOpcode::ExtractValue => LLVMOpcode::LLVMExtractValue,
+            #[cfg(feature = "llvm8-0")]
+            InstructionOpcode::FNeg => LLVMOpcode::LLVMFNeg,
             InstructionOpcode::FAdd => LLVMOpcode::LLVMFAdd,
             InstructionOpcode::FCmp => LLVMOpcode::LLVMFCmp,
             InstructionOpcode::FDiv => LLVMOpcode::LLVMFDiv,

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -32,6 +32,8 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 23;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 #[cfg(feature = "llvm7-0")]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
+#[cfg(feature = "llvm8-0")]
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue {


### PR DESCRIPTION
## Description

Add support for llvm 8.0:
 * Add new FNeg instruction.
 * LLVMAddAggressiveInstCombinerPass moved to llvm_sys::transforms::aggressive_instcombine.

## How This Has Been Tested

See issues I've filed recently. The tests fail, but they were already failing. I tested this by commenting out the bad parts and running cargo test under valgrind.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
