### PR TITLE
Added missing return 'ctx lt to const_int_from_string

### DIFF
--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -117,7 +117,7 @@ impl<'ctx> IntType<'ctx> {
     /// let i8_val = i8_type.const_int_from_string("ABCD", StringRadix::Binary);
     /// assert!(i8_val.is_none());
     /// ```
-    pub fn const_int_from_string(&self, slice: &str, radix: StringRadix) -> Option<IntValue> {
+    pub fn const_int_from_string(&self, slice: &str, radix: StringRadix) -> Option<IntValue<'ctx>> {
         if !radix.to_regex().is_match(slice) {
             return None
         }


### PR DESCRIPTION
Signed-off-by: Sean Young <sean@mess.org>

<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
