### PR TITLE
Introduce size_of() on BasicTypeEnum

### DIFF
--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -5,7 +5,7 @@ use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{Type, BasicTypeEnum, BasicType, PointerType, FunctionType};
+use crate::types::{Type, BasicTypeEnum, PointerType, FunctionType};
 use crate::values::{AsValueRef, ArrayValue, IntValue};
 
 /// An `ArrayType` is the type of contiguous constants or variables.
@@ -37,11 +37,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// let i8_array_type_size = i8_array_type.size_of();
     /// ```
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {
-        if self.is_sized() {
-            return Some(self.array_type.size_of())
-        }
-
-        None
+        self.array_type.size_of()
     }
 
     /// Gets the alignment of this `ArrayType`. Value may vary depending on the target architecture.

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -4,6 +4,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::types::{IntType, VoidType, FunctionType, PointerType, VectorType, ArrayType, StructType, FloatType};
 use crate::types::traits::AsTypeRef;
+use crate::values::IntValue;
 
 macro_rules! enum_type_set {
     ($(#[$enum_attrs:meta])* $enum_name:ident: { $($(#[$variant_attrs:meta])* $args:ident,)+ }) => (
@@ -233,6 +234,19 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             true
         } else {
             false
+        }
+    }
+
+    pub fn size_of(&self) -> Option<IntValue<'ctx>> {
+        match self {
+            AnyTypeEnum::ArrayType(t) => t.size_of(),
+            AnyTypeEnum::FloatType(t) => Some(t.size_of()),
+            AnyTypeEnum::IntType(t) => Some(t.size_of()),
+            AnyTypeEnum::PointerType(t) => Some(t.size_of()),
+            AnyTypeEnum::StructType(t) => t.size_of(),
+            AnyTypeEnum::VectorType(t) => t.size_of(),
+            AnyTypeEnum::VoidType(_) => None,
+            AnyTypeEnum::FunctionType(_) => None,
         }
     }
 }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -162,7 +162,7 @@ impl<'ctx> FloatType<'ctx> {
     /// let f32_type_size = f32_type.size_of();
     /// ```
     pub fn size_of(&self) -> IntValue<'ctx> {
-        self.float_type.size_of()
+        self.float_type.size_of().unwrap()
     }
 
     /// Gets the alignment of this `FloatType`. Value may vary depending on the target architecture.

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -261,7 +261,7 @@ impl<'ctx> IntType<'ctx> {
     /// let i8_type_size = i8_type.size_of();
     /// ```
     pub fn size_of(&self) -> IntValue<'ctx> {
-        self.int_type.size_of()
+        self.int_type.size_of().unwrap()
     }
 
     /// Gets the alignment of this `IntType`. Value may vary depending on the target architecture.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -172,16 +172,16 @@ impl<'ctx> Type<'ctx> {
         }
     }
 
-    // REVIEW: Option<IntValue>? If we want to provide it on enums that
-    // contain unsized types
-    fn size_of(&self) -> IntValue<'ctx> {
-        debug_assert!(self.is_sized());
+    fn size_of(&self) -> Option<IntValue<'ctx>> {
+        if !self.is_sized() {
+            return None;
+        }
 
         let int_value = unsafe {
             LLVMSizeOf(self.ty)
         };
 
-        IntValue::new(int_value)
+        Some(IntValue::new(int_value))
     }
 
     fn print_to_string(&self) -> LLVMString {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -39,7 +39,7 @@ impl<'ctx> PointerType<'ctx> {
     /// let f32_ptr_type_size = f32_ptr_type.size_of();
     /// ```
     pub fn size_of(&self) -> IntValue<'ctx> {
-        self.ptr_type.size_of()
+        self.ptr_type.size_of().unwrap()
     }
 
     /// Gets the alignment of this `PointerType`. Value may vary depending on the target architecture.

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -10,7 +10,7 @@ use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, BasicType, BasicTypeEnum, PointerType, FunctionType, Type};
+use crate::types::{ArrayType, BasicTypeEnum, PointerType, FunctionType, Type};
 use crate::values::{ArrayValue, BasicValueEnum, StructValue, IntValue, AsValueRef};
 
 /// A `StructType` is the type of a heterogeneous container of types.
@@ -117,11 +117,7 @@ impl<'ctx> StructType<'ctx> {
     /// let f32_struct_type_size = f32_struct_type.size_of();
     /// ```
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {
-        if self.is_sized() {
-            return Some(self.struct_type.size_of());
-        }
-
-        None
+        self.struct_type.size_of()
     }
 
     /// Gets the alignment of this `StructType`. Value may vary depending on the target architecture.

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -75,6 +75,23 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
         Type::new(self.as_type_ref()).is_sized()
     }
 
+    /// Gets the size of this `BasicType`. Value may vary depending on the target architecture.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::types::BasicType;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_basic_type = f32_type.as_basic_type_enum();
+    /// let f32_type_size = f32_basic_type.size_of();
+    /// ```
+    fn size_of(&self) -> Option<IntValue<'ctx>> {
+        Type::new(self.as_type_ref()).size_of()
+    }
+
     /// Create an `ArrayType` with this `BasicType` as its elements.
     ///
     /// Example:

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -4,7 +4,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
-use crate::types::{ArrayType, BasicTypeEnum, BasicType, Type, traits::AsTypeRef, FunctionType, PointerType};
+use crate::types::{ArrayType, BasicTypeEnum, Type, traits::AsTypeRef, FunctionType, PointerType};
 use crate::values::{AsValueRef, ArrayValue, BasicValue, VectorValue, IntValue};
 
 /// A `VectorType` is the type of a multiple value SIMD constant or variable.
@@ -38,11 +38,7 @@ impl<'ctx> VectorType<'ctx> {
     /// let f32_vec_type_size = f32_vec_type.size_of();
     /// ```
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {
-        if self.is_sized() {
-            return Some(self.vec_type.size_of())
-        }
-
-        None
+        self.vec_type.size_of()
     }
 
     /// Gets the alignment of this `VectorType`. Value may vary depending on the target architecture.

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -371,6 +371,8 @@ fn test_basic_type_enum() {
                    basic_type.ptr_type(addr));
         assert_eq!(basic_type.as_basic_type_enum().array_type(0),
                    basic_type.array_type(0));
+        assert_eq!(basic_type.as_basic_type_enum().size_of(),
+                   basic_type.size_of());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Sean Young <sean@mess.org>

<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

BasicTypeEnum does not have a size_of() so I have to match the enum and dispatch to the correct type. Better to support it directly.

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
