### PR TITLE
Add TryFrom traits from BasicValueEnum and BasicTypeEnum.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.6-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - env:
         - LLVM_VERSION="3.7"
       <<: *BASE
@@ -57,7 +57,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.7-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - env:
         - LLVM_VERSION="3.8"
       <<: *BASE
@@ -69,7 +69,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.8-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     # 3.9 seems to have a linking issue :/
     # - env:
     #     - LLVM_VERSION="3.9"
@@ -93,7 +93,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-4.0-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - env:
         - LLVM_VERSION="5.0"
       <<: *BASE
@@ -105,7 +105,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-5.0-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - env:
         - LLVM_VERSION="6.0"
       <<: *BASE
@@ -117,7 +117,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-6.0-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - env:
         - LLVM_VERSION="7.0"
       <<: *BASE
@@ -129,7 +129,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-7-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - env:
         - LLVM_VERSION="8.0"
       <<: *BASE
@@ -141,7 +141,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-8-dev
-      rust: nightly-2019-01-15
+      rust: nightly-2019-07-25
     - deploy: # Documentation build; Only latest supported LLVM version for now
         provider: pages
         skip-cleanup: true
@@ -188,7 +188,7 @@ env:
     - RUSTFLAGS="-C link-dead-code -C target-cpu=native -l ffi"
 
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == nightly-2019-01-15 ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" == nightly-2019-07-25 ]]; then
     cargo tarpaulin --features "llvm${LLVM_VERSION_DASH}" --ignore-tests --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inkwell aims to help you pen your own programming languages by safely wrapping l
 
 ## Requirements
 
-* Rust 1.31+
+* Rust 1.34+
 * Rust Stable, Beta, or Nightly
 * LLVM 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, or 8.0
 

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -1,5 +1,6 @@
 use llvm_sys::prelude::LLVMTypeRef;
 
+use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use crate::AddressSpace;

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -149,3 +149,25 @@ impl PointerMathType for VectorType {
     type ValueType = VectorValue;
     type PtrConvType = VectorType;
 }
+
+macro_rules! impl_try_from_basic_type_enum {
+    ($type_name:ident) => (
+        impl TryFrom<BasicTypeEnum> for $type_name {
+            type Error = &'static str;
+
+            fn try_from(ty: BasicTypeEnum) -> Result<Self, Self::Error> {
+                match ty {
+                    BasicTypeEnum::$type_name(ty) => Ok(ty),
+                    _ => Err("bad try from"),
+                }
+            }
+        }
+    )
+}
+
+impl_try_from_basic_type_enum!(ArrayType);
+impl_try_from_basic_type_enum!(FloatType);
+impl_try_from_basic_type_enum!(IntType);
+impl_try_from_basic_type_enum!(PointerType);
+impl_try_from_basic_type_enum!(StructType);
+impl_try_from_basic_type_enum!(VectorType);

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -1,10 +1,11 @@
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::core::{LLVMConstExtractValue, LLVMConstInsertValue};
 
+use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use crate::values::{ArrayValue, AggregateValueEnum, BasicValueUse, CallSiteValue, GlobalValue, StructValue, BasicValueEnum, AnyValueEnum, IntValue, FloatValue, PointerValue, PhiValue, VectorValue, FunctionValue, InstructionValue, Value};
-use crate::types::{IntMathType, FloatMathType, PointerMathType, IntType, FloatType, PointerType, VectorType};
+use crate::types::{ArrayType, BasicTypeEnum, IntMathType, FloatMathType, PointerMathType, IntType, FloatType, PointerType, StructType, VectorType};
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -124,3 +125,47 @@ trait_value_set! {BasicValue: ArrayValue, BasicValueEnum, AggregateValueEnum, In
 math_trait_value_set! {IntMathValue: (IntValue => IntType), (VectorValue => VectorType)}
 math_trait_value_set! {FloatMathValue: (FloatValue => FloatType), (VectorValue => VectorType)}
 math_trait_value_set! {PointerMathValue: (PointerValue => PointerType), (VectorValue => VectorType)}
+
+macro_rules! impl_try_from_basic_value_enum {
+    ($value_name:ident) => (
+        impl TryFrom<BasicValueEnum> for $value_name {
+            type Error = &'static str;
+            
+            fn try_from(value: BasicValueEnum) -> Result<Self, Self::Error> {
+                match value {
+                    BasicValueEnum::$value_name(value) => Ok(value),
+                    _ => Err("bad try from"),
+                }
+            }
+        }
+    )
+}
+
+impl_try_from_basic_value_enum!(ArrayValue);
+impl_try_from_basic_value_enum!(IntValue);
+impl_try_from_basic_value_enum!(FloatValue);
+impl_try_from_basic_value_enum!(PointerValue);
+impl_try_from_basic_value_enum!(StructValue);
+impl_try_from_basic_value_enum!(VectorValue);
+
+macro_rules! impl_try_from_basic_type_enum {
+    ($type_name:ident) => (
+        impl TryFrom<BasicTypeEnum> for $type_name {
+            type Error = &'static str;
+            
+            fn try_from(ty: BasicTypeEnum) -> Result<Self, Self::Error> {
+                match ty {
+                    BasicTypeEnum::$type_name(ty) => Ok(ty),
+                    _ => Err("bad try from"),
+                }
+            }
+        }
+    )
+}
+
+impl_try_from_basic_type_enum!(ArrayType);
+impl_try_from_basic_type_enum!(FloatType);
+impl_try_from_basic_type_enum!(IntType);
+impl_try_from_basic_type_enum!(PointerType);
+impl_try_from_basic_type_enum!(StructType);
+impl_try_from_basic_type_enum!(VectorType);

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -130,7 +130,7 @@ macro_rules! impl_try_from_basic_value_enum {
     ($value_name:ident) => (
         impl TryFrom<BasicValueEnum> for $value_name {
             type Error = &'static str;
-            
+
             fn try_from(value: BasicValueEnum) -> Result<Self, Self::Error> {
                 match value {
                     BasicValueEnum::$value_name(value) => Ok(value),
@@ -152,7 +152,7 @@ macro_rules! impl_try_from_basic_type_enum {
     ($type_name:ident) => (
         impl TryFrom<BasicTypeEnum> for $type_name {
             type Error = &'static str;
-            
+
             fn try_from(ty: BasicTypeEnum) -> Result<Self, Self::Error> {
                 match ty {
                     BasicTypeEnum::$type_name(ty) => Ok(ty),

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -147,25 +147,3 @@ impl_try_from_basic_value_enum!(FloatValue);
 impl_try_from_basic_value_enum!(PointerValue);
 impl_try_from_basic_value_enum!(StructValue);
 impl_try_from_basic_value_enum!(VectorValue);
-
-macro_rules! impl_try_from_basic_type_enum {
-    ($type_name:ident) => (
-        impl TryFrom<BasicTypeEnum> for $type_name {
-            type Error = &'static str;
-
-            fn try_from(ty: BasicTypeEnum) -> Result<Self, Self::Error> {
-                match ty {
-                    BasicTypeEnum::$type_name(ty) => Ok(ty),
-                    _ => Err("bad try from"),
-                }
-            }
-        }
-    )
-}
-
-impl_try_from_basic_type_enum!(ArrayType);
-impl_try_from_basic_type_enum!(FloatType);
-impl_try_from_basic_type_enum!(IntType);
-impl_try_from_basic_type_enum!(PointerType);
-impl_try_from_basic_type_enum!(StructType);
-impl_try_from_basic_type_enum!(VectorType);


### PR DESCRIPTION
## Description

Implement TryFrom trait for converting BasicValueEnum to ArrayValue, etc. and BasicTypeEnum to ArrayType, etc. This simplifies building generic code with inkwell.

## Related Issue

n/a

## How This Has Been Tested

```
$ cargo test --features=llvm8-0
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running target/debug/deps/inkwell-67dab86f6e0441b0

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/all-0e969bb6d979ad9d

running 95 tests
error: process didn't exit successfully: `/home/nick/inkwell/target/debug/deps/all-0e969bb6d979ad9d` (signal: 11, SIGSEGV: invalid memory reference)
```
¯\\\_(ツ)\_/¯

Honestly, I was planning to let inkwell Travis-CI run the PR after I create it since it seems to have the configuration where tests pass and I don't.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
