### PR TITLE
Add feature to disable linking to libffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ llvm7-0-no-llvm-linking = ["llvm7-0", "llvm-sys-70/no-llvm-linking"]
 llvm8-0-no-llvm-linking = ["llvm8-0", "llvm-sys-80/no-llvm-linking"]
 llvm9-0-no-llvm-linking = ["llvm9-0", "llvm-sys-90/no-llvm-linking"]
 llvm10-0-no-llvm-linking = ["llvm10-0", "llvm-sys-100/no-llvm-linking"]
+# Don't force linking to libffi on non-windows platforms. Without this feature
+# inkwell always links to libffi on non-windows platforms.
+no-libffi-linking = []
 target-x86 = []
 target-arm = []
 target-mips = []

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    if cfg!(not(target_os = "windows")) {
+    if cfg!(all(not(target_os = "windows"), not(feature = "no-libffi-linking"))) {
         println!("cargo:rustc-link-lib=dylib=ffi");
     }
 }


### PR DESCRIPTION
## Description

Adds a feature `no-libffi-linking` (not enabled by default) that stops linking to libffi by default. 

## Related Issue

https://github.com/TheDan64/inkwell/issues/206

## How This Has Been Tested

Building with the feature enabled no longer forces any dependency on libffi which is what I wanted to achieve. 

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
