### PR TITLE
The WebAssembly target is experimental on llvm 7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ target-all = [
     "target-sparc",
     "target-bpf",
     "target-lanai",
-    "target-webassembly"
 ]
 experimental = ["static-alloc"]
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -733,7 +733,7 @@ impl Target {
     }
 
     #[cfg(feature = "target-webassembly")]
-    #[llvm_versions(8.0..=latest)]
+    #[llvm_versions(7.0..=latest)]
     pub fn initialize_webassembly(config: &InitializationConfig) {
         use llvm_sys::target::{
             LLVMInitializeWebAssemblyAsmParser, LLVMInitializeWebAssemblyAsmPrinter,


### PR DESCRIPTION
So allow initialize_webassembly() to be called, but only if the
target-webassembly feature is enabled. This should not be enabled by
default by target-all, since it is experimental.

Signed-off-by: Sean Young <sean@mess.org>

This makes it possible to build https://github.com/hyperledger-labs/solang against llvm 7.0. I know you want merges to go into master and this merge request is not. However this change is specific to the llvm7-0 branch.
