### PR TITLE
Add ptr_type and array_type to BasicType

### DIFF
--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -38,17 +38,52 @@ pub trait BasicType: AnyType {
         BasicTypeEnum::new(self.as_type_ref())
     }
 
-    /// Create a function type from this `BasicType`.
+    /// Create a `FunctionType` with this `BasicType` as its return type.
+    ///
+    /// Example:
+    /// ```
+    /// use inkwell::context::Context;
+    /// use inkwell::types::BasicType;
+    ///
+    /// let context = Context::create();
+    /// let int = context.i32_type();
+    /// let int_basic_type = int.as_basic_type_enum();
+    /// assert_eq!(int_basic_type.fn_type(&[], false), int.fn_type(&[], false));
+    /// ```
     fn fn_type(&self, param_types: &[BasicTypeEnum], is_var_args: bool) -> FunctionType {
         Type::new(self.as_type_ref()).fn_type(param_types, is_var_args)
     }
 
-    /// Create an array type from this `BasicType`.
+    /// Create an `ArrayType` with this `BasicType` as its elements.
+    ///
+    /// Example:
+    /// ```
+    /// use inkwell::context::Context;
+    /// use inkwell::types::BasicType;
+    ///
+    /// let context = Context::create();
+    /// let int = context.i32_type();
+    /// let int_basic_type = int.as_basic_type_enum();
+    /// assert_eq!(int_basic_type.array_type(32), int.array_type(32));
+    /// ```
     fn array_type(&self, size: u32) -> ArrayType {
         Type::new(self.as_type_ref()).array_type(size)
     }
 
-    /// Create a pointer type from this `BasicType`.
+    /// Create a `PointerType` that points to this `BasicType`.
+    ///
+    /// Example:
+    /// ```
+    /// use inkwell::context::Context;
+    /// use inkwell::types::BasicType;
+    /// use inkwell::AddressSpace;
+    ///
+    /// let context = Context::create();
+    /// let int = context.i32_type();
+    /// let int_basic_type = int.as_basic_type_enum();
+    /// let addr_space = AddressSpace::Generic;
+    /// assert_eq!(int_basic_type.ptr_type(addr_space), int.ptr_type(addr_space));
+    /// ```
     fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
         Type::new(self.as_type_ref()).ptr_type(address_space)
     }

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -2,6 +2,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use std::fmt::Debug;
 
+use crate::AddressSpace;
 use crate::types::{IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VectorType, VoidType, Type};
 use crate::types::enums::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::{IntMathValue, FloatMathValue, PointerMathValue, IntValue, FloatValue, PointerValue, VectorValue};
@@ -40,6 +41,16 @@ pub trait BasicType: AnyType {
     /// Create a function type from this `BasicType`.
     fn fn_type(&self, param_types: &[BasicTypeEnum], is_var_args: bool) -> FunctionType {
         Type::new(self.as_type_ref()).fn_type(param_types, is_var_args)
+    }
+
+    /// Create an array type from this `BasicType`.
+    fn array_type(&self, size: u32) -> ArrayType {
+        Type::new(self.as_type_ref()).array_type(size)
+    }
+
+    /// Create a pointer type from this `BasicType`.
+    fn ptr_type(&self, address_space: AddressSpace) -> PointerType {
+        Type::new(self.as_type_ref()).ptr_type(address_space)
     }
 }
 

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -4,7 +4,7 @@ use std::ffi::CString;
 
 use self::inkwell::AddressSpace;
 use self::inkwell::context::Context;
-use self::inkwell::types::{FloatType, IntType, StructType, VoidType};
+use self::inkwell::types::{BasicType, FloatType, IntType, StructType, VoidType};
 
 #[test]
 fn test_struct_type() {
@@ -344,4 +344,25 @@ fn test_ptr_type() {
 
     assert_eq!(fn_ptr_type.get_element_type().into_function_type(), fn_type);
     assert_eq!(*fn_ptr_type.get_context(), context);
+}
+
+#[test]
+fn test_basic_type_enum() {
+    let context = Context::create();
+    let addr = AddressSpace::Generic;
+    let int = context.i32_type();
+    let types: &[&dyn BasicType] = &[
+        // ints and floats
+        &int, &context.i64_type(), &context.f32_type(), &context.f64_type(),
+        // derived types
+        &int.array_type(0), &int.ptr_type(addr),
+        &context.struct_type(&[int.as_basic_type_enum()], false),
+        &int.vec_type(0)
+    ];
+    for basic_type in types {
+        assert_eq!(basic_type.as_basic_type_enum().ptr_type(addr),
+                   basic_type.ptr_type(addr));
+        assert_eq!(basic_type.as_basic_type_enum().array_type(0),
+                   basic_type.array_type(0));
+    }
 }


### PR DESCRIPTION
<!--- Provide a brief summary of your changes in the title above -->

## Description
Add `ptr_type` and `array_type` functions to BasicType. This allows users of the library to use `BasicTypeEnum`s to create arrays and pointers instead of having to match on every element.

<!--- Describe your changes in detail -->
Implementation note:
Since VoidType can't have a pointer to it, I didn't think ptr_type made sense to
implement for AnyType. array_type isn't valid for FunctionType and
VoidType in any case.

## Related Issue
https://github.com/TheDan64/inkwell/issues/100
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested
I ran `cargo test` and all new and existing tests passed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Checklist
- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
- [X] My code follows the code style of this project (rustfmt and clippy have no complaints)
- [x] I have added documentation and doc tests to any new functions or types
- [X] I have updated documentation and doc tests to any modified functions or types as applicable
- [x] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] I am basing my changes off master, instead of one of the llvm version branches
