### PR TITLE
Remove get_entry_basic_block and make get_first_basic_block return None when llvm returns nullptr.

### DIFF
--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -1,5 +1,5 @@
 use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyFunction, LLVMViewFunctionCFG, LLVMViewFunctionCFGOnly};
-use llvm_sys::core::{LLVMIsAFunction, LLVMIsConstant, LLVMGetLinkage, LLVMGetPreviousFunction, LLVMGetNextFunction, LLVMGetParam, LLVMCountParams, LLVMGetLastParam, LLVMCountBasicBlocks, LLVMGetFirstParam, LLVMGetNextParam, LLVMGetBasicBlocks, LLVMAppendBasicBlock, LLVMDeleteFunction, LLVMGetLastBasicBlock, LLVMGetFirstBasicBlock, LLVMGetEntryBasicBlock, LLVMGetIntrinsicID, LLVMGetFunctionCallConv, LLVMSetFunctionCallConv, LLVMGetGC, LLVMSetGC, LLVMSetLinkage, LLVMSetParamAlignment, LLVMGetParams};
+use llvm_sys::core::{LLVMIsAFunction, LLVMIsConstant, LLVMGetLinkage, LLVMGetPreviousFunction, LLVMGetNextFunction, LLVMGetParam, LLVMCountParams, LLVMGetLastParam, LLVMCountBasicBlocks, LLVMGetFirstParam, LLVMGetNextParam, LLVMGetBasicBlocks, LLVMAppendBasicBlock, LLVMDeleteFunction, LLVMGetLastBasicBlock, LLVMGetFirstBasicBlock, LLVMGetIntrinsicID, LLVMGetFunctionCallConv, LLVMSetFunctionCallConv, LLVMGetGC, LLVMSetGC, LLVMSetLinkage, LLVMSetParamAlignment, LLVMGetParams};
 #[llvm_versions(3.7..=latest)]
 use llvm_sys::core::{LLVMGetPersonalityFn, LLVMSetPersonalityFn};
 #[llvm_versions(3.9..=latest)]
@@ -123,22 +123,6 @@ impl FunctionValue {
         Some(BasicValueEnum::new(param))
     }
 
-    // REVIEW: Odd behavior, a function with no BBs returns a ptr
-    // that isn't actually a basic_block and seems to get corrupted
-    // Should check filed LLVM bugs - maybe just return None since
-    // we can catch it with "LLVMIsABasicBlock"
-    pub fn get_entry_basic_block(&self) -> Option<BasicBlock> {
-        let bb = unsafe {
-            LLVMGetEntryBasicBlock(self.as_value_ref())
-        };
-
-        BasicBlock::new(bb)
-    }
-
-    // REVIEW: Odd behavior, a function with no BBs returns a ptr
-    // that isn't actually a basic_block and seems to get corrupted
-    // Should check filed LLVM bugs - maybe just return None since
-    // we can catch it with "LLVMIsABasicBlock"
     pub fn get_first_basic_block(&self) -> Option<BasicBlock> {
         let bb = unsafe {
             LLVMGetFirstBasicBlock(self.as_value_ref())

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -18,11 +18,7 @@ fn test_basic_block_ordering() {
 
     let function = module.add_function("testing", fn_type, None);
 
-    // REVIEW: Possibly LLVM bug - gives a basic block ptr that isn't
-    // actually a basic block instead of returning nullptr. Simplest solution
-    // may be to just return None if LLVMIsABB doesn't pass
-    // assert!(function.get_entry_basic_block().is_none());
-    // assert!(function.get_first_basic_block().is_none());
+    assert!(function.get_first_basic_block().is_none());
 
     let basic_block = context.append_basic_block(&function, "entry");
     let basic_block4 = context.insert_basic_block_after(&basic_block, "block4");
@@ -58,7 +54,7 @@ fn test_basic_block_ordering() {
 
     function.append_basic_block("block6");
 
-    let bb1 = function.get_entry_basic_block().unwrap();
+    let bb1 = function.get_first_basic_block().unwrap();
     let bb4 = basic_block5.get_previous_basic_block().unwrap();
 
     assert_eq!(bb1, basic_block3);


### PR DESCRIPTION
## Description

It's an invariant in LLVM that the first basic block in a function is the entry block, therefore `get_entry_basic_block` and `get_first_basic_block` are redundant. The main difference is that `get_entry_basic_block` assumes that there is at least one child block (aka. the llvm::Function is a definition instead of a declaration) and will execute undefined behaviour if it does not, while `get_first_basic_block` returns a nullptr on function declarations.

## Related Issue

n/a

## How This Has Been Tested

Modified kaleidoscope runs, test_basic_block tests pass.

## Option\<Breaking Changes\>

Removes the `get_entry_basic_block` function, callers should use `get_first_basic_block.unwrap()` instead. The behaviour is the same except that when the unwrap fails it does so in a Rust way, instead of executing undefined behaviour inside of LLVM C++ code.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
