### PR TITLE
Add BasicBlock::get_first_use().

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,12 +1,12 @@
 //! A `BasicBlock` is a container of instructions.
 
-use llvm_sys::core::{LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator, LLVMGetNextBasicBlock, LLVMIsABasicBlock, LLVMIsConstant, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDeleteBasicBlock, LLVMGetPreviousBasicBlock, LLVMRemoveBasicBlockFromParent, LLVMGetFirstInstruction, LLVMGetLastInstruction, LLVMGetTypeContext, LLVMBasicBlockAsValue, LLVMReplaceAllUsesWith};
+use llvm_sys::core::{LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator, LLVMGetNextBasicBlock, LLVMIsABasicBlock, LLVMIsConstant, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDeleteBasicBlock, LLVMGetPreviousBasicBlock, LLVMRemoveBasicBlockFromParent, LLVMGetFirstInstruction, LLVMGetLastInstruction, LLVMGetTypeContext, LLVMBasicBlockAsValue, LLVMReplaceAllUsesWith, LLVMGetFirstUse};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMGetBasicBlockName;
 use llvm_sys::prelude::{LLVMValueRef, LLVMBasicBlockRef};
 
 use crate::context::ContextRef;
-use crate::values::{FunctionValue, InstructionValue};
+use crate::values::{BasicValueUse, FunctionValue, InstructionValue};
 
 use std::fmt;
 use std::ffi::CStr;
@@ -484,6 +484,42 @@ impl<'ctx> BasicBlock<'ctx> {
                 LLVMReplaceAllUsesWith(value, other);
             }
         }
+    }
+
+    /// Gets the first use of this `BasicBlock` if any.
+    ///
+    /// The following example,
+    ///
+    /// ```no_run
+    /// use inkwell::AddressSpace;
+    /// use inkwell::context::Context;
+    /// use inkwell::values::BasicValue;
+    ///
+    /// let context = Context::create();
+    /// let module = context.create_module("ivs");
+    /// let builder = context.create_builder();
+    /// let void_type = context.void_type();
+    /// let fn_type = void_type.fn_type(&[], false);
+    /// let fn_val = module.add_function("my_fn", fn_type, None);
+    /// let entry = context.append_basic_block(fn_val, "entry");
+    /// let bb1 = context.append_basic_block(fn_val, "bb1");
+    /// let bb2 = context.append_basic_block(fn_val, "bb2");
+    /// builder.position_at_end(entry);
+    /// let branch_inst = builder.build_unconditional_branch(bb1);
+    ///
+    /// assert!(bb2.get_first_use().is_none());
+    /// assert!(bb1.get_first_use().is_some());
+    /// ```
+    pub fn get_first_use(&self) -> Option<BasicValueUse> {
+        let use_ = unsafe {
+            LLVMGetFirstUse(LLVMBasicBlockAsValue(self.basic_block))
+        };
+
+        if use_.is_null() {
+            return None;
+        }
+
+        Some(BasicValueUse::new(use_))
     }
 }
 

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -18,7 +18,7 @@ impl<'ctx> BasicValueUse<'ctx> {
         BasicValueUse(use_, PhantomData)
     }
 
-    /// Gets the next use of an `InstructionValue` or `BasicValue` if any.
+    /// Gets the next use of a `BasicBlock`, `InstructionValue` or `BasicValue` if any.
     ///
     /// The following example,
     ///

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -183,3 +183,23 @@ fn test_rauw() {
 
     assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);
 }
+
+#[test]
+fn test_get_first_use() {
+    let context = Context::create();
+    let module = context.create_module("ivs");
+    let builder = context.create_builder();
+    let void_type = context.void_type();
+    let fn_type = void_type.fn_type(&[], false);
+    let fn_val = module.add_function("my_fn", fn_type, None);
+    let entry = context.append_basic_block(fn_val, "entry");
+    let bb1 = context.append_basic_block(fn_val, "bb1");
+    let bb2 = context.append_basic_block(fn_val, "bb2");
+    builder.position_at_end(entry);
+    let branch_inst = builder.build_unconditional_branch(bb1);
+
+    assert!(bb2.get_first_use().is_none());
+    assert!(bb1.get_first_use().is_some());
+    assert_eq!(bb1.get_first_use().unwrap().get_user(), branch_inst);
+    assert!(bb1.get_first_use().unwrap().get_next_use().is_none());
+}


### PR DESCRIPTION
## Description

Makes it possible to get a `BasicValueUse` for a `BasicBlock`.

## Related Issue

#161 

## How This Has Been Tested

`cargo test --features=llvm10-0`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
