### PR TITLE
fix misuse of LLVM API found through inkwell tests

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -834,14 +834,14 @@ impl Builder {
     /// #![allow(overflowing_literals)]
     ///
     /// // Logical Right Shift
-    /// assert_eq!(0b1100_0000 >> 2, 0b0011_0000);
-    /// assert_eq!(0b0000_0010 >> 1, 0b0000_0001);
-    /// assert_eq!(0b0000_1100 >> 2, 0b0000_0011);
+    /// assert_eq!(0b1100_0000u8 >> 2, 0b0011_0000);
+    /// assert_eq!(0b0000_0010u8 >> 1, 0b0000_0001);
+    /// assert_eq!(0b0000_1100u8 >> 2, 0b0000_0011);
     ///
     /// // Sign Extended Right Shift
     /// assert_eq!(0b0100_0000i8 >> 2, 0b0001_0000);
-    /// assert_eq!(0b1110_0000i8 >> 1, 0b1111_0000);
-    /// assert_eq!(0b1100_0000i8 >> 2, 0b1111_0000);
+    /// assert_eq!(0b1110_0000u8 as i8 >> 1, 0b1111_0000u8 as i8);
+    /// assert_eq!(0b1100_0000u8 as i8 >> 2, 0b1111_0000u8 as i8);
     /// ```
     ///
     /// In Rust, functions that could do this for 8bit values look like:

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -174,34 +174,6 @@ impl ArrayType {
         ArrayValue::new(value)
     }
 
-    /// Creates a null `ArrayValue` of this `ArrayType`.
-    /// It will be automatically assigned this `ArrayType`'s `Context`.
-    ///
-    /// # Example
-    /// ```
-    /// use inkwell::context::Context;
-    /// use inkwell::types::FloatType;
-    /// use inkwell::AddressSpace;
-    ///
-    /// // Global Context
-    /// let f32_type = FloatType::f32_type();
-    /// let f32_array_type = f32_type.array_type(7);
-    /// let f32_array_null = f32_array_type.const_null();
-    ///
-    /// assert!(f32_array_null.is_null());
-    ///
-    /// // Custom Context
-    /// let context = Context::create();
-    /// let f32_type = context.f32_type();
-    /// let f32_array_type = f32_type.array_type(7);
-    /// let f32_array_null = f32_array_type.const_null();
-    ///
-    /// assert!(f32_array_null.is_null());
-    /// ```
-    pub fn const_null(&self) -> ArrayValue {
-        ArrayValue::new(self.array_type.const_null())
-    }
-
     /// Creates a constant zero value of this `ArrayType`.
     ///
     /// # Example

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -138,27 +138,6 @@ impl FloatType {
         FloatValue::new(value)
     }
 
-    /// Creates a constant null value of this `FloatType`.
-    /// It will be automatically assigned this `FloatType`'s `Context`.
-    ///
-    /// # Example
-    /// ```
-    /// use inkwell::context::Context;
-    /// use inkwell::types::FloatType;
-    ///
-    /// // Global Context
-    /// let f32_type = FloatType::f32_type();
-    /// let f32_value = f32_type.const_null();
-    ///
-    /// // Custom Context
-    /// let context = Context::create();
-    /// let f32_type = context.f32_type();
-    /// let f32_value = f32_type.const_null();
-    /// ```
-    pub fn const_null(&self) -> FloatValue {
-        FloatValue::new(self.float_type.const_null())
-    }
-
     /// Creates a constant zero value of this `FloatType`.
     ///
     /// # Example
@@ -170,7 +149,7 @@ impl FloatType {
     /// let f32_type = context.f32_type();
     /// let f32_zero = f32_type.const_zero();
     ///
-    /// assert_eq!(f32_zero.print_to_string().to_string(), "f32 0");
+    /// assert_eq!(f32_zero.print_to_string().to_string(), "float 0.000000e+00");
     /// ```
     pub fn const_zero(&self) -> FloatValue {
         FloatValue::new(self.float_type.const_zero())

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -280,26 +280,6 @@ impl IntType {
         IntValue::new(value)
     }
 
-    /// Creates a constant null value of this `IntType`.
-    ///
-    /// # Example
-    /// ```
-    /// use inkwell::context::Context;
-    /// use inkwell::types::IntType;
-    ///
-    /// // Global Context
-    /// let i32_type = IntType::i32_type();
-    /// let i32_value = i32_type.const_null();
-    ///
-    /// // Custom Context
-    /// let context = Context::create();
-    /// let i32_type = context.i32_type();
-    /// let i32_value = i32_type.const_null();
-    /// ```
-    pub fn const_null(&self) -> IntValue {
-        IntValue::new(self.int_type.const_null())
-    }
-
     /// Creates a constant zero value of this `IntType`.
     ///
     /// # Example

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -72,14 +72,6 @@ impl Type {
         }
     }
 
-    // Even though the LLVM fuction has the word "Pointer", it doesn't seem to create
-    // a pointer at all, just a null value of the current type...
-    fn const_null(&self) -> LLVMValueRef {
-        unsafe {
-            LLVMConstPointerNull(self.type_)
-        }
-    }
-
     fn const_zero(&self) -> LLVMValueRef {
         unsafe {
             LLVMConstNull(self.type_)

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -208,7 +208,7 @@ impl PointerType {
     /// assert!(f32_ptr_null.is_null());
     /// ```
     pub fn const_null(&self) -> PointerValue {
-        PointerValue::new(self.ptr_type.const_null())
+        PointerValue::new(self.ptr_type.const_zero())
     }
 
     // REVIEW: Unlike the other const_zero functions, this one becomes null instead of a 0 value. Maybe remove?

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -110,33 +110,6 @@ impl StructType {
         StructValue::new(value)
     }
 
-    /// Creates a null `StructValue` of this `StructType`.
-    /// It will be automatically assigned this `StructType`'s `Context`.
-    ///
-    /// # Example
-    /// ```
-    /// use inkwell::context::Context;
-    /// use inkwell::types::{FloatType, StructType};
-    ///
-    /// // Global Context
-    /// let f32_type = FloatType::f32_type();
-    /// let struct_type = StructType::struct_type(&[f32_type.into(), f32_type.into()], false);
-    /// let struct_null = struct_type.const_null();
-    ///
-    /// assert!(struct_null.is_null());
-    ///
-    /// // Custom Context
-    /// let context = Context::create();
-    /// let f32_type = context.f32_type();
-    /// let struct_type = context.struct_type(&[f32_type.into(), f32_type.into()], false);
-    /// let struct_null = struct_type.const_null();
-    ///
-    /// assert!(struct_null.is_null());
-    /// ```
-    pub fn const_null(&self) -> StructValue {
-        StructValue::new(self.struct_type.const_null())
-    }
-
     /// Creates a constant zero value of this `StructType`.
     ///
     /// # Example

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -459,25 +459,6 @@ impl StructType {
         is_opaque
     }
 
-    /// Creates a `VectorType` with this `StructType` for its element type.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use inkwell::context::Context;
-    ///
-    /// let context = Context::create();
-    /// let f32_type = context.f32_type();
-    /// let struct_type = context.struct_type(&[f32_type.into(), f32_type.into()], false);
-    /// let struct_vec_type = struct_type.vec_type(3);
-    ///
-    /// assert_eq!(struct_vec_type.get_size(), 3);
-    /// assert_eq!(struct_vec_type.get_element_type().into_struct_type(), struct_type);
-    /// ```
-    pub fn vec_type(&self, size: u32) -> VectorType {
-        self.struct_type.vec_type(size)
-    }
-
     /// Creates a constant `ArrayValue`.
     ///
     /// # Example

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -133,33 +133,6 @@ impl VectorType {
         VectorValue::new(vec_value)
     }
 
-    /// Creates a null `VectorValue` of this `VectorType`.
-    /// It will be automatically assigned this `VectorType`'s `Context`.
-    ///
-    /// # Example
-    /// ```
-    /// use inkwell::context::Context;
-    /// use inkwell::types::FloatType;
-    ///
-    /// // Global Context
-    /// let f32_type = FloatType::f32_type();
-    /// let f32_vec_type = f32_type.vec_type(7);
-    /// let f32_vec_null = f32_vec_type.const_null();
-    ///
-    /// assert!(f32_vec_null.is_null());
-    ///
-    /// // Custom Context
-    /// let context = Context::create();
-    /// let f32_type = context.f32_type();
-    /// let f32_vec_type = f32_type.vec_type(7);
-    /// let f32_vec_null = f32_vec_type.const_null();
-    ///
-    /// assert!(f32_vec_null.is_null());
-    /// ```
-    pub fn const_null(&self) -> VectorValue {
-        VectorValue::new(self.vec_type.const_null())
-    }
-
     /// Creates a constant zero value of this `VectorType`.
     ///
     /// # Example

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -199,25 +199,6 @@ impl VectorType {
 
     }
 
-    /// Creates a `VectorType` with this `VectorType` for its element type.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use inkwell::context::Context;
-    ///
-    /// let context = Context::create();
-    /// let f32_type = context.f32_type();
-    /// let f32_vector_type = f32_type.vec_type(3);
-    /// let f32_vector_vector_type = f32_vector_type.vec_type(3);
-    ///
-    /// assert_eq!(f32_vector_vector_type.get_size(), 3);
-    /// assert_eq!(f32_vector_vector_type.get_element_type().into_vector_type(), f32_vector_type);
-    /// ```
-    pub fn vec_type(&self, size: u32) -> VectorType {
-        self.vec_type.vec_type(size)
-    }
-
     /// Creates a `PointerType` with this `VectorType` for its element type.
     ///
     /// # Example

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -7,8 +7,8 @@ use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{Type, BasicTypeEnum, FunctionType, PointerType};
 
-/// A `VoidType` is a special type with no possible direct instances. It's particularly
-/// useful as a pointer element type or a function return type.
+/// A `VoidType` is a special type with no possible direct instances. It's only
+/// useful as a function return type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct VoidType {
     void_type: Type,
@@ -24,7 +24,7 @@ impl VoidType {
     }
 
     // REVIEW: Always false -> const fn?
-    /// Gets whether or not this `VectorType` is sized or not. This may always
+    /// Gets whether or not this `VoidType` is sized or not. This may always
     /// be false and as such this function may be removed in the future.
     ///
     /// # Example
@@ -55,24 +55,6 @@ impl VoidType {
     /// ```
     pub fn get_context(&self) -> ContextRef {
         self.void_type.get_context()
-    }
-
-    /// Creates a `PointerType` with this `VoidType` for its element type.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use inkwell::context::Context;
-    /// use inkwell::AddressSpace;
-    ///
-    /// let context = Context::create();
-    /// let void_type = context.void_type();
-    /// let void_ptr_type = void_type.ptr_type(AddressSpace::Generic);
-    ///
-    /// assert_eq!(void_ptr_type.get_element_type().into_void_type(), void_type);
-    /// ```
-    pub fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
-        self.void_type.ptr_type(address_space)
     }
 
     /// Creates a `FunctionType` with this `VoidType` for its return type.

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -420,6 +420,9 @@ impl IntValue {
         if !self.is_const() {
             return None;
         }
+        if self.get_type().get_bit_width() > 64 {
+            return None;
+        }
 
         unsafe {
             Some(LLVMConstIntGetZExtValue(self.as_value_ref()))
@@ -442,6 +445,9 @@ impl IntValue {
     pub fn get_sign_extended_constant(&self) -> Option<i64> {
         // Garbage values are produced on non constant values
         if !self.is_const() {
+            return None;
+        }
+        if self.get_type().get_bit_width() > 64 {
             return None;
         }
 

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -51,9 +51,6 @@ impl PointerValue {
     ///
     /// let context = Context::create();
     /// let void_type = context.void_type();
-    /// let void_ptr_null = void_type.ptr_type(AddressSpace::Generic).const_null();
-    ///
-    /// assert!(void_ptr_null.is_const());
     /// ```
     pub fn is_const(&self) -> bool {
         self.ptr_value.is_const()

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -32,9 +32,9 @@ impl VectorValue {
     /// let context = Context::create();
     /// let i8_type = context.i8_type();
     /// let i8_vec_type = i8_type.vec_type(3);
-    /// let i8_vec_null = i8_vec_type.const_null();
+    /// let i8_vec_zero = i8_vec_type.const_zero();
     ///
-    /// assert!(i8_vec_null.is_const());
+    /// assert!(i8_vec_zero.is_const());
     /// ```
     pub fn is_const(&self) -> bool {
         self.vec_value.is_const()

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -57,34 +57,6 @@ fn test_enum_attribute_kinds() {
 }
 
 #[test]
-fn test_enum_attributes() {
-    let context = Context::create();
-    let enum_attribute = context.create_enum_attribute(0, 10);
-
-    assert!(enum_attribute.is_enum());
-    assert!(!enum_attribute.is_string());
-
-    assert_eq!(enum_attribute.get_enum_kind_id(), 0);
-    assert_eq!(enum_attribute.get_enum_value(), 10);
-
-    let enum_attribute2 = context.create_enum_attribute(3, 14);
-
-    assert!(enum_attribute2.is_enum());
-    assert!(!enum_attribute2.is_string());
-
-    assert_eq!(enum_attribute2.get_enum_kind_id(), 3);
-    assert_eq!(enum_attribute2.get_enum_value(), 14);
-
-    let enum_attribute3 = context.create_enum_attribute(56, 20);
-
-    assert!(enum_attribute3.is_enum());
-    assert!(!enum_attribute3.is_string());
-
-    assert_eq!(enum_attribute3.get_enum_kind_id(), 56);
-    assert_eq!(enum_attribute3.get_enum_value(), 20);
-}
-
-#[test]
 fn test_string_attributes() {
     let context = Context::create();
     let string_attribute = context.create_string_attribute("my_key_123", "my_val");
@@ -155,11 +127,11 @@ fn test_attributes_on_call_site_values() {
 
     builder.position_at_end(&entry_bb);
 
-    let call_site_value = builder.build_call(fn_value, &[], "my_fn");
+    let call_site_value = builder.build_call(fn_value, &[i32_type.const_int(1, false).into()], "my_fn");
 
     builder.build_return(None);
 
-    assert_eq!(call_site_value.count_arguments(), 0);
+    assert_eq!(call_site_value.count_arguments(), 1);
     assert_eq!(call_site_value.count_attributes(0), 0);
     assert_eq!(call_site_value.count_attributes(1), 0);
 

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -107,7 +107,8 @@ fn test_attributes_on_function_values() {
     let fn_value = module.add_function("my_fn", fn_type, None);
     let entry_bb = fn_value.append_basic_block("entry");
     let string_attribute = context.create_string_attribute("my_key", "my_val");
-    let enum_attribute = context.create_enum_attribute(1, 1);
+    let alignstack_attribute = Attribute::get_named_enum_kind_id("alignstack");
+    let enum_attribute = context.create_enum_attribute(alignstack_attribute, 1);
 
     builder.position_at_end(&entry_bb);
     builder.build_return(None);
@@ -116,7 +117,7 @@ fn test_attributes_on_function_values() {
     assert_eq!(fn_value.count_attributes(1), 0);
 
     fn_value.remove_string_attribute(0, "my_key"); // Noop
-    fn_value.remove_enum_attribute(0, 1); // Noop
+    fn_value.remove_enum_attribute(0, alignstack_attribute); // Noop
 
     // define align 1 "my_key"="my_val" void @my_fn()
     fn_value.add_attribute(0, string_attribute);
@@ -124,17 +125,17 @@ fn test_attributes_on_function_values() {
     fn_value.add_attribute(0, enum_attribute);
 
     assert_eq!(fn_value.count_attributes(0), 2);
-    assert_eq!(fn_value.get_enum_attribute(0, 1), Some(enum_attribute));
+    assert_eq!(fn_value.get_enum_attribute(0, alignstack_attribute), Some(enum_attribute));
     assert_eq!(fn_value.get_string_attribute(0, "my_key"), Some(string_attribute));
 
     fn_value.remove_string_attribute(0, "my_key");
 
     assert_eq!(fn_value.count_attributes(0), 1);
 
-    fn_value.remove_enum_attribute(0, 1);
+    fn_value.remove_enum_attribute(0, alignstack_attribute);
 
     assert_eq!(fn_value.count_attributes(0), 0);
-    assert!(fn_value.get_enum_attribute(0, 1).is_none());
+    assert!(fn_value.get_enum_attribute(0, alignstack_attribute).is_none());
     assert!(fn_value.get_string_attribute(0, "my_key").is_none());
 }
 
@@ -149,7 +150,8 @@ fn test_attributes_on_call_site_values() {
     let fn_value = module.add_function("my_fn", fn_type, None);
     let entry_bb = fn_value.append_basic_block("entry");
     let string_attribute = context.create_string_attribute("my_key", "my_val");
-    let enum_attribute = context.create_enum_attribute(1, 1);
+    let alignstack_attribute = Attribute::get_named_enum_kind_id("alignstack");
+    let enum_attribute = context.create_enum_attribute(alignstack_attribute, 1);
 
     builder.position_at_end(&entry_bb);
 
@@ -162,7 +164,7 @@ fn test_attributes_on_call_site_values() {
     assert_eq!(call_site_value.count_attributes(1), 0);
 
     call_site_value.remove_string_attribute(0, "my_key"); // Noop
-    call_site_value.remove_enum_attribute(0, 1); // Noop
+    call_site_value.remove_enum_attribute(0, alignstack_attribute); // Noop
 
     // define align 1 "my_key"="my_val" void @my_fn()
     call_site_value.add_attribute(0, string_attribute);
@@ -170,21 +172,21 @@ fn test_attributes_on_call_site_values() {
     call_site_value.add_attribute(0, enum_attribute);
 
     assert_eq!(call_site_value.count_attributes(0), 2);
-    assert_eq!(call_site_value.get_enum_attribute(0, 1), Some(enum_attribute));
+    assert_eq!(call_site_value.get_enum_attribute(0, alignstack_attribute), Some(enum_attribute));
     assert_eq!(call_site_value.get_string_attribute(0, "my_key"), Some(string_attribute));
 
     call_site_value.remove_string_attribute(0, "my_key");
 
     assert_eq!(call_site_value.count_attributes(0), 1);
 
-    call_site_value.remove_enum_attribute(0, 1);
+    call_site_value.remove_enum_attribute(0, alignstack_attribute);
 
     assert_eq!(call_site_value.count_attributes(0), 0);
-    assert!(call_site_value.get_enum_attribute(0, 1).is_none());
+    assert!(call_site_value.get_enum_attribute(0, alignstack_attribute).is_none());
     assert!(call_site_value.get_string_attribute(0, "my_key").is_none());
     assert_eq!(call_site_value.get_called_fn_value(), fn_value);
 
-    call_site_value.set_param_alignment_attribute(0, 12);
+    call_site_value.set_param_alignment_attribute(0, 16);
 
     assert_eq!(call_site_value.count_attributes(0), 1);
     assert!(call_site_value.get_enum_attribute(0, 1).is_some());

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -661,6 +661,7 @@ fn test_bitcast() {
     let void_type = context.void_type();
     let f32_type = context.f32_type();
     let i32_type = context.i32_type();
+    let f64_type = context.f64_type();
     let i64_type = context.i64_type();
     let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
     let i64_ptr_type = i64_type.ptr_type(AddressSpace::Generic);
@@ -670,6 +671,7 @@ fn test_bitcast() {
         f32_type.into(),
         i32_vec_type.into(),
         i32_ptr_type.into(),
+        f64_type.into(),
     ];
     let fn_type = void_type.fn_type(&arg_types, false);
     let fn_value = module.add_function("bc", fn_type, None);
@@ -679,6 +681,7 @@ fn test_bitcast() {
     let f32_arg = fn_value.get_nth_param(1).unwrap();
     let i32_vec_arg = fn_value.get_nth_param(2).unwrap();
     let i32_ptr_arg = fn_value.get_nth_param(3).unwrap();
+    let f64_arg = fn_value.get_nth_param(4).unwrap();
 
     builder.position_at_end(&entry);
 
@@ -695,7 +698,7 @@ fn test_bitcast() {
     let first_iv = cast.as_instruction_value().unwrap();
 
     builder.position_before(&first_iv);
-    builder.build_bitcast(f32_arg, i64_type, "f32toi64");
+    builder.build_bitcast(f64_arg, i64_type, "f64toi64");
 
-    assert!(module.verify().is_err());
+    assert!(module.verify().is_ok());
 }

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -174,7 +174,6 @@ fn test_sized_types() {
     assert!(!fn_type3.is_sized());
     assert!(!fn_type4.is_sized());
 
-    assert!(void_type.ptr_type(AddressSpace::Generic).is_sized());
     assert!(bool_type.ptr_type(AddressSpace::Generic).is_sized());
     assert!(i8_type.ptr_type(AddressSpace::Generic).is_sized());
     assert!(i16_type.ptr_type(AddressSpace::Generic).is_sized());
@@ -193,8 +192,6 @@ fn test_sized_types() {
     assert!(struct_type4.ptr_type(AddressSpace::Generic).is_sized());
     assert!(opaque_struct_type.ptr_type(AddressSpace::Generic).is_sized());
 
-    // REVIEW: You can't have array of void right?
-    assert!(void_type.ptr_type(AddressSpace::Generic).array_type(42).is_sized());
     assert!(bool_type.array_type(42).is_sized());
     assert!(i8_type.array_type(42).is_sized());
     assert!(i16_type.array_type(42).is_sized());
@@ -213,8 +210,6 @@ fn test_sized_types() {
     assert!(struct_type4.array_type(0).is_sized());
     assert!(!opaque_struct_type.array_type(0).is_sized());
 
-    // REVIEW: You can't have vec of void right?
-    assert!(void_type.ptr_type(AddressSpace::Generic).vec_type(42).is_sized());
     assert!(bool_type.vec_type(42).is_sized());
     assert!(i8_type.vec_type(42).is_sized());
     assert!(i16_type.vec_type(42).is_sized());
@@ -349,13 +344,8 @@ fn test_ptr_type() {
     assert_eq!(ptr_type.get_address_space(), AddressSpace::Generic);
     assert_eq!(ptr_type.get_element_type().into_int_type(), i8_type);
 
-    // Void ptr:
-    let void_type = context.void_type();
-    let void_ptr_type = void_type.ptr_type(AddressSpace::Generic);
-
-    assert_eq!(void_ptr_type.get_element_type().into_void_type(), void_type);
-
     // Fn ptr:
+    let void_type = context.void_type();
     let fn_type = void_type.fn_type(&[], false);
     let fn_ptr_type = fn_type.ptr_type(AddressSpace::Generic);
 

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -235,7 +235,7 @@ fn test_sized_types() {
 }
 
 #[test]
-fn test_const_null() {
+fn test_const_zero() {
     let context = Context::create();
     let bool_type = context.bool_type();
     let i8_type = context.i8_type();
@@ -318,57 +318,6 @@ fn test_const_null() {
     assert_eq!(*ptr_zero.print_to_string(), *CString::new("double* null").unwrap());
     assert_eq!(*vec_zero.print_to_string(), *CString::new("<42 x double> zeroinitializer").unwrap());
     assert_eq!(*array_zero.print_to_string(), *CString::new("[42 x double] zeroinitializer").unwrap());
-
-    let bool_null = bool_type.const_null();
-    let i8_null = i8_type.const_null();
-    let i16_null = i16_type.const_null();
-    let i32_null = i32_type.const_null();
-    let i64_null = i64_type.const_null();
-    let i128_null = i128_type.const_null();
-    let f16_null = f16_type.const_null();
-    let f32_null = f32_type.const_null();
-    let f64_null = f64_type.const_null();
-    let f80_null = f80_type.const_null();
-    let f128_null = f128_type.const_null();
-    let ppc_f128_null = ppc_f128_type.const_null();
-    let struct_null = struct_type.const_null();
-    let ptr_null = ptr_type.const_null();
-    let vec_null = vec_type.const_null();
-    let array_null = array_type.const_null();
-
-    assert!(bool_null.is_null());
-    assert!(i8_null.is_null());
-    assert!(i16_null.is_null());
-    assert!(i32_null.is_null());
-    assert!(i64_null.is_null());
-    assert!(i128_null.is_null());
-    assert!(f16_null.is_null());
-    assert!(f32_null.is_null());
-    assert!(f64_null.is_null());
-    assert!(f80_null.is_null());
-    assert!(f128_null.is_null());
-    assert!(ppc_f128_null.is_null());
-    assert!(struct_null.is_null());
-    assert!(ptr_null.is_null());
-    assert!(vec_null.is_null());
-    assert!(array_null.is_null());
-
-    assert_eq!(*bool_null.print_to_string(), *CString::new("i1 null").unwrap());
-    assert_eq!(*i8_null.print_to_string(), *CString::new("i8 null").unwrap());
-    assert_eq!(*i16_null.print_to_string(), *CString::new("i16 null").unwrap());
-    assert_eq!(*i32_null.print_to_string(), *CString::new("i32 null").unwrap());
-    assert_eq!(*i64_null.print_to_string(), *CString::new("i64 null").unwrap());
-    assert_eq!(*i128_null.print_to_string(), *CString::new("i128 null").unwrap());
-    assert_eq!(*f16_null.print_to_string(), *CString::new("half null").unwrap());
-    assert_eq!(*f32_null.print_to_string(), *CString::new("float null").unwrap());
-    assert_eq!(*f64_null.print_to_string(), *CString::new("double null").unwrap());
-    assert_eq!(*f80_null.print_to_string(), *CString::new("x86_fp80 null").unwrap());
-    assert_eq!(*f128_null.print_to_string(), *CString::new("fp128 null").unwrap());
-    assert_eq!(*ppc_f128_null.print_to_string(), *CString::new("ppc_fp128 null").unwrap());
-    assert_eq!(*struct_null.print_to_string(), *CString::new("{ i8, fp128 } null").unwrap());
-    assert_eq!(*ptr_null.print_to_string(), *CString::new("double* null").unwrap());
-    assert_eq!(*vec_null.print_to_string(), *CString::new("<42 x double> null").unwrap());
-    assert_eq!(*array_null.print_to_string(), *CString::new("[42 x double] null").unwrap());
 }
 
 #[test]

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -222,11 +222,6 @@ fn test_sized_types() {
     assert!(f80_type.vec_type(42).is_sized());
     assert!(f128_type.vec_type(42).is_sized());
     assert!(ppc_f128_type.vec_type(42).is_sized());
-    assert!(struct_type.vec_type(42).is_sized());
-    assert!(struct_type2.vec_type(42).is_sized());
-    assert!(struct_type3.vec_type(42).is_sized());
-    assert!(struct_type4.vec_type(42).is_sized());
-    assert!(!opaque_struct_type.vec_type(42).is_sized());
 }
 
 #[test]
@@ -320,10 +315,8 @@ fn test_vec_type() {
     let context = Context::create();
     let int = context.i8_type();
     let vec_type = int.vec_type(42);
-    let vec_type2 = vec_type.vec_type(7);
 
     assert_eq!(vec_type.get_size(), 42);
-    assert_eq!(vec_type2.get_element_type().into_vector_type(), vec_type);
 }
 
 #[test]

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -848,17 +848,18 @@ fn test_globals() {
     assert!(!global.is_declaration());
     assert_eq!(global.get_section(), &*CString::new("not sure what goes here").unwrap());
 
+    // Either linkage is non-local or visibility is default.
+    global.set_visibility(GlobalVisibility::Default);
     global.set_linkage(Private);
 
     assert_eq!(global.get_linkage(), Private);
-    // Setting linkage seems to reset visibility
-    assert_eq!(global.get_visibility(), GlobalVisibility::Default);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
     global.set_unnamed_address(UnnamedAddress::Global);
     global.set_dll_storage_class(DLLStorageClass::Export);
     global.set_thread_local(false);
+    global.set_linkage(External);
     global.set_visibility(GlobalVisibility::Protected);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1119,15 +1119,14 @@ fn test_consts() {
     assert_eq!(i16_val.get_zero_extended_constant(), Some(u16::max_value() as u64));
     assert_eq!(i32_val.get_zero_extended_constant(), Some(u32::max_value() as u64));
     assert_eq!(i64_val.get_zero_extended_constant(), Some(u64::max_value() as u64));
-    assert_eq!(i128_val.get_zero_extended_constant(), Some(u128::max_value() as u64));
+    assert_eq!(i128_val.get_zero_extended_constant(), None);
 
-    // How does a bool get sign extended to -1??
     assert_eq!(bool_val.get_sign_extended_constant(), Some(-1));
     assert_eq!(i8_val.get_sign_extended_constant(), Some(-1));
     assert_eq!(i16_val.get_sign_extended_constant(), Some(-1));
     assert_eq!(i32_val.get_sign_extended_constant(), Some(-1));
     assert_eq!(i64_val.get_sign_extended_constant(), Some(-1));
-    assert_eq!(i128_val.get_sign_extended_constant(), Some(-1));
+    assert_eq!(i128_val.get_sign_extended_constant(), None);
 
     assert_eq!(f16_val.get_constant(), Some((1.2001953125, false)));
     assert_eq!(f32_val.get_constant(), Some((3.4000000953674316, false)));

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1193,15 +1193,15 @@ fn test_non_fn_ptr_called() {
     let context = Context::create();
     let builder = context.create_builder();
     let module = context.create_module("my_mod");
-    let void_type = context.void_type();
-    let void_ptr_type = void_type.ptr_type(AddressSpace::Generic);
-    let fn_type = void_type.fn_type(&[void_ptr_type.into()], false);
+    let i8_type = context.i8_type();
+    let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let fn_type = i8_type.fn_type(&[i8_ptr_type.into()], false);
     let fn_value = module.add_function("my_func", fn_type, None);
     let bb = fn_value.append_basic_block("entry");
-    let void_ptr_param = fn_value.get_first_param().unwrap().into_pointer_value();
+    let i8_ptr_param = fn_value.get_first_param().unwrap().into_pointer_value();
 
     builder.position_at_end(&bb);
-    builder.build_call(void_ptr_param, &[], "call");
+    builder.build_call(i8_ptr_param, &[], "call");
     builder.build_return(None);
 
     assert!(module.verify().is_ok());


### PR DESCRIPTION
Running inkwell's tests with against an asserts-enabled expensive-checks-enabled, address-sanitizer undefined-behaviour-sanitizer LLVM found some problems. The ones I have fixes for are collected in this branch, the more complicated ones I filed (or will file) bugs for.

This is not yet enough to make inkwell tests run cleanly on my test system, this contains only the parts I think are clean enough to be committed. Most of the changes are to the tests rather than deeper changes that make inkwell safe. I want to work on that too, but I'm going to start with just getting to green (tests passing).

## Description

I've marked the changes where I only fixed the test but where inkwell still allows a consumer to trigger the problem.

 * const_null() is removed. See \<Breaking Changes\>.
 * the element type of a vector may only be an integer, floating point, or pointer.  [test only]
 * void type can not be used as an aggregate in a pointer, structure, array, etc.  [test only]
 * LLVMConstIntGet[SZ]ExtValue are convenience functions to access the value of your constant integer when it is 64 bits or less. Return None for larger integers.
 * test_enum_attributes() is removed, it was testing creation and use of custom kinds of enum attributes. As far as I can tell, LLVM does not intend to allow library users to create their own kinds of attributes, and it sometimes asserts on it.  [test only]
 * don't build a bitcast from f32 to i64. LLVM will detect that this bitcast can't be valid and assert. (In general, LLVM tries hard to assert as early as possible with the intention that this will help developers find bugs.)   [test only]
 * 12 is not a valid alignment as it is not a power of 2. Replaced with 16.  [test only]
 * fix 8-bit literals in right shift example in doc string vs. rust nightly.

## Related Issue

Related to issues #73 and #80.

This is part of what I mentioned was coming in PR #92.

## How This Has Been Tested

`cargo +nightly test --features=llvm7-0` but also I did a build of LLVM 7.0.1 with ASan and UBSan and added RUSTFLAGS="-Z sanitizer=address" to the test run.

## Option\<Breaking Changes\>

I deleted the const_null() function. It does exactly what const_zero() does except when it exhibits undefined behaviour.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
