### PR TITLE
Remove MetadataValue::create_*, use context explicitly

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -824,7 +824,6 @@ impl Module {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
-    /// use inkwell::values::MetadataValue;
     ///
     /// let context = Context::create();
     /// let module = context.create_module("my_module");
@@ -835,8 +834,8 @@ impl Module {
     ///
     /// assert_eq!(module.get_global_metadata_size("my_md"), 0);
     ///
-    /// let md_string = MetadataValue::create_string("lots of metadata here");
-    /// let md_node = MetadataValue::create_node(&[&bool_val, &f32_val]);
+    /// let md_string = context.metadata_string("lots of metadata here");
+    /// let md_node = context.metadata_node(&[bool_val.into(), f32_val.into()]);
     ///
     /// module.add_global_metadata("my_md", &md_string);
     /// module.add_global_metadata("my_md", &md_node);
@@ -870,7 +869,6 @@ impl Module {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
-    /// use inkwell::values::MetadataValue;
     ///
     /// let context = Context::create();
     /// let module = context.create_module("my_module");
@@ -881,8 +879,8 @@ impl Module {
     ///
     /// assert_eq!(module.get_global_metadata_size("my_md"), 0);
     ///
-    /// let md_string = MetadataValue::create_string("lots of metadata here");
-    /// let md_node = MetadataValue::create_node(&[&bool_val, &f32_val]);
+    /// let md_string = context.metadata_string("lots of metadata here");
+    /// let md_node = context.metadata_node(&[bool_val.into(), f32_val.into()]);
     ///
     /// module.add_global_metadata("my_md", &md_string);
     /// module.add_global_metadata("my_md", &md_node);
@@ -916,7 +914,6 @@ impl Module {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
-    /// use inkwell::values::MetadataValue;
     ///
     /// let context = Context::create();
     /// let module = context.create_module("my_module");
@@ -927,8 +924,8 @@ impl Module {
     ///
     /// assert_eq!(module.get_global_metadata_size("my_md"), 0);
     ///
-    /// let md_string = MetadataValue::create_string("lots of metadata here");
-    /// let md_node = MetadataValue::create_node(&[&bool_val, &f32_val]);
+    /// let md_string = context.metadata_string("lots of metadata here");
+    /// let md_node = context.metadata_node(&[bool_val.into(), f32_val.into()]);
     ///
     /// module.add_global_metadata("my_md", &md_string);
     /// module.add_global_metadata("my_md", &md_node);

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -74,27 +74,6 @@ impl MetadataValue {
         }
     }
 
-    pub fn create_node(values: &[&dyn BasicValue]) -> Self {
-        let mut tuple_values: Vec<LLVMValueRef> = values.iter()
-                                                        .map(|val| val.as_value_ref())
-                                                        .collect();
-        let metadata_value = unsafe {
-            LLVMMDNode(tuple_values.as_mut_ptr(), tuple_values.len() as u32)
-        };
-
-        MetadataValue::new(metadata_value)
-    }
-
-    pub fn create_string(string: &str) -> Self {
-        let c_string = CString::new(string).expect("Conversion to CString failed unexpectedly");
-
-        let metadata_value = unsafe {
-            LLVMMDString(c_string.as_ptr(), string.len() as u32)
-        };
-
-        MetadataValue::new(metadata_value)
-    }
-
     pub fn get_string_value(&self) -> Option<&CStr> {
         if self.is_node() {
             return None;

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -2,7 +2,7 @@
 
 extern crate either;
 #[macro_use]
-extern crate inkwell_internal_macros;
+extern crate inkwell_internals;
 
 #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
 mod test_attributes;

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -429,11 +429,10 @@ fn test_metadata_flags() {
         let module = context.create_module("my_module");
 
         use self::inkwell::module::FlagBehavior;
-        use self::inkwell::values::MetadataValue;
 
         assert!(module.get_flag("some_key").is_none());
 
-        let md = MetadataValue::create_string("lots of metadata here");
+        let md = context.metadata_string("lots of metadata here");
 
         module.add_metadata_flag("some_key", FlagBehavior::Error, md);
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -436,7 +436,7 @@ fn test_metadata() {
     assert_eq!(module.get_global_metadata_size("my_string_md"), 0);
     assert_eq!(module.get_global_metadata("my_string_md").len(), 0);
 
-    let md_string = MetadataValue::create_string("lots of metadata here");
+    let md_string = context.metadata_string("lots of metadata here");
 
     assert_eq!(md_string.get_node_size(), 0);
     assert_eq!(md_string.get_node_values().len(), 0);
@@ -473,7 +473,7 @@ fn test_metadata() {
     let vec_val = VectorType::const_vector(&[i8_val]);
     let fn_val = module.add_function("my_fn", fn_type, None);
 
-    let md_node = MetadataValue::create_node(&[&bool_val, &f32_val]);
+    let md_node = context.metadata_node(&[bool_val.into(), f32_val.into()]);
 
     let node_values = md_node.get_node_values();
 


### PR DESCRIPTION
Hi!

This removes the `MetadataValue::create` functions which cause LLVM to use global context.

This makes these functions not thread safe.  The solution is that users should always supply a context when creating metadata values.

## Description

Remove `MetadataValue::create_node` and `MetadataValue::create_string`

## How This Has Been Tested

`while cargo test --features "llvm8-0" test_metadata -- --nocapture ; do : ; done` and wait 5 seconds to 5 minutes; before this change there are segfaults.

## Option\<Breaking Changes\>

`MetadataValue::create_node` and `MetadataValue::create_string` are removed.  They should be removed because they're not safe in general and there's a good alternative to them.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
