### PR TITLE
Make `target_data.ptr_sized_int_type_in_context` return an IntType with lifetime from the context.

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1316,11 +1316,11 @@ impl TargetData {
     /// let target_data = execution_engine.get_target_data();
     /// let int_type = target_data.ptr_sized_int_type_in_context(&context, None);
     /// ```
-    pub fn ptr_sized_int_type_in_context(
+    pub fn ptr_sized_int_type_in_context<'ctx>(
         &self,
-        context: &Context,
+        context: &'ctx Context,
         address_space: Option<AddressSpace>,
-    ) -> IntType {
+    ) -> IntType<'ctx> {
         let int_type_ptr = match address_space {
             Some(address_space) => unsafe {
                 LLVMIntPtrTypeForASInContext(


### PR DESCRIPTION
## Description

In the current API, Rust requires that the `IntType` returned by `ptr_sized_int_type_in_context` not outlive the `TargetData`, but in reality it's owned by the `Context` and goes away with the `Context` independent of the `TargetData`.

## Related Issue

n/a. (This fix was required to write tests in #174.)

## How This Has Been Tested

`cargo test --features=llvm8-0`

## Option\<Breaking Changes\>

This might be breaking? I think it's strictly more permissive, but I'm not certain.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
