### PR TITLE
Add build_memcpy and build_memmove

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -357,13 +357,13 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
     #[llvm_versions(8.0..=latest)]
-    pub fn build_memcpy<T: IntMathValue<'ctx>>(
+    pub fn build_memcpy(
         &self,
         dest: PointerValue<'ctx>,
         dest_align_bytes: u32,
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
-        size: T,
+        size: IntValue<'ctx>,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         let value = unsafe {
             LLVMBuildMemCpy(
@@ -385,13 +385,13 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
     #[llvm_versions(8.0..=latest)]
-    pub fn build_memmove<T: IntMathValue<'ctx>>(
+    pub fn build_memmove(
         &self,
         dest: PointerValue<'ctx>,
         dest_align_bytes: u32,
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
-        size: T,
+        size: IntValue<'ctx>,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         let value = unsafe {
             LLVMBuildMemMove(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
@@ -345,6 +345,60 @@ impl<'ctx> Builder<'ctx> {
         };
 
         PointerValue::new(value)
+    }
+
+    /// Alignment arguments are specified in bytes, and should always be a power of 2.
+    ///
+    /// The final argument should be a pointer-sized integer.
+    ///
+    /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    pub fn build_memcpy<T: IntMathValue<'ctx>>(
+        &self,
+        dest: PointerValue<'ctx>,
+        dest_align_bytes: u32,
+        src: PointerValue<'ctx>,
+        src_align_bytes: u32,
+        size: T,
+    ) -> Result<PointerValue<'ctx>, &'static str> {
+        let value = unsafe {
+            LLVMBuildMemCpy(
+                self.builder,
+                dest.as_value_ref(),
+                dest_align_bytes,
+                src.as_value_ref(),
+                src_align_bytes,
+                size.as_value_ref(),
+            )
+        };
+
+        Ok(PointerValue::new(value))
+    }
+
+    /// Alignment arguments are specified in bytes, and should always be a power of 2.
+    ///
+    /// The final argument should be a pointer-sized integer.
+    ///
+    /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    pub fn build_memmove<T: IntMathValue<'ctx>>(
+        &self,
+        dest: PointerValue<'ctx>,
+        dest_align_bytes: u32,
+        src: PointerValue<'ctx>,
+        src_align_bytes: u32,
+        size: T,
+    ) -> Result<PointerValue<'ctx>, &'static str> {
+        let value = unsafe {
+            LLVMBuildMemMove(
+                self.builder,
+                dest.as_value_ref(),
+                dest_align_bytes,
+                src.as_value_ref(),
+                src_align_bytes,
+                size.as_value_ref(),
+            )
+        };
+
+        Ok(PointerValue::new(value))
     }
 
     // TODOC: Heap allocation

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,13 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::core::LLVMBuildMemCpy;
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::core::LLVMBuildMemMove;
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 use llvm_sys::{LLVMTypeKind};
 
@@ -352,6 +356,7 @@ impl<'ctx> Builder<'ctx> {
     /// The final argument should be a pointer-sized integer.
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    #[llvm_versions(8.0..=latest)]
     pub fn build_memcpy<T: IntMathValue<'ctx>>(
         &self,
         dest: PointerValue<'ctx>,
@@ -379,6 +384,7 @@ impl<'ctx> Builder<'ctx> {
     /// The final argument should be a pointer-sized integer.
     ///
     /// [`TargetData::ptr_sized_int_type_in_context`](https://thedan64.github.io/inkwell/inkwell/targets/struct.TargetData.html#method.ptr_sized_int_type_in_context) will get you one of those.
+    #[llvm_versions(8.0..=latest)]
     pub fn build_memmove<T: IntMathValue<'ctx>>(
         &self,
         dest: PointerValue<'ctx>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,9 +5,7 @@ use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArray
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 #[llvm_versions(8.0..=latest)]
-use llvm_sys::core::LLVMBuildMemCpy;
-#[llvm_versions(8.0..=latest)]
-use llvm_sys::core::LLVMBuildMemMove;
+use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 use llvm_sys::{LLVMTypeKind};
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -364,7 +364,7 @@ impl<'ctx> Builder<'ctx> {
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
         size: IntValue<'ctx>,
-    ) -> Result<PointerValue<'ctx>, &'static str> {
+    ) -> PointerValue<'ctx> {
         let value = unsafe {
             LLVMBuildMemCpy(
                 self.builder,
@@ -376,7 +376,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        Ok(PointerValue::new(value))
+        PointerValue::new(value)
     }
 
     /// Build a [memmove](http://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) instruction.
@@ -394,7 +394,7 @@ impl<'ctx> Builder<'ctx> {
         src: PointerValue<'ctx>,
         src_align_bytes: u32,
         size: IntValue<'ctx>,
-    ) -> Result<PointerValue<'ctx>, &'static str> {
+    ) -> PointerValue<'ctx> {
         let value = unsafe {
             LLVMBuildMemMove(
                 self.builder,
@@ -406,7 +406,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        Ok(PointerValue::new(value))
+        PointerValue::new(value)
     }
 
     // TODOC: Heap allocation

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -349,6 +349,8 @@ impl<'ctx> Builder<'ctx> {
         PointerValue::new(value)
     }
 
+    /// Build a [memcpy](https://llvm.org/docs/LangRef.html#llvm-memcpy-intrinsic) instruction.
+    ///
     /// Alignment arguments are specified in bytes, and should always be a power of 2.
     ///
     /// The final argument should be a pointer-sized integer.
@@ -377,6 +379,8 @@ impl<'ctx> Builder<'ctx> {
         Ok(PointerValue::new(value))
     }
 
+    /// Build a [memmove](http://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) instruction.
+    ///
     /// Alignment arguments are specified in bytes, and should always be a power of 2.
     ///
     /// The final argument should be a pointer-sized integer.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -662,6 +662,14 @@ fn test_alignment_bytes() {
         } else {
             assert!(module.verify().is_err(), "alignment of {:?} was neither 0 nor a power of 2, yet verification passed for memcpy when it should not have.", alignment);
         }
+
+        run_memmove_on(&context, &module, alignment);
+
+        if alignment == 0 || alignment.is_power_of_two() {
+            assert!(module.verify().is_ok(), "alignment of {:?} was neither 0 nor a power of 2, but did not verify for memmov.", alignment);
+        } else {
+            assert!(module.verify().is_err(), "alignment of {:?} was neither 0 nor a power of 2, yet verification passed for memmov when it should not have.", alignment);
+        }
     };
 
     for alignment in 0..32 {
@@ -733,6 +741,67 @@ fn test_memcpy() {
     }
 }
 
+#[llvm_versions(8.0..=latest)]
+fn run_memmove_on<'ctx>(context: &'ctx Context, module: &self::inkwell::module::Module<'ctx>, alignment: u32) {
+    let i32_type = context.i32_type();
+    let i64_type = context.i64_type();
+    let array_len = 4;
+    let fn_type = i32_type.ptr_type(AddressSpace::Generic).fn_type(&[], false);
+    let fn_value = module.add_function("test_fn", fn_type, None);
+    let builder = context.create_builder();
+    let entry = context.append_basic_block(fn_value, "entry");
+
+    builder.position_at_end(entry);
+
+    let len_value = i64_type.const_int(array_len as u64, false);
+    let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
+
+    // Initialize the array with the values [1, 2, 3, 4]
+    for index in 0..4 {
+        let index_val = i32_type.const_int(index, false);
+        let elem_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
+        let int_val = i32_type.const_int(index + 1, false);
+
+        builder.build_store(elem_ptr, int_val);
+    }
+
+    // Memcpy the first half of the array over the second half of the array.
+    let elems_to_copy = 2;
+    let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
+    let size_val = i64_type.const_int(bytes_to_copy as u64, false);
+    let index_val = i32_type.const_int(2, false);
+    let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
+
+    builder.build_memmove(dest_ptr, alignment, array_ptr, alignment, size_val);
+
+    builder.build_return(Some(&array_ptr));
+}
+
+#[llvm_versions(8.0..=latest)]
+#[test]
+fn test_memmove() {
+    // 1. Allocate an array with a few elements.
+    // 2. Memmove from the first half of the array to the second half.
+    // 3. Run the code in an execution engine and verify the array's contents.
+    let context = Context::create();
+    let module = context.create_module("av");
+
+    run_memcpy_on(&context, &module, 8);
+
+    // Verify the module
+    if let Err(errors) = module.verify() {
+        panic!("Errors defining module: {:?}", errors);
+    }
+
+    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+
+    unsafe {
+        let func = execution_engine.get_function::<unsafe extern "C" fn() -> *const i32>("test_fn").unwrap();
+        let actual = std::slice::from_raw_parts(func.call(), 4);
+
+        assert_eq!(&[1, 2, 1, 2], actual);
+    }
+}
 
 #[test]
 fn test_bitcast() {

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -648,8 +648,8 @@ fn test_insert_value() {
     assert!(module.verify().is_ok());
 }
 
-#[test]
 #[llvm_versions(8.0..=latest)]
+#[test]
 fn test_alignment_bytes() {
     let verify_alignment = |alignment: u32| {
         let context = Context::create();
@@ -707,8 +707,8 @@ fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &self::inkwell::module::M
     builder.build_return(Some(&array_ptr));
 }
 
-#[test]
 #[llvm_versions(8.0..=latest)]
+#[test]
 fn test_memcpy() {
     // 1. Allocate an array with a few elements.
     // 2. Memcpy from the first half of the array to the second half.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -2,7 +2,6 @@ extern crate inkwell;
 
 use self::inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, OptimizationLevel};
 use self::inkwell::context::Context;
-use self::inkwell::module::Module;
 use self::inkwell::values::BasicValue;
 
 // use std::ffi::CString;
@@ -673,7 +672,7 @@ fn test_alignment_bytes() {
 }
 
 #[llvm_versions(8.0..=latest)]
-fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &Module<'ctx>, alignment: u32) {
+fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &self::inkwell::module::Module<'ctx>, alignment: u32) {
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -649,6 +649,7 @@ fn test_insert_value() {
 }
 
 #[test]
+#[llvm_versions(8.0..=latest)]
 fn test_memcpy() {
     // 1. Allocate an array with a few elements.
     // 2. Memcpy from the first half of the array to the second half.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -686,7 +686,7 @@ fn test_memcpy() {
     let index_val = i32_type.const_int(2, false);
     let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
 
-    builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val).unwrap();
+    builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val);
 
     builder.build_return(Some(&array_ptr));
 

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -649,6 +649,29 @@ fn test_insert_value() {
     assert!(module.verify().is_ok());
 }
 
+#[test]
+#[llvm_versions(8.0..=latest)]
+fn test_alignment_bytes() {
+    let verify_alignment = |alignment: u32| {
+        let context = Context::create();
+        let module = context.create_module("av");
+
+        run_memcpy_on(&context, &module, alignment);
+
+        if alignment == 0 || alignment.is_power_of_two() {
+            assert!(module.verify().is_ok(), "alignment of {:?} was neither 0 nor a power of 2, but did not verify for memcpy.", alignment);
+        } else {
+            assert!(module.verify().is_err(), "alignment of {:?} was neither 0 nor a power of 2, yet verification passed for memcpy when it should not have.", alignment);
+        }
+    };
+
+    for alignment in 0..32 {
+        verify_alignment(alignment);
+    }
+
+    verify_alignment(u32::max_value());
+}
+
 #[llvm_versions(8.0..=latest)]
 fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &Module<'ctx>, alignment: u32) {
     let i32_type = context.i32_type();

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -678,7 +678,14 @@ fn test_memcpy() {
     }
 
     // Memcpy the first half of the array over the second half of the array.
-    // TODO run the memcpy here
+    let elems_to_copy = 2;
+    let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
+    let size_val = i64_type.const_int(bytes_to_copy as u64, false);
+    let alignment = 8;
+    let index_val = i32_type.const_int(2, false);
+    let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
+
+    builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val).unwrap();
 
     builder.build_return(Some(&array_ptr));
 


### PR DESCRIPTION
## Description

Add `build_memcpy` and `build_memmove` LLVM intrinsics.

## Related Issue

https://github.com/TheDan64/inkwell/issues/145#issuecomment-600399438

## How This Has Been Tested

TODO

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
