### PR TITLE
Set target fix

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -395,12 +395,12 @@ impl<'ctx> Module<'ctx> {
             .map_err(|mut err_string| {
                 err_string.push('\0');
 
-                LLVMString::create(&err_string)
+                LLVMString::create_from_str(&err_string)
             })?;
 
         if self.owned_by_ee.borrow().is_some() {
             let string = "This module is already owned by an ExecutionEngine.\0";
-            return Err(LLVMString::create(string));
+            return Err(LLVMString::create_from_str(string));
         }
 
         let mut execution_engine = MaybeUninit::uninit();
@@ -446,12 +446,12 @@ impl<'ctx> Module<'ctx> {
             .map_err(|mut err_string| {
                 err_string.push('\0');
 
-                LLVMString::create(&err_string)
+                LLVMString::create_from_str(&err_string)
             })?;
 
         if self.owned_by_ee.borrow().is_some() {
             let string = "This module is already owned by an ExecutionEngine.\0";
-            return Err(LLVMString::create(string));
+            return Err(LLVMString::create_from_str(string));
         }
 
         let mut execution_engine = MaybeUninit::uninit();
@@ -499,12 +499,12 @@ impl<'ctx> Module<'ctx> {
             .map_err(|mut err_string| {
                 err_string.push('\0');
 
-                LLVMString::create(&err_string)
+                LLVMString::create_from_str(&err_string)
             })?;
 
         if self.owned_by_ee.borrow().is_some() {
             let string = "This module is already owned by an ExecutionEngine.\0";
-            return Err(LLVMString::create(string));
+            return Err(LLVMString::create_from_str(string));
         }
 
         let mut execution_engine = MaybeUninit::uninit();
@@ -1209,7 +1209,7 @@ impl<'ctx> Module<'ctx> {
     pub fn link_in_module(&self, other: Self) -> Result<(), LLVMString> {
         if other.owned_by_ee.borrow().is_some() {
             let string = "Cannot link a module which is already owned by an ExecutionEngine.\0";
-            return Err(LLVMString::create(string));
+            return Err(LLVMString::create_from_str(string));
         }
 
         #[cfg(any(feature = "llvm3-6", feature = "llvm3-7"))]

--- a/src/module.rs
+++ b/src/module.rs
@@ -16,7 +16,6 @@ use llvm_sys::LLVMLinkage;
 use llvm_sys::LLVMModuleFlagBehavior;
 
 use std::cell::{Cell, RefCell, Ref};
-#[llvm_versions(3.9..=latest)]
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::fs::File;

--- a/src/module.rs
+++ b/src/module.rs
@@ -327,19 +327,20 @@ impl<'ctx> Module<'ctx> {
     ///
     /// ```rust,no_run
     /// use inkwell::context::Context;
-    /// use inkwell::targets::TargetTriple;
+    /// use inkwell::targets::{Target, TargetTriple};
     ///
+    /// Target::initialize_x86(&Default::default());
     /// let context = Context::create();
     /// let module = context.create_module("mod");
     /// let triple = TargetTriple::create("x86_64-pc-linux-gnu");
     ///
-    /// assert_eq!(module.get_target(), TargetTriple::create(""));
+    /// assert_eq!(module.get_target_triple(), TargetTriple::create(""));
     ///
-    /// module.set_target(&triple);
+    /// module.set_target_triple(&triple);
     ///
-    /// assert_eq!(module.get_target(), triple);
+    /// assert_eq!(module.get_target_triple(), triple);
     /// ```
-    pub fn set_target(&self, target_triple: &TargetTriple) {
+    pub fn set_target_triple(&self, target_triple: &TargetTriple) {
         unsafe {
             LLVMSetTarget(self.module.get(), target_triple.as_ptr())
         }
@@ -352,19 +353,20 @@ impl<'ctx> Module<'ctx> {
     ///
     /// ```rust,no_run
     /// use inkwell::context::Context;
-    /// use inkwell::targets::TargetTriple;
+    /// use inkwell::targets::{Target, TargetTriple};
     ///
+    /// Target::initialize_x86(&Default::default());
     /// let context = Context::create();
     /// let module = context.create_module("mod");
     /// let triple = TargetTriple::create("x86_64-pc-linux-gnu");
     ///
-    /// assert_eq!(module.get_target(), TargetTriple::create(""));
+    /// assert_eq!(module.get_target_triple(), TargetTriple::create(""));
     ///
-    /// module.set_target(&triple);
+    /// module.set_target_triple(&triple);
     ///
-    /// assert_eq!(module.get_target(), triple);
+    /// assert_eq!(module.get_target_triple(), triple);
     /// ```
-    pub fn get_target(&self) -> TargetTriple {
+    pub fn get_target_triple(&self) -> TargetTriple {
         // REVIEW: This isn't an owned LLVMString, is it? If so, need to deallocate.
         let target_str = unsafe {
             LLVMGetTarget(self.module.get())

--- a/src/module.rs
+++ b/src/module.rs
@@ -334,13 +334,13 @@ impl<'ctx> Module<'ctx> {
     /// let module = context.create_module("mod");
     /// let triple = TargetTriple::create("x86_64-pc-linux-gnu");
     ///
-    /// assert_eq!(module.get_target_triple(), TargetTriple::create(""));
+    /// assert_eq!(module.get_triple(), TargetTriple::create(""));
     ///
-    /// module.set_target_triple(&triple);
+    /// module.set_triple(&triple);
     ///
-    /// assert_eq!(module.get_target_triple(), triple);
+    /// assert_eq!(module.get_triple(), triple);
     /// ```
-    pub fn set_target_triple(&self, target_triple: &TargetTriple) {
+    pub fn set_triple(&self, target_triple: &TargetTriple) {
         unsafe {
             LLVMSetTarget(self.module.get(), target_triple.as_ptr())
         }
@@ -360,19 +360,19 @@ impl<'ctx> Module<'ctx> {
     /// let module = context.create_module("mod");
     /// let triple = TargetTriple::create("x86_64-pc-linux-gnu");
     ///
-    /// assert_eq!(module.get_target_triple(), TargetTriple::create(""));
+    /// assert_eq!(module.get_triple(), TargetTriple::create(""));
     ///
-    /// module.set_target_triple(&triple);
+    /// module.set_triple(&triple);
     ///
-    /// assert_eq!(module.get_target_triple(), triple);
+    /// assert_eq!(module.get_triple(), triple);
     /// ```
-    pub fn get_target_triple(&self) -> TargetTriple {
+    pub fn get_triple(&self) -> TargetTriple {
         // REVIEW: This isn't an owned LLVMString, is it? If so, need to deallocate.
         let target_str = unsafe {
             LLVMGetTarget(self.module.get())
         };
 
-        TargetTriple::new_borrowed(target_str)
+        TargetTriple::new(LLVMString::create_from_c_str(unsafe { CStr::from_ptr(target_str) }))
     }
 
     /// Creates an `ExecutionEngine` from this `Module`.

--- a/src/module.rs
+++ b/src/module.rs
@@ -340,9 +340,9 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert_eq!(module.get_triple(), triple);
     /// ```
-    pub fn set_triple(&self, target_triple: &TargetTriple) {
+    pub fn set_triple(&self, triple: &TargetTriple) {
         unsafe {
-            LLVMSetTarget(self.module.get(), target_triple.as_ptr())
+            LLVMSetTarget(self.module.get(), triple.as_ptr())
         }
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -35,7 +35,7 @@ use crate::data_layout::DataLayout;
 use crate::execution_engine::ExecutionEngine;
 use crate::memory_buffer::MemoryBuffer;
 use crate::support::LLVMString;
-use crate::targets::{Target, InitializationConfig};
+use crate::targets::{InitializationConfig, Target, TargetTriple};
 use crate::types::{AsTypeRef, BasicType, FunctionType, BasicTypeEnum};
 use crate::values::{AsValueRef, FunctionValue, GlobalValue, MetadataValue};
 #[llvm_versions(7.0..=latest)]
@@ -341,9 +341,9 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert_eq!(module.get_target().unwrap(), target);
     /// ```
-    pub fn set_target(&self, target: &Target) {
+    pub fn set_target(&self, target_triple: &TargetTriple) {
         unsafe {
-            LLVMSetTarget(self.module.get(), target.get_name().as_ptr())
+            LLVMSetTarget(self.module.get(), target_triple.as_ptr())
         }
     }
 
@@ -367,13 +367,13 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert_eq!(module.get_target().unwrap(), target);
     /// ```
-    pub fn get_target(&self) -> Option<Target> {
+    pub fn get_target(&self) -> TargetTriple {
         // REVIEW: This isn't an owned LLVMString, is it? If so, need to deallocate.
         let target_str = unsafe {
             LLVMGetTarget(self.module.get())
         };
 
-        Target::from_name_raw(target_str)
+        TargetTriple::new_borrowed(target_str)
     }
 
     /// Creates an `ExecutionEngine` from this `Module`.

--- a/src/module.rs
+++ b/src/module.rs
@@ -321,25 +321,23 @@ impl<'ctx> Module<'ctx> {
         Some(BasicTypeEnum::new(type_))
     }
 
-    /// Sets a `Target` to this `Module`.
+    /// Assigns a `TargetTriple` to this `Module`.
     ///
     /// # Example
     ///
     /// ```rust,no_run
     /// use inkwell::context::Context;
-    /// use inkwell::targets::Target;
-    ///
-    /// Target::initialize_x86(&Default::default());
+    /// use inkwell::targets::TargetTriple;
     ///
     /// let context = Context::create();
     /// let module = context.create_module("mod");
-    /// let target = Target::from_name("x86-64").unwrap();
+    /// let triple = TargetTriple::create("x86_64-pc-linux-gnu");
     ///
-    /// assert!(module.get_target().is_none());
+    /// assert_eq!(module.get_target(), TargetTriple::create(""));
     ///
-    /// module.set_target(&target);
+    /// module.set_target(&triple);
     ///
-    /// assert_eq!(module.get_target().unwrap(), target);
+    /// assert_eq!(module.get_target(), triple);
     /// ```
     pub fn set_target(&self, target_triple: &TargetTriple) {
         unsafe {
@@ -347,25 +345,24 @@ impl<'ctx> Module<'ctx> {
         }
     }
 
-    /// Gets the `Target` assigned to this `Module`, if any.
+    /// Gets the `TargetTriple` assigned to this `Module`. If none has been
+    /// assigned, the triple will default to "".
     ///
     /// # Example
     ///
     /// ```rust,no_run
     /// use inkwell::context::Context;
-    /// use inkwell::targets::Target;
-    ///
-    /// Target::initialize_x86(&Default::default());
+    /// use inkwell::targets::TargetTriple;
     ///
     /// let context = Context::create();
     /// let module = context.create_module("mod");
-    /// let target = Target::from_name("x86-64").unwrap();
+    /// let triple = TargetTriple::create("x86_64-pc-linux-gnu");
     ///
-    /// assert!(module.get_target().is_none());
+    /// assert_eq!(module.get_target(), TargetTriple::create(""));
     ///
-    /// module.set_target(&target);
+    /// module.set_target(&triple);
     ///
-    /// assert_eq!(module.get_target().unwrap(), target);
+    /// assert_eq!(module.get_target(), triple);
     /// ```
     pub fn get_target(&self) -> TargetTriple {
         // REVIEW: This isn't an owned LLVMString, is it? If so, need to deallocate.

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -33,7 +33,16 @@ impl LLVMString {
     }
 
     /// This method will allocate a c string through LLVM
-    pub(crate) fn create(string: &str) -> LLVMString {
+    pub(crate) fn create_from_c_str(string: &CStr) -> LLVMString {
+        let ptr = unsafe {
+            LLVMCreateMessage(string.as_ptr() as *const _)
+        };
+
+        LLVMString::new(ptr)
+    }
+
+    /// This method will allocate a c string through LLVM
+    pub(crate) fn create_from_str(string: &str) -> LLVMString {
         debug_assert_eq!(string.as_bytes()[string.as_bytes().len() - 1], 0);
 
         let ptr = unsafe {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -119,11 +119,10 @@ impl TargetTriple {
     }
 
     pub fn create(target_triple: &str) -> TargetTriple {
-        let mut target_triple_copy = target_triple.to_owned();
-        target_triple_copy.push('\0');
+        let c_string = CString::new(target_triple).expect("Conversion to CString failed unexpectedly");
 
         TargetTriple {
-            target_triple: LLVMStringOrRaw::Owned(LLVMString::create(&target_triple_copy))
+            target_triple: LLVMStringOrRaw::Owned(LLVMString::create_from_c_str(c_string.as_c_str()))
         }
     }
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -97,21 +97,21 @@ impl Default for InitializationConfig {
 
 #[derive(Eq)]
 pub struct TargetTriple {
-    pub(crate) target_triple: LLVMString,
+    pub(crate) triple: LLVMString,
 }
 
 impl TargetTriple {
-    pub(crate) fn new(target_triple: LLVMString) -> TargetTriple {
+    pub(crate) fn new(triple: LLVMString) -> TargetTriple {
         TargetTriple {
-            target_triple,
+            triple,
         }
     }
 
-    pub fn create(target_triple: &str) -> TargetTriple {
-        let c_string = CString::new(target_triple).expect("Conversion to CString failed unexpectedly");
+    pub fn create(triple: &str) -> TargetTriple {
+        let c_string = CString::new(triple).expect("Conversion to CString failed unexpectedly");
 
         TargetTriple {
-            target_triple: LLVMString::create_from_c_str(c_string.as_c_str())
+            triple: LLVMString::create_from_c_str(c_string.as_c_str())
         }
     }
 
@@ -120,25 +120,25 @@ impl TargetTriple {
     }
 
     pub fn as_ptr(&self) -> *const ::libc::c_char {
-        self.target_triple.as_ptr()
+        self.triple.as_ptr()
     }
 }
 
 impl PartialEq for TargetTriple {
     fn eq(&self, other: &TargetTriple) -> bool {
-        self.target_triple == other.target_triple
+        self.triple == other.triple
     }
 }
 
 impl fmt::Debug for TargetTriple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TargetTriple({:?})", self.target_triple)
+        write!(f, "TargetTriple({:?})", self.triple)
     }
 }
 
 impl fmt::Display for TargetTriple {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "TargetTriple({:?})", self.target_triple)
+        write!(f, "TargetTriple({:?})", self.triple)
     }
 }
 
@@ -1002,13 +1002,13 @@ impl Target {
         Some(Target::new(target))
     }
 
-    pub fn from_triple(target_triple: &TargetTriple) -> Result<Self, LLVMString> {
+    pub fn from_triple(triple: &TargetTriple) -> Result<Self, LLVMString> {
         let mut target = ptr::null_mut();
         let mut err_string = MaybeUninit::uninit();
 
         let code = {
             let _guard = TARGET_LOCK.read();
-            unsafe { LLVMGetTargetFromTriple(target_triple.as_ptr(), &mut target, err_string.as_mut_ptr()) }
+            unsafe { LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, err_string.as_mut_ptr()) }
         };
 
         if code == 1 {
@@ -1076,7 +1076,7 @@ impl TargetMachine {
     }
 
     #[llvm_versions(7.0..=latest)]
-    pub fn normalize_target_triple(triple: &TargetTriple) -> TargetTriple {
+    pub fn normalize_triple(triple: &TargetTriple) -> TargetTriple {
         use llvm_sys::target_machine::LLVMNormalizeTargetTriple;
 
         let normalized = unsafe { LLVMNormalizeTargetTriple(triple.as_ptr()) };

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -108,10 +108,8 @@ impl TargetTriple {
     }
 
     pub fn create(triple: &str) -> TargetTriple {
-        let c_string = CString::new(triple).expect("Conversion to CString failed unexpectedly");
-
         TargetTriple {
-            triple: LLVMString::create_from_c_str(c_string.as_c_str())
+            triple: LLVMString::create_from_str(triple)
         }
     }
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,4 +1,3 @@
-#[llvm_versions(7.0..=latest)]
 use llvm_sys::target::{
     LLVMABIAlignmentOfType, LLVMABISizeOfType, LLVMByteOrder, LLVMByteOrdering,
     LLVMCallFrameAlignmentOfType, LLVMCopyStringRepOfTargetData, LLVMCreateTargetData,

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -108,8 +108,10 @@ impl TargetTriple {
     }
 
     pub fn create(triple: &str) -> TargetTriple {
+        let c_string = CString::new(triple).expect("Conversion to CString failed unexpectedly");
+
         TargetTriple {
-            triple: LLVMString::create_from_str(triple)
+            triple: LLVMString::create_from_c_str(c_string.as_c_str())
         }
     }
 

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -4,7 +4,7 @@ use self::inkwell::OptimizationLevel;
 use self::inkwell::context::Context;
 use self::inkwell::memory_buffer::MemoryBuffer;
 use self::inkwell::module::Module;
-use self::inkwell::targets::Target;
+use self::inkwell::targets::TargetTriple;
 
 use std::env::temp_dir;
 use std::ffi::CString;
@@ -316,15 +316,13 @@ fn test_print_to_file() {
 
 #[test]
 fn test_get_set_target() {
-    Target::initialize_x86(&Default::default());
-
     let context = Context::create();
     let module = context.create_module("mod");
-    let target = Target::from_name("x86-64").unwrap();
+    let triple = TargetTriple::create("x86_64-pc-linux-gnu");
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     assert_eq!(*module.get_name(), *CString::new("mod").unwrap());
-    assert!(module.get_target().is_none());
+    assert_eq!(module.get_target(), TargetTriple::create(""));
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
@@ -332,11 +330,11 @@ fn test_get_set_target() {
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     module.set_name("mod2");
-    module.set_target(&target);
+    module.set_target(&triple);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     assert_eq!(*module.get_name(), *CString::new("mod2").unwrap());
-    assert_eq!(module.get_target().unwrap(), target);
+    assert_eq!(module.get_target(), triple);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -323,7 +323,7 @@ fn test_get_set_target() {
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     assert_eq!(*module.get_name(), *CString::new("mod").unwrap());
-    assert_eq!(module.get_target_triple(), TargetTriple::create(""));
+    assert_eq!(module.get_triple(), TargetTriple::create(""));
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
@@ -331,11 +331,11 @@ fn test_get_set_target() {
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     module.set_name("mod2");
-    module.set_target_triple(&triple);
+    module.set_triple(&triple);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     assert_eq!(*module.get_name(), *CString::new("mod2").unwrap());
-    assert_eq!(module.get_target_triple(), triple);
+    assert_eq!(module.get_triple(), triple);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -4,7 +4,7 @@ use self::inkwell::OptimizationLevel;
 use self::inkwell::context::Context;
 use self::inkwell::memory_buffer::MemoryBuffer;
 use self::inkwell::module::Module;
-use self::inkwell::targets::TargetTriple;
+use self::inkwell::targets::{Target, TargetTriple};
 
 use std::env::temp_dir;
 use std::ffi::CString;
@@ -316,13 +316,14 @@ fn test_print_to_file() {
 
 #[test]
 fn test_get_set_target() {
+    Target::initialize_x86(&Default::default());
     let context = Context::create();
     let module = context.create_module("mod");
     let triple = TargetTriple::create("x86_64-pc-linux-gnu");
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     assert_eq!(*module.get_name(), *CString::new("mod").unwrap());
-    assert_eq!(module.get_target(), TargetTriple::create(""));
+    assert_eq!(module.get_target_triple(), TargetTriple::create(""));
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
@@ -330,11 +331,11 @@ fn test_get_set_target() {
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     module.set_name("mod2");
-    module.set_target(&triple);
+    module.set_target_triple(&triple);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
     assert_eq!(*module.get_name(), *CString::new("mod2").unwrap());
-    assert_eq!(module.get_target(), triple);
+    assert_eq!(module.get_target_triple(), triple);
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
                   feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -136,7 +136,7 @@ fn test_target_and_target_machine() {
     {
         // TODO: Try and find a triple that actually gets normalized..
         assert_eq!(
-            TargetMachine::normalize_target_triple(&triple).as_str(),
+            TargetMachine::normalize_triple(&triple).as_str(),
             CString::new("x86_64-pc-linux-gnu").unwrap().as_c_str(),
         );
 
@@ -146,18 +146,18 @@ fn test_target_and_target_machine() {
 }
 
 #[test]
-fn test_default_target_triple() {
-    let default_target_triple = TargetMachine::get_default_triple();
-    let default_target_triple = default_target_triple.as_str().to_string_lossy();
+fn test_default_triple() {
+    let default_triple = TargetMachine::get_default_triple();
+    let default_triple = default_triple.as_str().to_string_lossy();
 
     #[cfg(target_os = "linux")]
-    let cond = default_target_triple == "x86_64-pc-linux-gnu" ||
-               default_target_triple == "x86_64-unknown-linux-gnu";
+    let cond = default_triple == "x86_64-pc-linux-gnu" ||
+               default_triple == "x86_64-unknown-linux-gnu";
 
     #[cfg(target_os = "macos")]
-    let cond = default_target_triple.starts_with("x86_64-apple-darwin");
+    let cond = default_triple.starts_with("x86_64-apple-darwin");
 
-    assert!(cond, "Unexpected target triple: {}", default_target_triple);
+    assert!(cond, "Unexpected target triple: {}", default_triple);
 
     // TODO: CFG for other supported major OSes
 }


### PR DESCRIPTION
## Description

I added a new struct, `inkwell::targets::TargetTriple` that models a target triple more explicitly in the type system. I fixed the bug where `Module::set_target` and `Module::get_target` were operating on a target rather than a target triple. I also updated all of the functions in the inkwell API which deal with target triples (I think I got all of them at least) to use the `TargetTriple` struct. Corresponding changes were made to the documentation.

`TargetTriple` is a thin wrapper around an `LLVMStringOrRaw`. I modeled `TargetTriple` after `DataLayout`, which achieves a similar aim albeit for a different part of the API. So, even though there are a good number of breaking changes here, the end result is consistent with other parts of the already existing API.

The only part of the implementation I'm not completely satisfied with is the two string copies that have to be made in `TargetTriple::create`, which is the user facing constructor. But, even though this isn't ideal, it should probably be OK because it's unlikely to be on the critical path and, on the off chance it is, things are probably still OK.

## Related Issue

[Fixes this issue.](https://github.com/TheDan64/inkwell/issues/149)

## How This Has Been Tested

There were already test cases for all (most?) of the functions I modified. I updated the existing test suite where needed to be compatible with the new API. I ran `cargo test` and everything passed.

## Breaking Changes

- `Module::set_target` takes a `&TargetTriple` rather than a `&Target`
- `Module::get_target` returns a `TargetTriple` rather than a `Target`
- `Target::create_target_machine` takes a `&TargetTriple` rather than a ` &str` to specify the target triple
- `Target::from_triple` takes a `&TargetTriple` rather than a `&str`
- `TargetMachine::get_triple` returns a `TargetTriple` rather than an `LLVMString`
- `TargetMachine::get_default_triple` returns a `TargetTriple` rather than an `LLVMString`
- `TargetMachine::normalized_target_triple` takes a `&TargetTriple` rather than an `Either<&str, &CStr>` and returns a `TargetTriple` rather than a `LLVMString`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
