### PR TITLE
Fix #220

### DIFF
--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -77,15 +77,15 @@ fn test_section_iterator() {
 
     let gv_a = module.add_global(context.i8_type(), None, "a");
     gv_a.set_initializer(&context.i8_type().const_zero().as_basic_value_enum());
-    gv_a.set_section("A");
+    gv_a.set_section(Some("A"));
 
     let gv_b = module.add_global(context.i16_type(), None, "b");
     gv_b.set_initializer(&context.i16_type().const_zero().as_basic_value_enum());
-    gv_b.set_section("B");
+    gv_b.set_section(Some("B"));
 
     let gv_c = module.add_global(context.i32_type(), None, "c");
     gv_c.set_initializer(&context.i32_type().const_zero().as_basic_value_enum());
-    gv_c.set_section("C");
+    gv_c.set_section(Some("C"));
 
     apply_target_to_module(&target_machine, &module);
 
@@ -225,7 +225,7 @@ fn test_section_contains_nul() {
             .const_int(0xff0000ff, false)
             .as_basic_value_enum(),
     );
-    gv.set_section("test");
+    gv.set_section(Some("test"));
 
     apply_target_to_module(&target_machine, &module);
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -729,9 +729,10 @@ fn test_globals() {
     assert!(!global.has_unnamed_addr());
     assert!(!global.is_externally_initialized());
     assert_eq!(global.get_name().to_str(), Ok("my_global"));
-    // REVIEW: Segfaults in 4.0 -> 11.0
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0")))]
+    #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9"))]
     assert_eq!(global.get_section().map(|cs| cs.to_str()), Some(Ok("")));
+    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9")))]
+    assert_eq!(global.get_section(), None);
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());
     assert_eq!(global.get_linkage(), External);
@@ -742,7 +743,6 @@ fn test_globals() {
     global.set_name("glob");
 
     assert_eq!(global.get_name().to_str(), Ok("glob"));
-    assert_eq!(global.get_section(), None);
     assert!(module.get_global("my_global").is_none());
     assert_eq!(module.get_global("glob").unwrap(), global);
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -731,7 +731,7 @@ fn test_globals() {
     assert_eq!(global.get_name().to_str(), Ok("my_global"));
     // REVIEW: Segfaults in 4.0 -> 7.0
     #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
-    assert_eq!(global.get_section().to_str(), Ok(""));
+    assert_eq!(global.get_section().map(|cs| cs.to_str()), Some(Ok("")));
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());
     assert_eq!(global.get_linkage(), External);
@@ -742,6 +742,7 @@ fn test_globals() {
     global.set_name("glob");
 
     assert_eq!(global.get_name().to_str(), Ok("glob"));
+    assert_eq!(global.get_section(), None);
     assert!(module.get_global("my_global").is_none());
     assert_eq!(module.get_global("glob").unwrap(), global);
 
@@ -754,7 +755,7 @@ fn test_globals() {
     global.set_unnamed_addr(true);
     global.set_constant(true);
     global.set_visibility(GlobalVisibility::Hidden);
-    global.set_section("not sure what goes here");
+    global.set_section(Some("not sure what goes here"));
 
     // REVIEW: Not sure why this is Global when we set it to Local
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
@@ -768,7 +769,11 @@ fn test_globals() {
     assert!(global.has_unnamed_addr());
     assert!(global.is_constant());
     assert!(!global.is_declaration());
-    assert_eq!(global.get_section().to_str(), Ok("not sure what goes here"));
+    assert_eq!(global.get_section().map(|cs| cs.to_str()), Some(Ok("not sure what goes here")));
+
+    global.set_section(None);
+
+    assert_eq!(global.get_section(), None);
 
     // Either linkage is non-local or visibility is default.
     global.set_visibility(GlobalVisibility::Default);

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -729,8 +729,7 @@ fn test_globals() {
     assert!(!global.has_unnamed_addr());
     assert!(!global.is_externally_initialized());
     assert_eq!(global.get_name().to_str(), Ok("my_global"));
-    #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9"))]
-    assert_eq!(global.get_section().map(|cs| cs.to_str()), Some(Ok("")));
+    // REVIEW: LLVM 3.6 - 3.9 just straight up segfault here. Maybe a bug?:
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9")))]
     assert_eq!(global.get_section(), None);
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());


### PR DESCRIPTION
Fixes issue #220.

## Description

Changed the `GlobalValue::get_section` and `GlobalValue::set_section` to deal with null pointers. Signatures have changed as follows:

`pub fn get_section(&self) -> &CStr` becomes `pub fn get_section(&self) -> Option<&CStr>`

`pub fn set_section(self, section: &str)` becomes `pub fn set_section(self, maybe_section: Option<&str>)`

Tests have been updated to reflect the changes in the API. New lines in `test_globals` have been added to test setting and getting `None`.

## Related Issue

#220

## How This Has Been Tested

Ran `cargo test --features llvm10-0`

## Option\<Breaking Changes\>

API for accessing sections on globals has changed. This is unavoidable as the original API was broken.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
