### PR TITLE
Move PassManager::{initialize,finalize} to PassManager<FunctionValue>.

### DIFF
--- a/src/passes.rs
+++ b/src/passes.rs
@@ -209,6 +209,21 @@ pub struct PassManager<T> {
     sub_type: PhantomData<T>,
 }
 
+impl PassManager<FunctionValue> {
+    // return true means some pass modified the module, not an error occurred
+    pub fn initialize(&self) -> bool {
+        unsafe {
+            LLVMInitializeFunctionPassManager(self.pass_manager) == 1
+        }
+    }
+
+    pub fn finalize(&self) -> bool {
+        unsafe {
+            LLVMFinalizeFunctionPassManager(self.pass_manager) == 1
+        }
+    }
+}
+
 impl<T: PassManagerSubType> PassManager<T> {
     pub(crate) fn new(pass_manager: LLVMPassManagerRef) -> Self {
         assert!(!pass_manager.is_null());
@@ -225,19 +240,6 @@ impl<T: PassManagerSubType> PassManager<T> {
         };
 
         PassManager::new(pass_manager)
-    }
-
-    // return true means some pass modified the module, not an error occurred
-    pub fn initialize(&self) -> bool {
-        unsafe {
-            LLVMInitializeFunctionPassManager(self.pass_manager) == 1
-        }
-    }
-
-    pub fn finalize(&self) -> bool {
-        unsafe {
-            LLVMFinalizeFunctionPassManager(self.pass_manager) == 1
-        }
     }
 
     /// This method returns true if any of the passes modified the function or module

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -112,12 +112,16 @@ fn test_pass_manager_builder() {
     builder.position_at_end(&entry);
     builder.build_return(None);
 
+    #[cfg(not(feature = "llvm3-7"))]
+    assert!(!fn_pass_manager.initialize());
+    #[cfg(feature = "llvm3-7")]
+    fn_pass_manager.initialize();
+
     // TODO: Test with actual changes? Would be true in that case
     // REVIEW: Segfaults in 4.0
     #[cfg(not(feature = "llvm4-0"))]
     assert!(!fn_pass_manager.run_on(&fn_value));
 
-    assert!(!fn_pass_manager.initialize());
     assert!(!fn_pass_manager.finalize());
     
     let module_pass_manager = PassManager::create(());

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -82,15 +82,7 @@ fn test_init_all_passes_for_module() {
         pass_manager.add_loop_unroll_and_jam_pass();
     }
 
-    assert!(!pass_manager.initialize());
-    assert!(!pass_manager.finalize());
-
     pass_manager.run_on(&module);
-
-    assert!(!pass_manager.initialize());
-    assert!(!pass_manager.finalize());
-
-    // TODO: Test when initialize and finalize are true
 }
 
 #[test]
@@ -125,6 +117,9 @@ fn test_pass_manager_builder() {
     #[cfg(not(feature = "llvm4-0"))]
     assert!(!fn_pass_manager.run_on(&fn_value));
 
+    assert!(!fn_pass_manager.initialize());
+    assert!(!fn_pass_manager.finalize());
+    
     let module_pass_manager = PassManager::create(());
 
     pass_manager_builder.populate_module_pass_manager(&module_pass_manager);


### PR DESCRIPTION
## Description

LLVMInitializeFunctionPassManager and LLVMFinalizeFunctionPassManager are only applicable to FunctionPassManagers, not all types of PassManager. Move those two functions to their own `impl` block so that they are only provided for that specialization.

## Related Issue

Issue #91 .

## How This Has Been Tested

```
$ /home/nicholas/inkwell/target/debug/deps/all-3f9595a010399385 --nocapture --test-threads 1 test_passes

running 3 tests
test test_passes::test_init_all_passes_for_module ... ok
test test_passes::test_pass_manager_builder ... ok
test test_passes::test_pass_registry ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out
```

## Option\<Breaking Changes\>

Two methods are removed from `PassManager<T>` and are only available on `PassManager<FunctionValue>`. This may cause a build failure for callers of those methods on `PassManager<Module>`. Such callers should probably simply remove the calls to `initialize()` and `finalize()`, or if all their passes are function passes, they can create a function pass manager via `PassManager::create(&module)`.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
