### PR TITLE
Derive Clone, Copy, and Hash for CallSiteValue

### DIFF
--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -13,7 +13,7 @@ use crate::values::FunctionValue;
 /// A value resulting from a function call. It may have function attributes applied to it.
 ///
 /// This struct may be removed in the future in favor of an `InstructionValue<CallSite>` type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy, Hash)]
 pub struct CallSiteValue(Value);
 
 impl CallSiteValue {


### PR DESCRIPTION
## Description

`CallSiteValue` is another wrapper around `Value` that didn't get `Clone` and `Copy` derived on it (whereas most other `Value` wrappers have those traits).  Similar to #88, I added `Hash` again while I'm here.

## Related Issue

None; can make one if discussion is needed.

## How This Has Been Tested

All tests still pass after this patch has been applied to the `llvm7-0` branch. Not tested with other branches, or on platforms other than macOS.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
