### PR TITLE
Change Context::metadata_node to take a list of BasicMetadataValueEnums.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -17,7 +17,7 @@ use crate::memory_buffer::MemoryBuffer;
 use crate::module::Module;
 use crate::support::LLVMString;
 use crate::types::{BasicTypeEnum, FloatType, IntType, StructType, VoidType, AsTypeRef};
-use crate::values::{AsValueRef, FunctionValue, StructValue, MetadataValue, BasicValueEnum, VectorValue};
+use crate::values::{AsValueRef, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, StructValue, MetadataValue, VectorValue};
 
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -701,8 +701,7 @@ impl Context {
     /// ```
     // REVIEW: Maybe more helpful to beginners to call this metadata_tuple?
     // REVIEW: Seems to be unassgned to anything
-    // REVIEW: Should maybe make this take &[BasicValueEnum]?
-    pub fn metadata_node(&self, values: &[BasicValueEnum]) -> MetadataValue {
+    pub fn metadata_node(&self, values: &[BasicMetadataValueEnum]) -> MetadataValue {
         let mut tuple_values: Vec<LLVMValueRef> = values.iter()
                                                         .map(|val| val.as_value_ref())
                                                         .collect();

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -356,3 +356,32 @@ fn test_atomic_ordering_mem_instructions() {
     assert!(fadd_instruction.get_atomic_ordering().is_err());
     assert!(fadd_instruction.set_atomic_ordering(AtomicOrdering::NotAtomic).is_err());
 }
+
+#[test]
+fn test_metadata_kinds() {
+    let context = Context::create();
+
+    let i8_type = context.i8_type();
+    let f32_type = context.f32_type();
+    let ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let struct_type = context.struct_type(&[i8_type.into(), f32_type.into()], false);
+    let vector_type = i8_type.vec_type(2);
+
+    let i8_value = i8_type.const_zero();
+    let i8_array_value = i8_type.const_array(&[i8_value]);
+    let f32_value = f32_type.const_zero();
+    let ptr_value = ptr_type.const_null();
+    let struct_value = struct_type.get_undef();
+    let vector_value = vector_type.const_zero();
+
+    let md_string = context.metadata_string("lots of metadata here");
+    let md_node = context.metadata_node(&[
+        i8_array_value.into(),
+        i8_value.into(),
+        f32_value.into(),
+        ptr_value.into(),
+        struct_value.into(),
+        vector_value.into(),
+        md_string.into(),
+    ]);
+}

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -375,7 +375,7 @@ fn test_metadata_kinds() {
     let vector_value = vector_type.const_zero();
 
     let md_string = context.metadata_string("lots of metadata here");
-    let md_node = context.metadata_node(&[
+    context.metadata_node(&[
         i8_array_value.into(),
         i8_value.into(),
         f32_value.into(),


### PR DESCRIPTION
## Description

Changes Context::metadata_node to take a list of BasicMetadataValueEnums instead of BasicValueEnums. This allows us to put metadata strings and other metadata nodes inside metadata nodes.

## How This Has Been Tested

Adds a test for each type of value that we can insert.

We use this to build up TBAA (type-based aliasing analysis) metadata in the Wasmer LLVM backend.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
