### PR TITLE
A block without a parent doesn't have a next/previous. Return None in those cases.

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -95,6 +95,10 @@ impl BasicBlock {
     /// assert_eq!(basic_block3.get_previous_basic_block().unwrap(), basic_block2);
     /// ```
     pub fn get_previous_basic_block(&self) -> Option<BasicBlock> {
+        if self.get_parent().is_none() {
+            return None;
+        }
+
         let bb = unsafe {
             LLVMGetPreviousBasicBlock(self.basic_block)
         };
@@ -130,6 +134,10 @@ impl BasicBlock {
     /// assert!(basic_block3.get_next_basic_block().is_none());
     /// ```
     pub fn get_next_basic_block(&self) -> Option<BasicBlock> {
+        if self.get_parent().is_none() {
+            return None;
+        }
+ 
         let bb = unsafe {
             LLVMGetNextBasicBlock(self.basic_block)
         };


### PR DESCRIPTION
## Description

Both LLVMGetNextBasicBlock and LLVMGetPreviousBasicBlock unconditionally dereference members off the block's parent. That ends badly when it doesn't have a parent.
```
 LLVMBasicBlockRef LLVMGetNextBasicBlock(LLVMBasicBlockRef BB) {
   BasicBlock *Block = unwrap(BB);
   Function::iterator I(Block);
   if (++I == Block->getParent()->end())
     return nullptr;
   return wrap(&*I);
 }
```

## Related Issue

Related to issue #93 , but not a complete fix.

## How This Has Been Tested

before:
```
$ target/debug/deps/all-c57b01cc5b0c609a --nocapture --test-threads 1

running 95 tests
test test_attributes::test_attributes_on_call_site_values ... ok
test test_attributes::test_attributes_on_function_values ... ok
test test_attributes::test_enum_attribute_kinds ... ok
test test_attributes::test_string_attributes ... ok
test test_basic_block::test_basic_block_ordering ... ok
test test_basic_block::test_get_basic_blocks ... ok
test test_basic_block::test_get_terminator ... ok
test test_basic_block::test_no_parent ... Segmentation fault
```

after:
```
$ target/debug/deps/all-c57b01cc5b0c609a --nocapture --test-threads 1

running 95 tests
test test_attributes::test_attributes_on_call_site_values ... ok
test test_attributes::test_attributes_on_function_values ... ok
test test_attributes::test_enum_attribute_kinds ... ok
test test_attributes::test_string_attributes ... ok
test test_basic_block::test_basic_block_ordering ... ok
test test_basic_block::test_get_basic_blocks ... ok
test test_basic_block::test_get_terminator ... ok
test test_basic_block::test_no_parent ... ok
test test_builder::test_binary_ops ... ok
test test_builder::test_bit_shifts ... ok
test test_builder::test_bitcast ... ok
test test_builder::test_build_call ... ok
test test_builder::test_global_builder ... ok
test test_builder::test_insert_value ... ok
test test_builder::test_no_builder_double_free ... ok
test test_builder::test_no_builder_double_free2 ... ok
test test_builder::test_null_checked_ptr_ops ... ok
test test_builder::test_switch ... ok
test test_builder::test_unconditional_branch ... ok
test test_builder::test_vector_binary_ops ... ok
test test_builder::test_vector_convert_ops ... ok
test test_builder::test_vector_pointer_ops ... ok
test test_context::test_basic_block_context ... ok
test test_context::test_get_context_from_contextless_value ... ok
test test_context::test_no_context_double_free ... ok
test test_context::test_no_context_double_free3 ... ok
test test_context::test_values_get_context ... ok
test test_execution_engine::test_add_remove_module ... ok
test test_execution_engine::test_execution_engine ... ok
test test_execution_engine::test_get_function_address ... ok
test test_execution_engine::test_interpreter_execution_engine ... ok
test test_execution_engine::test_jit_execution_engine ... ok
test test_execution_engine::test_previous_double_free ... ok
test test_execution_engine::test_previous_double_free2 ... ok
test test_instruction_values::test_basic_block_operand ... ok
test test_instruction_values::test_get_next_use ... ok
test test_instruction_values::test_instructions ... ok
test test_instruction_values::test_operands ... ok
test test_module::test_clone ... ok
test test_module::test_double_ee_from_same_module ... ok
test test_module::test_garbage_ir_fails_create_module_from_ir ... ok
test test_module::test_garbage_ir_fails_create_module_from_ir_copy ... ok
test test_module::test_get_function ... ok
test test_module::test_get_set_target ... ok
test test_module::test_get_type ... ok
test test_module::test_get_type_global_context ... ok
test test_module::test_linking_modules ... Segmentation fault
```

Progress!

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
