### PR TITLE
Check for RAUW'ing a value with itself. That's just a no-op.

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -477,8 +477,12 @@ impl<'ctx> BasicBlock<'ctx> {
     pub fn replace_all_uses_with(&self, other: &BasicBlock<'ctx>) {
         let value = unsafe { LLVMBasicBlockAsValue(self.basic_block) };
         let other = unsafe { LLVMBasicBlockAsValue(other.basic_block) };
-        unsafe {
-            LLVMReplaceAllUsesWith(value, other);
+
+        // LLVM may infinite-loop when they aren't distinct, which is UB in C++.
+        if value != other {
+            unsafe {
+                LLVMReplaceAllUsesWith(value, other);
+            }
         }
     }
 }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -173,8 +173,11 @@ impl<'ctx> Value<'ctx> {
     // REVIEW: I think this is memory safe, though it may result in an IR error
     // if used incorrectly, which is OK.
     fn replace_all_uses_with(&self, other: LLVMValueRef) {
-        unsafe {
-            LLVMReplaceAllUsesWith(self.value, other)
+        // LLVM may infinite-loop when they aren't distinct, which is UB in C++.
+        if self.value != other {
+            unsafe {
+                LLVMReplaceAllUsesWith(self.value, other)
+            }
         }
     }
 

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -178,6 +178,7 @@ fn test_rauw() {
     builder.position_at_end(entry);
     let branch_inst = builder.build_unconditional_branch(bb1);
 
+    bb1.replace_all_uses_with(&bb1);  // no-op
     bb1.replace_all_uses_with(&bb2);
 
     assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);


### PR DESCRIPTION
## Description

Replacing a value with itself is a no-op, but LLVM can enter an infinite loop. Infinite loops are UB in C++, let's just not do that.

## Related Issue

Ran into this after fixing #160, doh.

## How This Has Been Tested

`cargo test --features=llvm8-0`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
