### PR TITLE
Don't increment the iterator while a Section/Relocation/Symbol is using it.

### DIFF
--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -12,6 +12,7 @@ mod test_context;
 mod test_execution_engine;
 mod test_instruction_values;
 mod test_module;
+mod test_object_file;
 mod test_passes;
 mod test_targets;
 mod test_tari_example;

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -1,0 +1,76 @@
+extern crate inkwell;
+
+use self::inkwell::context::Context;
+use self::inkwell::module::Module;
+use self::inkwell::targets::{
+    ByteOrdering, CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetData,
+    TargetMachine, TargetTriple,
+};
+use self::inkwell::OptimizationLevel;
+
+#[test]
+fn test_section_iterator() {
+    Target::initialize_native(&InitializationConfig::default())
+        .expect("Failed to initialize native target");
+    let target_triple = TargetMachine::get_default_triple();
+    let target = Target::from_triple(&target_triple).unwrap();
+    let target_machine = target
+        .create_target_machine(
+            &target_triple,
+            &TargetMachine::get_host_cpu_name().to_string(),
+            &TargetMachine::get_host_cpu_features().to_string(),
+            OptimizationLevel::None,
+            RelocMode::Static,
+            CodeModel::Small,
+        )
+        .unwrap();
+
+    let context = Context::create();
+    let mut module = context.create_module("my_module");
+    module.set_inline_assembly(
+        ".section A\n\
+        .byte 1\n\
+        .section B\n\
+        .byte 2, 2\n\
+        .section C\n\
+        .byte 3, 3, 3",
+    );
+    module.set_triple(&target_triple);
+    module.set_data_layout(&target_machine.get_target_data().get_data_layout());
+
+    let memory_buffer = target_machine
+        .write_to_memory_buffer(&mut module, FileType::Object)
+        .unwrap();
+    let object_file = memory_buffer.create_object_file().unwrap();
+
+    let mut has_section_a = false;
+    let mut has_section_b = false;
+    let mut has_section_c = false;
+    for (i, section) in object_file.get_sections().enumerate() {
+        // TODO: the first section has no name, skip it.
+        if i == 0 {
+            continue;
+        }
+        match section.get_name().to_str().unwrap() {
+            "A" => {
+                assert!(!has_section_a);
+                has_section_a = true;
+                assert_eq!(section.size(), 1);
+            }
+            "B" => {
+                assert!(!has_section_b);
+                has_section_b = true;
+                assert_eq!(section.size(), 2);
+            }
+            "C" => {
+                assert!(!has_section_c);
+                has_section_c = true;
+                assert_eq!(section.size(), 3);
+            }
+            _ => {}
+        }
+    }
+    assert!(has_section_a);
+    assert!(has_section_b);
+    assert!(has_section_c);
+}

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -33,11 +33,11 @@ fn apply_target_to_module<'ctx>(target_machine: &TargetMachine, module: &Module)
 
 #[llvm_versions(3.6..4.0)]
 fn get_host_cpu_name() -> String {
-    ""
+    "".to_string()
 }
 #[llvm_versions(3.6..4.0)]
 fn get_host_cpu_features() -> String {
-    ""
+    "".to_string()
 }
 #[llvm_versions(3.6..4.0)]
 fn ptr_sized_int_type<'ctx>(

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -1,10 +1,8 @@
 extern crate inkwell;
 
 use self::inkwell::context::Context;
-use self::inkwell::module::Module;
 use self::inkwell::targets::{
-    ByteOrdering, CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetData,
-    TargetMachine, TargetTriple,
+    CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine,
 };
 use self::inkwell::values::BasicValue;
 use self::inkwell::OptimizationLevel;
@@ -56,28 +54,26 @@ fn test_section_iterator() {
     let mut has_section_a = false;
     let mut has_section_b = false;
     let mut has_section_c = false;
-    for (i, section) in object_file.get_sections().enumerate() {
-        // TODO: the first section has no name, skip it.
-        if i == 0 {
-            continue;
-        }
-        match section.get_name().to_str().unwrap() {
-            "A" => {
-                assert!(!has_section_a);
-                has_section_a = true;
-                assert_eq!(section.size(), 1);
+    for section in object_file.get_sections() {
+        if let Some(name) = section.get_name() {
+            match name.to_str().unwrap() {
+                "A" => {
+                    assert!(!has_section_a);
+                    has_section_a = true;
+                    assert_eq!(section.size(), 1);
+                }
+                "B" => {
+                    assert!(!has_section_b);
+                    has_section_b = true;
+                    assert_eq!(section.size(), 2);
+                }
+                "C" => {
+                    assert!(!has_section_c);
+                    has_section_c = true;
+                    assert_eq!(section.size(), 4);
+                }
+                _ => {}
             }
-            "B" => {
-                assert!(!has_section_b);
-                has_section_b = true;
-                assert_eq!(section.size(), 2);
-            }
-            "C" => {
-                assert!(!has_section_c);
-                has_section_c = true;
-                assert_eq!(section.size(), 4);
-            }
-            _ => {}
         }
     }
     assert!(has_section_a);
@@ -112,23 +108,25 @@ fn test_symbol_iterator() {
     let mut has_symbol_b = false;
     let mut has_symbol_c = false;
     for symbol in object_file.get_symbols() {
-        match symbol.get_name().to_str().unwrap() {
-            "a" => {
-                assert!(!has_symbol_a);
-                has_symbol_a = true;
-                assert_eq!(symbol.size(), 1);
+        if let Some(name) = symbol.get_name() {
+            match name.to_str().unwrap() {
+                "a" => {
+                    assert!(!has_symbol_a);
+                    has_symbol_a = true;
+                    assert_eq!(symbol.size(), 1);
+                }
+                "b" => {
+                    assert!(!has_symbol_b);
+                    has_symbol_b = true;
+                    assert_eq!(symbol.size(), 2);
+                }
+                "c" => {
+                    assert!(!has_symbol_c);
+                    has_symbol_c = true;
+                    assert_eq!(symbol.size(), 4);
+                }
+                _ => {}
             }
-            "b" => {
-                assert!(!has_symbol_b);
-                has_symbol_b = true;
-                assert_eq!(symbol.size(), 2);
-            }
-            "c" => {
-                assert!(!has_symbol_c);
-                has_symbol_c = true;
-                assert_eq!(symbol.size(), 4);
-            }
-            _ => {}
         }
     }
     assert!(has_symbol_a);

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -9,11 +9,11 @@ use self::inkwell::types::IntType;
 use self::inkwell::values::BasicValue;
 use self::inkwell::OptimizationLevel;
 
-#[llvm_versions(4.0..=latest)]
+#[llvm_versions(7.0..=latest)]
 fn get_host_cpu_name() -> String {
     TargetMachine::get_host_cpu_name().to_string()
 }
-#[llvm_versions(4.0..=latest)]
+#[llvm_versions(7.0..=latest)]
 fn get_host_cpu_features() -> String {
     TargetMachine::get_host_cpu_features().to_string()
 }
@@ -31,11 +31,11 @@ fn apply_target_to_module<'ctx>(target_machine: &TargetMachine, module: &Module)
     module.set_data_layout(&target_machine.get_target_data().get_data_layout());
 }
 
-#[llvm_versions(3.6..4.0)]
+#[llvm_versions(3.6..7.0)]
 fn get_host_cpu_name() -> String {
     "".to_string()
 }
-#[llvm_versions(3.6..4.0)]
+#[llvm_versions(3.6..7.0)]
 fn get_host_cpu_features() -> String {
     "".to_string()
 }

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -31,7 +31,7 @@ fn test_section_iterator() {
     let target_machine = get_native_target_machine();
 
     let context = Context::create();
-    let mut module = context.create_module("my_module");
+    let mut module = context.create_module("test_section_iterator");
 
     let gv_a = module.add_global(context.i8_type(), None, "a");
     gv_a.set_initializer(&context.i8_type().const_zero().as_basic_value_enum());
@@ -90,7 +90,7 @@ fn test_symbol_iterator() {
     let target_machine = get_native_target_machine();
 
     let context = Context::create();
-    let mut module = context.create_module("my_module");
+    let mut module = context.create_module("test_symbol_iterator");
     module
         .add_global(context.i8_type(), None, "a")
         .set_initializer(&context.i8_type().const_zero().as_basic_value_enum());
@@ -141,15 +141,18 @@ fn test_reloc_iterator() {
     let target_machine = get_native_target_machine();
 
     let context = Context::create();
-    let mut module = context.create_module("my_module");
+    let target_data = target_machine.get_target_data();
+    let intptr_t = target_data.ptr_sized_int_type_in_context(&context, None);
+
+    let mut module = context.create_module("test_reloc_iterator");
     let x_ptr = module
         .add_global(context.i8_type(), None, "x")
         .as_pointer_value();
     let x_plus_4 = x_ptr
-        .const_to_int(context.i64_type())
-        .const_add(context.i64_type().const_int(4, false));
+        .const_to_int(intptr_t)
+        .const_add(intptr_t.const_int(4, false));
     module
-        .add_global(context.i64_type(), None, "a")
+        .add_global(intptr_t, None, "a")
         .set_initializer(&x_plus_4);
 
     module.set_triple(&target_machine.get_triple());
@@ -162,7 +165,7 @@ fn test_reloc_iterator() {
 
     let mut found_relocation = false;
     for section in object_file.get_sections() {
-        for reloc in section.get_relocations() {
+        for _ in section.get_relocations() {
             found_relocation = true;
             // We don't stop the traversal here, so as to exercise the iterators.
         }


### PR DESCRIPTION
## Description

Don't increment the iterator while a Section/Relocation/Symbol is using it.

## Related Issue

#172 

## How This Has Been Tested

There aren't unit tests for object_file yet. I think that in order to add some, we will need some binary test files in the inkwell tree. Thoughts?

As for for I tested it, the simple test driver program is:

```rust
use inkwell::memory_buffer::MemoryBuffer;
use std::path::Path;

fn main() {
    let mb = MemoryBuffer::create_from_file(Path::new("test.o")).unwrap();
    let obj = mb.create_object_file().unwrap();
    let mut first = true;
    for section in obj.get_sections() {
        dbg!("<section>");
        if !first {
            dbg!(section.get_name());
        } else {
            first = false;
        }
        dbg!(section.size());
        dbg!(section.get_address());
        for rel in section.get_relocations() {
            dbg!(rel.get_offset());
            /*
            for symbol in rel.get_symbols() {
                dbg!("<relocation symbol>");
                dbg!(symbol.get_name());
                dbg!(symbol.size());
                dbg!(symbol.get_address());
            }
            */
            dbg!(rel.get_type());
            dbg!(rel.get_value());
        }
    }
    for symbol in obj.get_symbols() {
        dbg!("<symbol>");
        //dbg!(symbol.get_name());
        dbg!(symbol.size());
        dbg!(symbol.get_address());
    }
}
```

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
