### PR TITLE
Add `no-llvm-linking` feature to prevent linking LLVM while building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ llvm5-0 = []
 llvm6-0 = []
 llvm7-0 = []
 llvm8-0 = []
+# Don't link aganist LLVM libraries. This is useful if another dependency is
+# installing LLVM. See llvm-sys for more details.
+no-llvm-linking = ["llvm-sys/no-llvm-linking"]
 target-x86 = []
 target-arm = []
 target-mips = []


### PR DESCRIPTION

## Description

This PR adds a cargo feature, `no-llvm-linking`, that enables a feature with the same name in `llvm-sys` which prevents `llvm-sys` from telling rust to link LLVM in its bulid.rs.
## Related Issue

Discussed beforehand, apologies for the lack of issue.

## How This Has Been Tested

It worked with `patch` locally, this change doesn't introduce much change on the inkwell side.  I have run into some issues on the Wasmer side landing this and don't have the bandwidth to fully investigate it right now.  It looks like we just need to do more on our side to ensure that LLVM gets properly linked in.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
