### PR TITLE
Section contents are arbitrary byte sequences, return a &[u8] for them instead of a CStr.

### DIFF
--- a/src/object_file.rs
+++ b/src/object_file.rs
@@ -130,9 +130,11 @@ impl Section {
         }
     }
 
-    pub fn get_contents(&self) -> &CStr {
+    pub fn get_contents(&self) -> &[u8] {
         unsafe {
-            CStr::from_ptr(LLVMGetSectionContents(self.section))
+            std::slice::from_raw_parts(
+                LLVMGetSectionContents(self.section) as *const u8,
+                self.size() as usize)
         }
     }
 


### PR DESCRIPTION
The trouble with a CStr is that it ends at the first NUL byte. This can lead to section contents appearing to be shorter than the reported size of the section.

## Description

Section::get_contents() is changed to return a &[u8] instead of a CStr and a test is added.

## Related Issue

n/a

## How This Has Been Tested

cargo test --features=llvm8-0

## Option\<Breaking Changes\>

Yes, a change in type. It appears that CStr follows the C string semantics of ending at the first NUL byte. Object file sections may contain arbitrary data including NUL bytes. Some change of type is unavoidable.

LLVM doesn't document the lifetime of the returned pointer, but my inspection of the ELFObjectFile implementation shows that it's returning a pointer into their buffer of the whole object file, so it outlives the section iterator and lives as long as the object file object. Hopefully `&[u8]` is fine for that.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
