### PR TITLE
Yup, calling LLVMIsTailCall on a non-CallInst is UB.

### DIFF
--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -183,6 +183,7 @@ impl<'ctx> InstructionValue<'ctx> {
     }
 
     pub fn is_tail_call(&self) -> bool {
+        // LLVMIsTailCall has UB if the value is not an llvm::CallInst*.
         if self.get_opcode() == InstructionOpcode::Call {
             unsafe {
                 LLVMIsTailCall(self.as_value_ref()) == 1

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -182,11 +182,13 @@ impl<'ctx> InstructionValue<'ctx> {
         BasicBlock::new(value)
     }
 
-    // REVIEW: See if necessary to check opcode == Call first.
-    // Does it always return false otherwise?
     pub fn is_tail_call(&self) -> bool {
-        unsafe {
-            LLVMIsTailCall(self.as_value_ref()) == 1
+        if self.get_opcode() == InstructionOpcode::Call {
+            unsafe {
+                LLVMIsTailCall(self.as_value_ref()) == 1
+            }
+        } else {
+            false
         }
     }
 


### PR DESCRIPTION
Noticed by inspection.