### PR TITLE
Add IntValue::is_constant_int() which is true iff is_const() and the int value is not a constant expression.

### DIFF
--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -388,7 +388,7 @@ impl IntValue {
     /// Determines whether or not an `IntValue` is an `llvm::Constant`.
     ///
     /// Constants includes values that are not known at compile time, for
-    /// the example the address of a function casted to an integer.
+    /// example the address of a function casted to an integer.
     ///
     /// # Example
     ///

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1251,3 +1251,20 @@ fn test_aggregate_returns() {
 
     assert!(module.verify().is_ok());
 }
+
+#[test]
+fn test_constant_expression() {
+    let context = Context::create();
+    let builder = context.create_builder();
+    let module = context.create_module("my_mod");
+
+    let i32_type = context.i32_type();
+    let void_type = context.void_type();
+    let fn_type = void_type.fn_type(&[], false);
+
+    let function = module.add_function("", fn_type, None);
+    let expr = builder.build_ptr_to_int(function.as_global_value().as_pointer_value(), i32_type, "");
+
+    assert!(expr.is_const());
+    assert!(!expr.is_constant_int());
+}


### PR DESCRIPTION
## Description

Of course in LLVM you can have a value which is a Constant, and an int, but not a ConstantInt. Add `is_constant_int()` method on `IntValue`.

Also fixes the safety test on `get_zero_extended_constant` and `get_sign_extended_constant` since those both require ConstantInt, not Constant with IntegerType.

## Related Issue

n/a. Needed this in wasmer, finally wrote a test and sending in the PR.

## How This Has Been Tested

New testcase creates constant expression `i32 ptrtoint (void ()* @0 to i32)` and checks it against `is_const` and `is_constant_int`. This testcase is a bit special in that we use the builder but never create an instruction with it. It must create a constant expression instead.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
