### PR TITLE
Make set/get_volatile check the type of value.

### DIFF
--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -279,16 +279,16 @@ fn test_mem_instructions() {
     let load = builder.build_load(arg1, "");
     let load_instruction = load.as_instruction_value().unwrap();
 
-    assert_eq!(store_instruction.get_volatile(), false);
-    assert_eq!(load_instruction.get_volatile(), false);
-    store_instruction.set_volatile(true);
-    load_instruction.set_volatile(true);
-    assert_eq!(store_instruction.get_volatile(), true);
-    assert_eq!(load_instruction.get_volatile(), true);
-    store_instruction.set_volatile(false);
-    load_instruction.set_volatile(false);
-    assert_eq!(store_instruction.get_volatile(), false);
-    assert_eq!(load_instruction.get_volatile(), false);
+    assert_eq!(store_instruction.get_volatile().unwrap(), false);
+    assert_eq!(load_instruction.get_volatile().unwrap(), false);
+    store_instruction.set_volatile(true).unwrap();
+    load_instruction.set_volatile(true).unwrap();
+    assert_eq!(store_instruction.get_volatile().unwrap(), true);
+    assert_eq!(load_instruction.get_volatile().unwrap(), true);
+    store_instruction.set_volatile(false).unwrap();
+    load_instruction.set_volatile(false).unwrap();
+    assert_eq!(store_instruction.get_volatile().unwrap(), false);
+    assert_eq!(load_instruction.get_volatile().unwrap(), false);
 
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);
     assert_eq!(load_instruction.get_alignment().unwrap(), 0);
@@ -305,6 +305,8 @@ fn test_mem_instructions() {
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);
 
     let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    assert!(fadd_instruction.get_volatile().is_err());
+    assert!(fadd_instruction.set_volatile(false).is_err());
     assert!(fadd_instruction.get_alignment().is_err());
     assert!(fadd_instruction.set_alignment(16).is_err());
 }


### PR DESCRIPTION
## Description

Similar to what we did for alignment, check that `get_volatile` and `set_volatile` apply to the underlying kind of value before calling the LLVM API to manipulate the Value. LLVM will do a checked-cast to `LoadInst` and if the value is not a load, it will do an unchecked-cast to `StoreInst`. If the value is not a load or store, LLVM has undefined behaviour.

## Related Issue

This is a cleanup after pull request #114. That PR was made by copying the style used by the volatile setters and getters. Since we improved it in code review, it makes sense to go back and apply those same changes to volatile.

## How This Has Been Tested

`cargo test --features=llvm8-0 --all -- test_instruction_values`

## Option\<Breaking Changes\>

`get_volatile` and `set_volatile` are changed to return `Result`s. This is necessary when the type of instruction is incorrect.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
