### PR TITLE
Use default implementation of Error trait

### DIFF
--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -22,17 +22,7 @@ pub enum FunctionLookupError {
     FunctionNotFound, // 404!
 }
 
-impl Error for FunctionLookupError {
-    // This method is deprecated on nighty so it's probably not
-    // something we should worry about
-    fn description(&self) -> &str {
-        self.as_str()
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        None
-    }
-}
+impl Error for FunctionLookupError {}
 
 impl FunctionLookupError {
     fn as_str(&self) -> &str {


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Because `Error::description` is soft-deprecated and `Error::cause` is deprecated (and replaced by `Error::source`) from `1.33`, the current implementation 

https://github.com/TheDan64/inkwell/blob/eb210cd235f6da087c825cfc536d28f3f777bf1d/src/execution_engine.rs#L25-L35

can be replaced simply by:

```rust
impl Error for FunctionLookupError {}
```

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
