### PR TITLE
rewrite redundant expression

### DIFF
--- a/examples/kaleidoscope/main.rs
+++ b/examples/kaleidoscope/main.rs
@@ -92,7 +92,7 @@ pub struct Lexer<'a> {
 impl<'a> Lexer<'a> {
     /// Creates a new `Lexer`, given its source `input`.
     pub fn new(input: &'a str) -> Lexer<'a> {
-        Lexer { input: input, chars: Box::new(input.chars().peekable()), pos: 0 }
+        Lexer { input, chars: Box::new(input.chars().peekable()), pos: 0 }
     }
 
     /// Lexes and returns the next `Token` from the source code.


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description
``` Lexer { input: input, .... } ``` looks redundant. So I think ``` Lexer { input, .... } ``` is better expression.
<!--- Describe your changes in detail -->

## Related Issue
Nothing.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested
run command ```  cargo run --example kaleidoscope --features "llvm10-0" ``` and type "1 + 1" and  "exit".
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->
nothing.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
