### PR TITLE
Make symbol and section names optional, for when llvm returns a nullptr.

### DIFF
--- a/src/object_file.rs
+++ b/src/object_file.rs
@@ -108,9 +108,14 @@ impl Section {
         }
     }
 
-    pub fn get_name(&self) -> &CStr {
-        unsafe {
-            CStr::from_ptr(LLVMGetSectionName(self.section))
+    pub fn get_name(&self) -> Option<&CStr> {
+        let name = unsafe {
+            LLVMGetSectionName(self.section)
+        }
+        if !name.is_null() {
+            CStr::from_ptr(name)
+        } else {
+            None
         }
     }
 
@@ -302,9 +307,14 @@ impl Symbol {
         }
     }
 
-    pub fn get_name(&self) -> &CStr {
-        unsafe {
-            CStr::from_ptr(LLVMGetSymbolName(self.symbol))
+    pub fn get_name(&self) -> Option<&CStr> {
+        let name = unsafe {
+            LLVMGetSymbolName(self.symbol)
+        }
+        if !name.is_null() {
+            CStr::from_ptr(name)
+        } else {
+            None
         }
     }
 

--- a/src/object_file.rs
+++ b/src/object_file.rs
@@ -111,9 +111,9 @@ impl Section {
     pub fn get_name(&self) -> Option<&CStr> {
         let name = unsafe {
             LLVMGetSectionName(self.section)
-        }
+        };
         if !name.is_null() {
-            CStr::from_ptr(name)
+            Some(unsafe { CStr::from_ptr(name) })
         } else {
             None
         }
@@ -310,9 +310,9 @@ impl Symbol {
     pub fn get_name(&self) -> Option<&CStr> {
         let name = unsafe {
             LLVMGetSymbolName(self.symbol)
-        }
+        };
         if !name.is_null() {
-            CStr::from_ptr(name)
+            Some(unsafe { CStr::from_ptr(name) })
         } else {
             None
         }


### PR DESCRIPTION
##  Description

The first section usually has no name, and LLVM returns a nullptr. Inkwell will dereference that to return the `&CStr`. The same thing should be able to happen with a `Symbol` but I haven't observed that myself. When LLVM returns a nullptr string as the name, return None.

## Related Issue

#173 

## How This Has Been Tested

Tried dumping names of all symbols and sections on a few object files.

## Option\<Breaking Changes\>

`get_name` now returns an Option instead of a `&CStr`.

It might be possible to return an empty string &CStr, but I tried and failed.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
