### PR TITLE
Build malloc fix

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,7 +12,7 @@ use crate::basic_block::BasicBlock;
 use crate::values::{AggregateValue, AggregateValueEnum, AsValueRef, BasicValue, BasicValueEnum, PhiValue, FunctionValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, PointerMathValue, InstructionOpcode, CallSiteValue};
 #[llvm_versions(3.9..=latest)]
 use crate::values::StructValue;
-use crate::types::{AsTypeRef, BasicType, IntMathType, FloatMathType, PointerType, PointerMathType};
+use crate::types::{AsTypeRef, BasicType, BasicTypeEnum, IntMathType, FloatMathType, PointerType, PointerMathType};
 
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -349,6 +349,19 @@ impl<'ctx> Builder<'ctx> {
 
     // TODOC: Heap allocation
     pub fn build_malloc<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> PointerValue<'ctx> {
+        // LLVMBulidMalloc segfaults if ty is unsized
+        let is_sized = match ty.as_basic_type_enum() {
+            BasicTypeEnum::ArrayType(ty) => ty.is_sized(),
+            BasicTypeEnum::FloatType(ty) => ty.is_sized(),
+            BasicTypeEnum::IntType(ty) => ty.is_sized(),
+            BasicTypeEnum::PointerType(ty) => ty.is_sized(),
+            BasicTypeEnum::StructType(ty) => ty.is_sized(),
+            BasicTypeEnum::VectorType(ty) => ty.is_sized(),
+        };
+        if !is_sized {
+            panic!("Cannot build malloc call for an unsized type {:?}", ty);
+        }
+
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
         let value = unsafe {

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -903,6 +903,7 @@ fn test_allocations() {
     let module = context.create_module("my_mod");
     let void_type = context.void_type();
     let i32_type = context.i32_type();
+    let unsized_type = context.opaque_struct_type("my_struct");
     let i32_three = i32_type.const_int(3, false);
     let fn_type = void_type.fn_type(&[], false);
     let fn_value = module.add_function("my_func", fn_type, None);
@@ -932,6 +933,14 @@ fn test_allocations() {
     let heap_array = builder.build_array_malloc(i32_type, i32_three, "heap_array");
 
     assert_eq!(*heap_array.get_type().print_to_string(), *CString::new("i32*").unwrap());
+
+    let bad_malloc_res = std::panic::catch_unwind(|| builder.build_malloc(unsized_type, ""));
+
+    assert!(bad_malloc_res.is_err());
+
+    let bad_array_malloc_res = std::panic::catch_unwind(|| builder.build_array_malloc(unsized_type, i32_three, ""));
+
+    assert!(bad_array_malloc_res.is_err());
 }
 
 #[test]

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -928,17 +928,19 @@ fn test_allocations() {
 
     let heap_ptr = builder.build_malloc(i32_type, "heap_ptr");
 
-    assert_eq!(*heap_ptr.get_type().print_to_string(), *CString::new("i32*").unwrap());
+    assert!(heap_ptr.is_ok());
+    assert_eq!(*heap_ptr.unwrap().get_type().print_to_string(), *CString::new("i32*").unwrap());
 
     let heap_array = builder.build_array_malloc(i32_type, i32_three, "heap_array");
 
-    assert_eq!(*heap_array.get_type().print_to_string(), *CString::new("i32*").unwrap());
+    assert!(heap_array.is_ok());
+    assert_eq!(*heap_array.unwrap().get_type().print_to_string(), *CString::new("i32*").unwrap());
 
-    let bad_malloc_res = std::panic::catch_unwind(|| builder.build_malloc(unsized_type, ""));
+    let bad_malloc_res = builder.build_malloc(unsized_type, "");
 
     assert!(bad_malloc_res.is_err());
 
-    let bad_array_malloc_res = std::panic::catch_unwind(|| builder.build_array_malloc(unsized_type, i32_three, ""));
+    let bad_array_malloc_res = builder.build_array_malloc(unsized_type, i32_three, "");
 
     assert!(bad_array_malloc_res.is_err());
 }


### PR DESCRIPTION
## Description

I added checks that the types passed to `build_malloc` and `build_array_malloc` are sized before shelling out to `llvm-sys`. One annoying thing about the implementation is that it has to match on the `BasicTypeEnum` because there isn't another way (as far as I know) to check `is_sized`. There are a few functions like this in `inkwell` where QOL could be improved in the future. For now I think this is fine, though maybe I should have left a TODO there.

## Related Issue

[Fixes this issue.](https://github.com/TheDan64/inkwell/issues/150)

## How This Has Been Tested

I added two new checks to `test_allocations` which ensure `build_malloc` and `build_array_malloc` panic when handed unsized types (instead of segfaulting). I also ran the entire existing test suite and all tests pass.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
