### PR TITLE
MemoryBuffer::create_from_memory_range should take &[u8], not &str

### DIFF
--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -11,7 +11,6 @@ use std::ffi::CString;
 use std::fs::{File, remove_file};
 use std::io::Read;
 use std::path::Path;
-use std::str::from_utf8;
 
 #[test]
 fn test_write_bitcode_to_path() {
@@ -129,20 +128,20 @@ fn test_write_and_load_memory_buffer() {
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range("garbage ir data", "my_ir");
+    let memory_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data", "my_ir");
 
     assert_eq!(memory_buffer.get_size(), 15);
-    assert_eq!(from_utf8(memory_buffer.as_slice()).unwrap(), "garbage ir data");
+    assert_eq!(memory_buffer.as_slice(), b"garbage ir data");
     assert!(context.create_module_from_ir(memory_buffer).is_err());
 }
 
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir_copy() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range_copy("garbage ir data", "my_ir");
+    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(b"garbage ir data", "my_ir");
 
     assert_eq!(memory_buffer.get_size(), 15);
-    assert_eq!(from_utf8(memory_buffer.as_slice()).unwrap(), "garbage ir data");
+    assert_eq!(memory_buffer.as_slice(), b"garbage ir data");
     assert!(context.create_module_from_ir(memory_buffer).is_err());
 }
 
@@ -199,7 +198,7 @@ fn test_owned_module_dropped_ee_and_context() {
 #[test]
 fn test_parse_from_buffer() {
     let context = Context::create();
-    let garbage_buffer = MemoryBuffer::create_from_memory_range("garbage ir data", "my_ir");
+    let garbage_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data", "my_ir");
     let module_result = Module::parse_bitcode_from_buffer(&garbage_buffer);
 
     assert!(module_result.is_err());


### PR DESCRIPTION
When using Module::parse_bitcode_from_buffer_in_context(), the memory
buffer contains bytes, not a string.

Signed-off-by: Sean Young <sean.young@monax.io>

<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
