### PR TITLE
Add set_alignment and get_alignment on InstructionValue.

### DIFF
--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -1,5 +1,5 @@
 use either::{Either, Either::{Left, Right}};
-use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate};
+use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMInstructionRemoveFromParent;
 use llvm_sys::LLVMOpcode;
@@ -200,9 +200,15 @@ impl InstructionValue {
 
     // SubTypes: Only apply to memory access and alloca instructions
     /// Returns alignment on a memory access instruction or alloca.
-    pub fn get_alignment(&self) -> u32 {
+    pub fn get_alignment(&self) -> Result<u32, &'static str> {
+        let value_ref = self.as_value_ref();
         unsafe {
-            LLVMGetAlignment(self.as_value_ref())
+            if LLVMIsAAllocaInst(value_ref).is_null() &&
+                LLVMIsALoadInst(value_ref).is_null() &&
+                LLVMIsAStoreInst(value_ref).is_null() {
+                return Err("Value is not an alloca, load or store.");
+            }
+            Ok(LLVMGetAlignment(value_ref))
         }
     }
 
@@ -212,8 +218,14 @@ impl InstructionValue {
         if !alignment.is_power_of_two() && alignment != 0 {
             return Err("Alignment is not a power of 2!");
         }
+        let value_ref = self.as_value_ref();
         unsafe {
-            Ok(LLVMSetAlignment(self.as_value_ref(), alignment))
+            if LLVMIsAAllocaInst(value_ref).is_null() &&
+                LLVMIsALoadInst(value_ref).is_null() &&
+                LLVMIsAStoreInst(value_ref).is_null() {
+                return Err("Value is not an alloca, load or store.");
+            }
+            Ok(LLVMSetAlignment(value_ref, alignment))
         }
     }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -209,7 +209,7 @@ impl InstructionValue {
     // SubTypes: Only apply to memory access and alloca instructions
     /// Sets alignment on a memory access instruction or alloca.
     pub fn set_alignment(&self, alignment: u32) -> Result<(), &'static str> {
-        if !alignment.is_power_of_two() {
+        if !alignment.is_power_of_two() && alignment != 0 {
             return Err("Alignment is not a power of 2!");
         }
         unsafe {

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -1,5 +1,5 @@
 use either::{Either, Either::{Left, Right}};
-use llvm_sys::core::{LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate};
+use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMInstructionRemoveFromParent;
 use llvm_sys::LLVMOpcode;
@@ -195,6 +195,22 @@ impl InstructionValue {
     pub fn set_volatile(&self, volatile: bool) {
         unsafe {
             LLVMSetVolatile(self.as_value_ref(), volatile as i32)
+        }
+    }
+
+    // SubTypes: Only apply to memory access and alloca instructions
+    /// Returns alignment on a memory access instruction or alloca.
+    pub fn get_alignment(&self) -> u32 {
+        unsafe {
+            LLVMGetAlignment(self.as_value_ref())
+        }
+    }
+
+    // SubTypes: Only apply to memory access and alloca instructions
+    /// Sets alignment on a memory access instruction or alloca.
+    pub fn set_alignment(&self, alignment: u32) {
+        unsafe {
+            LLVMSetAlignment(self.as_value_ref(), alignment)
         }
     }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -208,9 +208,12 @@ impl InstructionValue {
 
     // SubTypes: Only apply to memory access and alloca instructions
     /// Sets alignment on a memory access instruction or alloca.
-    pub fn set_alignment(&self, alignment: u32) {
+    pub fn set_alignment(&self, alignment: u32) -> Result<(), &'static str> {
+        if !alignment.is_power_of_two() {
+            return Err("Alignment is not a power of 2!");
+        }
         unsafe {
-            LLVMSetAlignment(self.as_value_ref(), alignment)
+            Ok(LLVMSetAlignment(self.as_value_ref(), alignment))
         }
     }
 

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -250,3 +250,56 @@ fn test_instructions() {
 
     assert_eq!(instruction_clone, instruction_clone_copy);
 }
+
+#[test]
+fn test_mem_instructions() {
+    let context = Context::create();
+    let module = context.create_module("testing");
+    let builder = context.create_builder();
+
+    let void_type = context.void_type();
+    let f32_type = context.f32_type();
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
+
+    let function = module.add_function("mem_inst", fn_type, None);
+    let basic_block = context.append_basic_block(&function, "entry");
+
+    builder.position_at_end(&basic_block);
+
+    let arg1 = function.get_first_param().unwrap().into_pointer_value();
+    let arg2 = function.get_nth_param(1).unwrap().into_float_value();
+
+    assert!(arg1.get_first_use().is_none());
+    assert!(arg2.get_first_use().is_none());
+
+    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+
+    let store_instruction = builder.build_store(arg1, f32_val);
+    let load_instruction = builder.build_load(arg1, "").as_instruction_value().unwrap();
+
+    assert_eq!(store_instruction.get_volatile(), false);
+    assert_eq!(load_instruction.get_volatile(), false);
+    store_instruction.set_volatile(true);
+    load_instruction.set_volatile(true);
+    assert_eq!(store_instruction.get_volatile(), true);
+    assert_eq!(load_instruction.get_volatile(), true);
+    store_instruction.set_volatile(false);
+    load_instruction.set_volatile(false);
+    assert_eq!(store_instruction.get_volatile(), false);
+    assert_eq!(load_instruction.get_volatile(), false);
+
+    assert_eq!(store_instruction.get_alignment(), 0);
+    assert_eq!(load_instruction.get_alignment(), 0);
+    assert!(store_instruction.set_alignment(16).is_ok());
+    assert!(load_instruction.set_alignment(16).is_ok());
+    assert_eq!(store_instruction.get_alignment(), 16);
+    assert_eq!(load_instruction.get_alignment(), 16);
+    assert!(store_instruction.set_alignment(0).is_ok());
+    assert!(load_instruction.set_alignment(0).is_ok());
+    assert_eq!(store_instruction.get_alignment(), 0);
+    assert_eq!(load_instruction.get_alignment(), 0);
+
+    assert!(store_instruction.set_alignment(14).is_err());
+    assert_eq!(store_instruction.get_alignment(), 0);
+}

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -276,7 +276,8 @@ fn test_mem_instructions() {
     let f32_val = f32_type.const_float(::std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val);
-    let load_instruction = builder.build_load(arg1, "").as_instruction_value().unwrap();
+    let load = builder.build_load(arg1, "");
+    let load_instruction = load.as_instruction_value().unwrap();
 
     assert_eq!(store_instruction.get_volatile(), false);
     assert_eq!(load_instruction.get_volatile(), false);
@@ -289,17 +290,21 @@ fn test_mem_instructions() {
     assert_eq!(store_instruction.get_volatile(), false);
     assert_eq!(load_instruction.get_volatile(), false);
 
-    assert_eq!(store_instruction.get_alignment(), 0);
-    assert_eq!(load_instruction.get_alignment(), 0);
+    assert_eq!(store_instruction.get_alignment().unwrap(), 0);
+    assert_eq!(load_instruction.get_alignment().unwrap(), 0);
     assert!(store_instruction.set_alignment(16).is_ok());
     assert!(load_instruction.set_alignment(16).is_ok());
-    assert_eq!(store_instruction.get_alignment(), 16);
-    assert_eq!(load_instruction.get_alignment(), 16);
+    assert_eq!(store_instruction.get_alignment().unwrap(), 16);
+    assert_eq!(load_instruction.get_alignment().unwrap(), 16);
     assert!(store_instruction.set_alignment(0).is_ok());
     assert!(load_instruction.set_alignment(0).is_ok());
-    assert_eq!(store_instruction.get_alignment(), 0);
-    assert_eq!(load_instruction.get_alignment(), 0);
+    assert_eq!(store_instruction.get_alignment().unwrap(), 0);
+    assert_eq!(load_instruction.get_alignment().unwrap(), 0);
 
     assert!(store_instruction.set_alignment(14).is_err());
-    assert_eq!(store_instruction.get_alignment(), 0);
+    assert_eq!(store_instruction.get_alignment().unwrap(), 0);
+
+    let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    assert!(fadd_instruction.get_alignment().is_err());
+    assert!(fadd_instruction.set_alignment(16).is_err());
 }


### PR DESCRIPTION
## Description

Adds the ability to get and set alignment on instructions. Copied the approach of getting and setting volatile. Added tests for volatile too when adding tests for alignment.

## Related Issue

Related to issue #110. This doesn't add the type safety discussed in that issue, which is closer to #8 and #16. 

## How This Has Been Tested

Tests!

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
