### PR TITLE
Metadata

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -648,10 +648,21 @@ impl Context {
     /// let f32_zero = f32_type.const_float(0.);
     /// let md_node = context.metadata_node(&[i8_two.into(), f32_zero.into()]);
     /// let f32_one = f32_type.const_float(1.);
+    /// let void_type = context.void_type();
+    ///
+    /// let builder = context.create_builder();
+    /// let module = context.create_module("my_mod");
+    /// let fn_type = void_type.fn_type(&[f32_type.into()], false);
+    /// let fn_value = module.add_function("my_func", fn_type, None);
+    /// let entry_block = fn_value.append_basic_block("entry");
+    ///
+    /// builder.position_at_end(&entry_block);
+    ///
+    /// let ret_instr = builder.build_return(None);
     ///
     /// assert!(md_node.is_node());
     ///
-    /// f32_one.set_metadata(md_node, 0);
+    /// ret_instr.set_metadata(md_node, 0);
     /// ```
     // REVIEW: Maybe more helpful to beginners to call this metadata_tuple?
     // REVIEW: Seems to be unassgned to anything
@@ -678,12 +689,23 @@ impl Context {
     /// let md_string = context.metadata_string("Floats are awesome!");
     /// let f32_type = context.f32_type();
     /// let f32_one = f32_type.const_float(1.);
+    /// let void_type = context.void_type();
+    ///
+    /// let builder = context.create_builder();
+    /// let module = context.create_module("my_mod");
+    /// let fn_type = void_type.fn_type(&[f32_type.into()], false);
+    /// let fn_value = module.add_function("my_func", fn_type, None);
+    /// let entry_block = fn_value.append_basic_block("entry");
+    ///
+    /// builder.position_at_end(&entry_block);
+    ///
+    /// let ret_instr = builder.build_return(None);
     ///
     /// assert!(md_string.is_string());
     ///
-    /// f32_one.set_metadata(md_string, 0);
+    /// ret_instr.set_metadata(md_string, 0);
     /// ```
-    // REVIEW: Seems to be unassgned to anything
+    // REVIEW: Seems to be unassigned to anything
     pub fn metadata_string(&self, string: &str) -> MetadataValue {
         let c_string = CString::new(string).expect("Conversion to CString failed unexpectedly");
 

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use crate::support::LLVMString;
 use crate::types::ArrayType;
 use crate::values::traits::AsValueRef;
-use crate::values::{Value, InstructionValue, MetadataValue};
+use crate::values::{Value, InstructionValue};
 
 /// An `ArrayValue` is a block of contiguous constants or variables.
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
@@ -65,21 +65,6 @@ impl ArrayValue {
         self.array_value.as_instruction()
     }
 
-    /// Determines whether or not this `ArrayValue` has any associated metadata.
-    pub fn has_metadata(&self) -> bool {
-        self.array_value.has_metadata()
-    }
-
-    /// Gets the `MetadataValue` associated with this `ArrayValue` at a specific
-    /// `kind_id`.
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.array_value.get_metadata(kind_id)
-    }
-
-    /// Assigns a `MetadataValue` to this `ArrayValue` at a specific `kind_id`.
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.array_value.set_metadata(metadata, kind_id)
-    }
 
     /// Replaces all uses of this value with another value of the same type.
     /// If used incorrectly this may result in invalid IR.

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -7,7 +7,7 @@ use crate::FloatPredicate;
 use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, IntType};
 use crate::values::traits::AsValueRef;
-use crate::values::{InstructionValue, IntValue, Value, MetadataValue};
+use crate::values::{InstructionValue, IntValue, Value};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FloatValue {
@@ -141,18 +141,6 @@ impl FloatValue {
         };
 
         FloatValue::new(value)
-    }
-
-    pub fn has_metadata(&self) -> bool {
-        self.float_value.has_metadata()
-    }
-
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.float_value.get_metadata(kind_id)
-    }
-
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.float_value.set_metadata(metadata, kind_id)
     }
 
     // SubType: rhs same as lhs; return IntValue<bool>

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -17,7 +17,7 @@ use crate::module::Linkage;
 use crate::support::LLVMString;
 use crate::types::{FunctionType, PointerType};
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValueEnum, GlobalValue, MetadataValue, Value};
+use crate::values::{BasicValueEnum, GlobalValue, Value};
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FunctionValue {
@@ -241,18 +241,6 @@ impl FunctionValue {
         let ptr_type = PointerType::new(self.fn_value.get_type());
 
         ptr_type.get_element_type().into_function_type()
-    }
-
-    pub fn has_metadata(&self) -> bool {
-        self.fn_value.has_metadata()
-    }
-
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.fn_value.get_metadata(kind_id)
-    }
-
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.fn_value.set_metadata(metadata, kind_id)
     }
 
     // TODOC: How this works as an exception handler

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -1,5 +1,5 @@
 use either::{Either, Either::{Left, Right}};
-use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst};
+use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst, LLVMGetMetadata, LLVMHasMetadata, LLVMSetMetadata};
 #[llvm_versions(3.8..=latest)]
 use llvm_sys::core::{LLVMGetOrdering, LLVMSetOrdering};
 #[llvm_versions(3.9..=latest)]
@@ -9,7 +9,7 @@ use llvm_sys::prelude::LLVMValueRef;
 
 use crate::basic_block::BasicBlock;
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, Value};
+use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, Value, MetadataValue};
 use crate::{AtomicOrdering, IntPredicate, FloatPredicate};
 
 // REVIEW: Split up into structs for SubTypes on InstructionValues?
@@ -584,6 +584,35 @@ impl InstructionValue {
             Some(FloatPredicate::new(pred))
         } else {
             None
+        }
+    }
+
+    /// Determines whether or not this `Instruction` has any associated metadata.
+    pub fn has_metadata(&self) -> bool {
+        unsafe {
+            LLVMHasMetadata(self.instruction_value.value) == 1
+        }
+    }
+
+    /// Gets the `MetadataValue` associated with this `Instruction` at a specific
+    /// `kind_id`.
+    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
+        let metadata_value = unsafe {
+            LLVMGetMetadata(self.instruction_value.value, kind_id)
+        };
+
+        if metadata_value.is_null() {
+            return None;
+        }
+
+        Some(MetadataValue::new(metadata_value))
+    }
+
+    /// Determines whether or not this `Instruction` has any associated metadata
+    /// `kind_id`.
+    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
+        unsafe {
+            LLVMSetMetadata(self.instruction_value.value, kind_id, metadata.as_value_ref())
         }
     }
 }

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -9,7 +9,7 @@ use crate::IntPredicate;
 use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, PointerType, IntType};
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value, MetadataValue};
+use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct IntValue {
@@ -353,18 +353,6 @@ impl IntValue {
         };
 
         IntValue::new(value)
-    }
-
-    pub fn has_metadata(&self) -> bool {
-        self.int_value.has_metadata()
-    }
-
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.int_value.get_metadata(kind_id)
-    }
-
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.int_value.set_metadata(metadata, kind_id)
     }
 
     // SubType: rhs same as lhs; return IntValue<bool>

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -40,7 +40,7 @@ pub use crate::values::traits::{AnyValue, AggregateValue, BasicValue, IntMathVal
 pub use crate::values::vec_value::VectorValue;
 pub(crate) use crate::values::traits::AsValueRef;
 
-use llvm_sys::core::{LLVMIsConstant, LLVMIsNull, LLVMIsUndef, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDumpValue, LLVMIsAInstruction, LLVMGetMetadata, LLVMHasMetadata, LLVMSetMetadata, LLVMReplaceAllUsesWith, LLVMGetFirstUse};
+use llvm_sys::core::{LLVMIsConstant, LLVMIsNull, LLVMIsUndef, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDumpValue, LLVMIsAInstruction, LLVMReplaceAllUsesWith, LLVMGetFirstUse};
 use llvm_sys::prelude::{LLVMValueRef, LLVMTypeRef};
 
 use std::ffi::CStr;
@@ -164,32 +164,6 @@ impl Value {
     fn print_to_stderr(&self) {
         unsafe {
             LLVMDumpValue(self.value)
-        }
-    }
-
-    fn has_metadata(&self) -> bool {
-        unsafe {
-            LLVMHasMetadata(self.value) == 1
-        }
-    }
-
-    // SubTypes: -> Option<MetadataValue<Node>>
-    // TODOC: This always returns a metadata node, which can be used to get its node values
-    fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        let metadata_value = unsafe {
-            LLVMGetMetadata(self.value, kind_id)
-        };
-
-        if metadata_value.is_null() {
-            return None;
-        }
-
-        Some(MetadataValue::new(metadata_value))
-    }
-
-    fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        unsafe {
-            LLVMSetMetadata(self.value, kind_id, metadata.as_value_ref())
         }
     }
 

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -5,7 +5,7 @@ use std::ffi::CStr;
 
 use crate::support::LLVMString;
 use crate::types::{AsTypeRef, IntType, PointerType};
-use crate::values::{AsValueRef, InstructionValue, IntValue, Value, MetadataValue};
+use crate::values::{AsValueRef, InstructionValue, IntValue, Value};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct PointerValue {
@@ -66,18 +66,6 @@ impl PointerValue {
 
     pub fn as_instruction(&self) -> Option<InstructionValue> {
         self.ptr_value.as_instruction()
-    }
-
-    pub fn has_metadata(&self) -> bool {
-        self.ptr_value.has_metadata()
-    }
-
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.ptr_value.get_metadata(kind_id)
-    }
-
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.ptr_value.set_metadata(metadata, kind_id)
     }
 
     // REVIEW: Should this be on array value too?

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -5,7 +5,7 @@ use std::ffi::CStr;
 use crate::support::LLVMString;
 use crate::types::StructType;
 use crate::values::traits::AsValueRef;
-use crate::values::{InstructionValue, Value, MetadataValue};
+use crate::values::{InstructionValue, Value};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct StructValue {
@@ -51,18 +51,6 @@ impl StructValue {
 
     pub fn as_instruction(&self) -> Option<InstructionValue> {
         self.struct_value.as_instruction()
-    }
-
-    pub fn has_metadata(&self) -> bool {
-        self.struct_value.has_metadata()
-    }
-
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.struct_value.get_metadata(kind_id)
-    }
-
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.struct_value.set_metadata(metadata, kind_id)
     }
 
     pub fn replace_all_uses_with(&self, other: StructValue) {

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -6,7 +6,7 @@ use std::ffi::CStr;
 use crate::support::LLVMString;
 use crate::types::{VectorType};
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValueEnum, BasicValue, InstructionValue, Value, IntValue, MetadataValue};
+use crate::values::{BasicValueEnum, BasicValue, InstructionValue, Value, IntValue};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct VectorValue {
@@ -99,18 +99,6 @@ impl VectorValue {
         };
 
         BasicValueEnum::new(value)
-    }
-
-    pub fn has_metadata(&self) -> bool {
-        self.vec_value.has_metadata()
-    }
-
-    pub fn get_metadata(&self, kind_id: u32) -> Option<MetadataValue> {
-        self.vec_value.get_metadata(kind_id)
-    }
-
-    pub fn set_metadata(&self, metadata: MetadataValue, kind_id: u32) {
-        self.vec_value.set_metadata(metadata, kind_id)
     }
 
     pub fn replace_all_uses_with(&self, other: VectorValue) {

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -443,35 +443,35 @@ fn test_metadata() {
     assert_eq!(md_string.get_string_value().unwrap(), &*CString::new("lots of metadata here").unwrap());
 
     let bool_type = context.bool_type();
-    let i8_type = context.i8_type();
+    // let i8_type = context.i8_type();
     // let i16_type = context.i16_type();
     // let i32_type = context.i32_type();
-    let i64_type = context.i64_type();
+    // let i64_type = context.i64_type();
     // let i128_type = context.i128_type();
     // let f16_type = context.f16_type();
     let f32_type = context.f32_type();
-    let f64_type = context.f64_type();
-    let f128_type = context.f128_type();
-    let array_type = f64_type.array_type(42);
+    // let f64_type = context.f64_type();
+    // let f128_type = context.f128_type();
+    // let array_type = f64_type.array_type(42);
     // let ppc_f128_type = context.ppc_f128_type();
-    let fn_type = bool_type.fn_type(&[i64_type.into(), array_type.into()], false);
+    // let fn_type = bool_type.fn_type(&[i64_type.into(), array_type.into()], false);
 
     let bool_val = bool_type.const_int(0, false);
-    let i8_val = i8_type.const_int(0, false);
+    // let i8_val = i8_type.const_int(0, false);
     // let i16_val = i16_type.const_int(0, false);
     // let i32_val = i32_type.const_int(0, false);
     // let i64_val = i64_type.const_int(0, false);
     // let i128_val = i128_type.const_int(0, false);
     // let f16_val = f16_type.const_float(0.0);
     let f32_val = f32_type.const_float(0.0);
-    let f64_val = f64_type.const_float(0.0);
-    let f128_val = f128_type.const_float(0.0);
+    // let f64_val = f64_type.const_float(0.0);
+    // let f128_val = f128_type.const_float(0.0);
     // let ppc_f128_val = ppc_f128_type.const_float(0.0);
-    let ptr_val = bool_type.ptr_type(AddressSpace::Generic).const_null();
-    let array_val = f64_type.const_array(&[f64_val]);
-    let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
-    let vec_val = VectorType::const_vector(&[i8_val]);
-    let fn_val = module.add_function("my_fn", fn_type, None);
+    // let ptr_val = bool_type.ptr_type(AddressSpace::Generic).const_null();
+    // let array_val = f64_type.const_array(&[f64_val]);
+    // let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
+    // let vec_val = VectorType::const_vector(&[i8_val]);
+    // let fn_val = module.add_function("my_fn", fn_type, None);
 
     let md_node = MetadataValue::create_node(&[&bool_val, &f32_val]);
 
@@ -524,82 +524,29 @@ fn test_metadata() {
     // assert!(!vec_val.has_metadata());
     // assert!(!fn_val.has_metadata());
 
-    bool_val.set_metadata(md_string, 3);
+    let builder = context.create_builder();
+    let module = context.create_module("my_mod");
+    let void_type = context.void_type();
+    let bool_type = context.bool_type();
+    let fn_type = void_type.fn_type(&[bool_type.into()], false);
+    let fn_value = module.add_function("my_func", fn_type, None);
 
-    assert!(bool_val.has_metadata());
-    assert!(bool_val.get_metadata(1).is_none());
-    assert!(bool_val.get_metadata(2).is_none());
+    let entry_block = fn_value.append_basic_block("entry");
 
-    let md_node_values = bool_val.get_metadata(3).unwrap().get_node_values();
+    builder.position_at_end(&entry_block);
 
-    assert_eq!(md_node_values.len(), 1);
-    assert_eq!(md_node_values[0].as_metadata_value().get_string_value(), md_string.get_string_value());
+    let ret_instr = builder.build_return(None);
 
-    f128_val.set_metadata(md_node, 3);
+    ret_instr.set_metadata(md_string, 2);
 
-    assert!(f128_val.has_metadata());
-    assert!(f128_val.get_metadata(1).is_none());
-    assert!(f128_val.get_metadata(2).is_none());
+    assert!(ret_instr.has_metadata());
+    assert!(ret_instr.get_metadata(1).is_none());
 
-    let md_node_values = f128_val.get_metadata(3).unwrap().get_node_values();
-
-    assert_eq!(md_node_values.len(), 2);
-    assert_eq!(md_node_values[0].as_int_value(), &bool_val);
-    assert_eq!(md_node_values[1].as_float_value(), &f32_val);
-
-    array_val.set_metadata(md_string, 2);
-
-    assert!(array_val.has_metadata());
-    assert!(array_val.get_metadata(1).is_none());
-
-    let md_node_values = array_val.get_metadata(2).unwrap().get_node_values();
+    let md_node_values = ret_instr.get_metadata(2).unwrap().get_node_values();
 
     assert_eq!(md_node_values.len(), 1);
     assert_eq!(md_node_values[0].as_metadata_value().get_string_value(), md_string.get_string_value());
 
-    struct_val.set_metadata(md_node, 4);
-
-    assert!(struct_val.has_metadata());
-    assert!(struct_val.get_metadata(1).is_none());
-    assert!(struct_val.get_metadata(2).is_none());
-    assert!(struct_val.get_metadata(3).is_none());
-
-    let md_node_values = struct_val.get_metadata(4).unwrap().get_node_values();
-
-    assert_eq!(md_node_values.len(), 2);
-    assert_eq!(md_node_values[0].as_int_value(), &bool_val);
-    assert_eq!(md_node_values[1].as_float_value(), &f32_val);
-
-    vec_val.set_metadata(md_string, 1);
-
-    assert!(vec_val.has_metadata());
-
-    let md_node_values = vec_val.get_metadata(1).unwrap().get_node_values();
-
-    assert_eq!(md_node_values.len(), 1);
-    assert_eq!(md_node_values[0].as_metadata_value().get_string_value(), md_string.get_string_value());
-
-    fn_val.set_metadata(md_node, 4);
-
-    assert!(fn_val.has_metadata());
-    assert!(fn_val.get_metadata(1).is_none());
-    assert!(fn_val.get_metadata(2).is_none());
-    assert!(fn_val.get_metadata(3).is_none());
-
-    let md_node_values = fn_val.get_metadata(4).unwrap().get_node_values();
-
-    assert_eq!(md_node_values.len(), 2);
-    assert_eq!(md_node_values[0].as_int_value(), &bool_val);
-    assert_eq!(md_node_values[1].as_float_value(), &f32_val);
-
-    ptr_val.set_metadata(md_string, 1);
-
-    assert!(ptr_val.has_metadata());
-
-    let md_node_values = ptr_val.get_metadata(1).unwrap().get_node_values();
-
-    assert_eq!(md_node_values.len(), 1);
-    assert_eq!(md_node_values[0].as_metadata_value().get_string_value(), md_string.get_string_value());
 
     // New Context Metadata
     let context_metadata_node = context.metadata_node(&[bool_val.into(), f32_val.into()]);


### PR DESCRIPTION
    metadata can only be attached to instructions
    
    See: https://llvm.org/docs/LangRef.html#metadata
    
    Attempting to set metadata on other LLVMValueRef will cause undefined
    behaviour in llvm, see here for example:
    
    https://github.com/llvm/llvm-project/blob/release/8.x/llvm/lib/IR/Core.cpp#L851

closes #130 
