### PR TITLE
Add {set,get}_atomic_ordering to instruction_value.

### DIFF
--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -1,5 +1,7 @@
 use either::{Either, Either::{Left, Right}};
-use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetOrdering, LLVMSetOrdering, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst};
+use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst};
+#[llvm_versions(3.8..=latest)]
+use llvm_sys::core::{LLVMGetOrdering, LLVMSetOrdering};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMInstructionRemoveFromParent;
 use llvm_sys::LLVMOpcode;
@@ -237,6 +239,7 @@ impl InstructionValue {
 
     // SubTypes: Only apply to memory access instructions
     /// Returns atomic ordering on a memory access instruction.
+    #[llvm_versions(3.8..=latest)]
     pub fn get_atomic_ordering(&self) -> Result<AtomicOrdering, &'static str> {
         if !self.is_a_load_inst() && !self.is_a_store_inst() {
             return Err("Value is not a load or store.");
@@ -246,6 +249,7 @@ impl InstructionValue {
 
     // SubTypes: Only apply to memory access instructions
     /// Sets atomic ordering on a memory access instruction.
+    #[llvm_versions(3.8..=latest)]
     pub fn set_atomic_ordering(&self, ordering: AtomicOrdering) -> Result<(), &'static str> {
         // Although fence and atomicrmw both have an ordering, the LLVM C API
         // does not support them. The cmpxchg instruction has two orderings and

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -1,6 +1,6 @@
 extern crate inkwell;
 
-use self::inkwell::{AddressSpace, IntPredicate, FloatPredicate};
+use self::inkwell::{AddressSpace, AtomicOrdering, IntPredicate, FloatPredicate};
 use self::inkwell::context::Context;
 use self::inkwell::values::{BasicValue, InstructionOpcode::*};
 
@@ -304,9 +304,23 @@ fn test_mem_instructions() {
     assert!(store_instruction.set_alignment(14).is_err());
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);
 
+    assert_eq!(store_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::NotAtomic);
+    assert_eq!(load_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::NotAtomic);
+    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Monotonic).is_ok());
+    assert_eq!(store_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::Monotonic);
+    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Release).is_ok());
+    assert!(load_instruction.set_atomic_ordering(AtomicOrdering::Acquire).is_ok());
+
+    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Acquire).is_err());
+    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::AcquireRelease).is_err());
+    assert!(load_instruction.set_atomic_ordering(AtomicOrdering::AcquireRelease).is_err());
+    assert!(load_instruction.set_atomic_ordering(AtomicOrdering::Release).is_err());
+
     let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
     assert!(fadd_instruction.get_volatile().is_err());
     assert!(fadd_instruction.set_volatile(false).is_err());
     assert!(fadd_instruction.get_alignment().is_err());
     assert!(fadd_instruction.set_alignment(16).is_err());
+    assert!(fadd_instruction.get_atomic_ordering().is_err());
+    assert!(fadd_instruction.set_atomic_ordering(AtomicOrdering::NotAtomic).is_err());
 }

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -304,6 +304,42 @@ fn test_mem_instructions() {
     assert!(store_instruction.set_alignment(14).is_err());
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);
 
+    let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    assert!(fadd_instruction.get_volatile().is_err());
+    assert!(fadd_instruction.set_volatile(false).is_err());
+    assert!(fadd_instruction.get_alignment().is_err());
+    assert!(fadd_instruction.set_alignment(16).is_err());
+}
+
+#[llvm_versions(3.8..=latest)]
+#[test]
+fn test_atomic_ordering_mem_instructions() {
+    let context = Context::create();
+    let module = context.create_module("testing");
+    let builder = context.create_builder();
+
+    let void_type = context.void_type();
+    let f32_type = context.f32_type();
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
+
+    let function = module.add_function("mem_inst", fn_type, None);
+    let basic_block = context.append_basic_block(&function, "entry");
+
+    builder.position_at_end(&basic_block);
+
+    let arg1 = function.get_first_param().unwrap().into_pointer_value();
+    let arg2 = function.get_nth_param(1).unwrap().into_float_value();
+
+    assert!(arg1.get_first_use().is_none());
+    assert!(arg2.get_first_use().is_none());
+
+    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+
+    let store_instruction = builder.build_store(arg1, f32_val);
+    let load = builder.build_load(arg1, "");
+    let load_instruction = load.as_instruction_value().unwrap();
+
     assert_eq!(store_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::NotAtomic);
     assert_eq!(load_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::NotAtomic);
     assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Monotonic).is_ok());
@@ -317,10 +353,6 @@ fn test_mem_instructions() {
     assert!(load_instruction.set_atomic_ordering(AtomicOrdering::Release).is_err());
 
     let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
-    assert!(fadd_instruction.get_volatile().is_err());
-    assert!(fadd_instruction.set_volatile(false).is_err());
-    assert!(fadd_instruction.get_alignment().is_err());
-    assert!(fadd_instruction.set_alignment(16).is_err());
     assert!(fadd_instruction.get_atomic_ordering().is_err());
     assert!(fadd_instruction.set_atomic_ordering(AtomicOrdering::NotAtomic).is_err());
 }


### PR DESCRIPTION
## Description

Two new methods to get and set the atomic ordering on load and store instructions.

## Related Issue

Fixes issue #111.

The safety checks don't check that alignment is set because the caller may choose to set them in the other order. This is "fine" in the sense that it won't cause LLVM to execute undefined behaviour on the spot, but it would cause a verifier failure if you attempt to optimize or generate code for loads and stores with atomic orderings but no alignment.

## How This Has Been Tested

`cargo test` passed!

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
