### PR TITLE
Don't allow linking in owned module

### DIFF
--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -415,17 +415,9 @@ fn test_linking_modules() {
 
     let execution_engine2 = module6.create_jit_execution_engine(OptimizationLevel::None).expect("Could not create Execution Engine");
 
-    // EE owned module links in EE owned module
-    assert!(module.link_in_module(module6).is_ok());
-
-    // EE2 still seems to "work" despite merging module6 into module...
-    // But f4 is now missing from EE2 (though this is expected, I'm really
-    // suprised it "just works" without segfault TBH)
-    // TODO: Test this much more thoroughly
-    #[cfg(feature = "llvm3-6")] // Likely a LLVM bug that 3-6 says ok, but others don't
+    // EE owned module cannot link another EE owned module
+    assert!(module.link_in_module(module6).is_err());
     assert_eq!(execution_engine2.get_function_value("f4"), Ok(fn_val4));
-    #[cfg(not(feature = "llvm3-6"))]
-    assert_ne!(execution_engine2.get_function_value("f4"), Ok(fn_val4));
 }
 
 #[test]


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
Don't allow a module to link in another module owned by an `ExecutionEngine`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
Fixes #90 

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tests 👍👍

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->
Breaking fix makes error safe instead of UB

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)

@nlewycky Do you think this is a sufficient fix?