### PR TITLE
Change BasicValueUse::get_user to return an AnyValueEnum.

### DIFF
--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -5,9 +5,9 @@ use llvm_sys::prelude::LLVMUseRef;
 use std::marker::PhantomData;
 
 use crate::basic_block::BasicBlock;
-use crate::values::{BasicValueEnum, InstructionValue};
+use crate::values::{AnyValueEnum, BasicValueEnum};
 
-/// A usage of a `BasicValue` in an `InstructionValue`.
+/// A usage of a `BasicValue` in another value.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BasicValueUse<'ctx>(LLVMUseRef, PhantomData<&'ctx ()>);
 
@@ -18,7 +18,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         BasicValueUse(use_, PhantomData)
     }
 
-    /// Gets the next use of an `InstructionValue` or `BasicValue` if any.
+    /// Gets the next use of a `BasicValue` if any.
     ///
     /// The following example,
     ///
@@ -83,7 +83,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         Some(Self::new(use_))
     }
 
-    /// Gets the user(an `InstructionValue`) of this use.
+    /// Gets the user (an `AnyValueEnum`) of this use.
     ///
     /// ```no_run
     /// use inkwell::AddressSpace;
@@ -115,15 +115,15 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// assert_eq!(store_operand_use0.get_user(), store_instruction);
     /// assert_eq!(store_operand_use1.get_user(), store_instruction);
     /// ```
-    pub fn get_user(&self) -> InstructionValue<'ctx> {
+    pub fn get_user(&self) -> AnyValueEnum<'ctx> {
         let user = unsafe {
             LLVMGetUser(self.0)
         };
 
-        InstructionValue::new(user)
+        AnyValueEnum::new(user)
     }
 
-    /// Gets the used value(a `BasicValueEnum` or `BasicBlock`) of this use.
+    /// Gets the used value (a `BasicValueEnum` or `BasicBlock`) of this use.
     ///
     /// ```no_run
     /// use inkwell::AddressSpace;

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -18,7 +18,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         BasicValueUse(use_, PhantomData)
     }
 
-    /// Gets the next use of a `BasicValue` if any.
+    /// Gets the next use of an `InstructionValue` or `BasicValue` if any.
     ///
     /// The following example,
     ///

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -1,4 +1,4 @@
-use llvm_sys::core::{LLVMTypeOf, LLVMGetTypeKind};
+use llvm_sys::core::{LLVMIsAInstruction, LLVMTypeOf, LLVMGetTypeKind};
 use llvm_sys::LLVMTypeKind;
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -71,7 +71,12 @@ impl<'ctx> AnyValueEnum<'ctx> {
             LLVMTypeKind::LLVMArrayTypeKind => AnyValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyValueEnum::VectorValue(VectorValue::new(value)),
             LLVMTypeKind::LLVMFunctionTypeKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),
-            LLVMTypeKind::LLVMVoidTypeKind => panic!("Void values shouldn't exist."),
+            LLVMTypeKind::LLVMVoidTypeKind => {
+                if unsafe { LLVMIsAInstruction(value) }.is_null() {
+                    panic!("Void value isn't an instruction.");
+                }
+                AnyValueEnum::InstructionValue(InstructionValue::new(value))
+            },
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Metadata values are not supported as AnyValue's."),
             _ => panic!("The given type is not supported.")
         }
@@ -157,7 +162,77 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
-    // TODO: into_x_value methods
+    pub fn into_array_value(self) -> ArrayValue<'ctx> {
+        if let AnyValueEnum::ArrayValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_int_value(self) -> IntValue<'ctx> {
+        if let AnyValueEnum::IntValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_float_value(self) -> FloatValue<'ctx> {
+        if let AnyValueEnum::FloatValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_phi_value(self) -> PhiValue<'ctx> {
+        if let AnyValueEnum::PhiValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_function_value(self) -> FunctionValue<'ctx> {
+        if let AnyValueEnum::FunctionValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_pointer_value(self) -> PointerValue<'ctx> {
+        if let AnyValueEnum::PointerValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_struct_value(self) -> StructValue<'ctx> {
+        if let AnyValueEnum::StructValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_vector_value(self) -> VectorValue<'ctx> {
+        if let AnyValueEnum::VectorValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
+
+    pub fn into_instruction_value(self) -> InstructionValue<'ctx> {
+        if let AnyValueEnum::InstructionValue(v) = self {
+            v
+        } else {
+            panic!("Found {:?} but expected a different variant", self)
+        }
+    }
 }
 
 impl<'ctx> BasicValueEnum<'ctx> {

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -109,8 +109,8 @@ fn test_operands() {
     assert!(store_operand_use1.get_next_use().is_none());
     assert_eq!(store_operand_use1, arg1_second_use);
 
-    assert_eq!(store_operand_use0.get_user(), store_instruction);
-    assert_eq!(store_operand_use1.get_user(), store_instruction);
+    assert_eq!(store_operand_use0.get_user().into_instruction_value(), store_instruction);
+    assert_eq!(store_operand_use1.get_user().into_instruction_value(), store_instruction);
     assert_eq!(store_operand_use0.get_used_value().left().unwrap(), f32_val);
     assert_eq!(store_operand_use1.get_used_value().left().unwrap(), arg1);
 
@@ -185,7 +185,7 @@ fn test_get_next_use() {
     let first_use = f32_val.get_first_use().unwrap();
 
     assert_eq!(first_use.get_user(), add_pi1.as_instruction_value().unwrap());
-    assert_eq!(first_use.get_next_use().map(|x| x.get_user()), add_pi0.as_instruction_value());
+    assert_eq!(first_use.get_next_use().map(|x| x.get_user().into_float_value()), Some(add_pi0));
     assert!(arg1.get_first_use().is_some());
     assert!(module.verify().is_ok());
 }


### PR DESCRIPTION
## Description

Change BasicValueUse::get_user to return an AnyValueEnum.

To make the tests pass, we need to improve AnyValueEnum too. When construction an AnyValueEnum with a void Value, choose the InstructionValue enum, for example a StoreInst. Implement the into_X_value() methods so that we can use the contained value.

## Related Issue

#162 

## How This Has Been Tested

`cargo test --features=llvm8-0`

## Option\<Breaking Changes\>

The return type of the function changed, callers may have to adjust.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
