### PR TITLE
Add debug checks to const gep argument bit sizes to resolve #213

### DIFF
--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -68,7 +68,17 @@ impl<'ctx> PointerValue<'ctx> {
 
     // REVIEW: Should this be on array value too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
+    /// GEP indexes must be 32 bit integer values. Constant folding may result in other sizes working.
     pub unsafe fn const_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
+        if cfg!(debug_assertions) {
+            for (index, value) in ordered_indexes.iter().enumerate() {
+                let bit_width = value.get_type().get_bit_width();
+                if bit_width != 32 {
+                    panic!("Index #{} in ordered_indexes argument to const_gep call was a {} bit integer instead of 32 bit integer - gep indexes must be i32 values", index, bit_width);
+                }
+            }
+        }
+
         let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
                                                                  .map(|val| val.as_value_ref())
                                                                  .collect();
@@ -80,7 +90,17 @@ impl<'ctx> PointerValue<'ctx> {
     }
 
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
+    /// GEP indexes must be 32 bit integer values. Constant folding may result in other sizes working.
     pub unsafe fn const_in_bounds_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
+        if cfg!(debug_assertions) {
+            for (index, value) in ordered_indexes.iter().enumerate() {
+                let bit_width = value.get_type().get_bit_width();
+                if bit_width != 32 {
+                    panic!("Index #{} in ordered_indexes argument to const_in_bounds_gep call was a {} bit integer instead of 32 bit integer - gep indexes must be i32 values", index, bit_width);
+                }
+            }
+        }
+
         let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
                                                                  .map(|val| val.as_value_ref())
                                                                  .collect();

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1203,3 +1203,30 @@ fn test_constant_expression() {
     assert!(expr.is_const());
     assert!(!expr.is_constant_int());
 }
+
+#[test]
+#[should_panic]
+fn test_const_gep_i64() {
+    let context = Context::create();
+
+    let i64_type = context.i64_type();
+    let i64_ptr_type = i64_type.ptr_type(AddressSpace::Generic);
+    let i64_ptr_null = i64_ptr_type.const_zero();
+    unsafe {
+        // i64 indexes are not permitted - should panic.
+        i64_ptr_null.const_gep(&[i64_type.const_zero()]);
+    }
+}
+
+#[test]
+fn test_const_gep_i32() {
+    let context = Context::create();
+
+    let i32_type = context.i32_type();
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    let i32_ptr_null = i32_ptr_type.const_zero();
+    unsafe {
+        // i32 indexes are permitted.
+        i32_ptr_null.const_gep(&[i32_type.const_zero()]);
+    }
+}


### PR DESCRIPTION
## Description

Add debug checks to const gep argument bit sizes.

## Related Issue

#213 

## How This Has Been Tested

Tested by running tests in a dependent project, which exercised passing i64 and i32 values. Tests are similar to those in #213.
Also added tests, but was unable to build the tests locally as Windows is not current supported in the tests. A trivial attempt to add Windows support failed. I copied the added tests to a dependent project and validated that they pass. Was unable to run all tests.

## Option\<Breaking Changes\>

This would break code which passes integers with bit widths other than 32, and were getting lucky and working due to constant folding. I'd say that's getting lucky with UB.

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
