### PR TITLE
Add support for global variable expressions in debug info

### DIFF
--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -87,7 +87,7 @@
 //!
 //! let gv_debug = di.create_global_variable_expression(cu.get_file().as_debug_info_scope(), "gv", "", cu.get_file(), 1, ditype.as_type(), true, Some(const_v), None, 8);
 //!
-//! let meta_value : inkwell::values::BasicMetadataValueEnum = gv_debug.as_metadata_value(&context).into();
+//! let meta_value: inkwell::values::BasicMetadataValueEnum = gv_debug.as_metadata_value(&context).into();
 //! let metadata = context.metadata_node(&[meta_value]);
 //! gv.set_metadata(metadata, 0);//dbg
 //! 
@@ -639,7 +639,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     }
 
     #[llvm_versions(8.0..=latest)]
-    pub fn create_constant_expression(&self,
+    pub fn create_constant_expression(
+        &self,
         value : i64,
     ) -> DIExpression<'ctx> {
         let metadata_ref = unsafe {
@@ -1108,7 +1109,7 @@ pub struct DIGlobalVariableExpression<'ctx> {
 }
 
 impl <'ctx> DIGlobalVariableExpression<'ctx>  {
-    pub fn as_metadata_value(&self, context : &Context) -> MetadataValue<'ctx> {
+    pub fn as_metadata_value(&self, context: &Context) -> MetadataValue<'ctx> {
         let value = unsafe {
             LLVMMetadataAsValue(context.context, self.metadata_ref)
         };

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -79,7 +79,7 @@
 //!     /* inlined_at */ None);
 //! builder.set_current_debug_location(&context, loc);
 //! 
-//! //Create global variable
+//! // Create global variable
 //! let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::Global), "gv");
 //!    
 //!
@@ -119,13 +119,14 @@ use llvm_sys::debuginfo::{
     LLVMDIBuilderCreateDebugLocation, LLVMDIBuilderCreateExpression, LLVMDIBuilderCreateFile,
     LLVMDIBuilderCreateFunction, LLVMDIBuilderCreateLexicalBlock, LLVMDIBuilderCreateMemberType,
     LLVMDIBuilderCreateNameSpace, LLVMDIBuilderCreateParameterVariable, 
-    LLVMDIBuilderCreateGlobalVariableExpression,LLVMDIBuilderCreateConstantValueExpression,
     LLVMDIBuilderCreateStructType, LLVMDIBuilderCreateSubroutineType, LLVMDIBuilderCreateUnionType,
     LLVMDIBuilderFinalize, LLVMDIBuilderInsertDbgValueBefore, LLVMDIBuilderInsertDeclareAtEnd,
     LLVMDIBuilderInsertDeclareBefore, LLVMDILocationGetColumn, LLVMDILocationGetLine,
     LLVMDILocationGetScope, LLVMDITypeGetAlignInBits, LLVMDITypeGetOffsetInBits,
     LLVMDITypeGetSizeInBits,
 };
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::debuginfo::{LLVMDIBuilderCreateGlobalVariableExpression,LLVMDIBuilderCreateConstantValueExpression};
 use llvm_sys::prelude::{LLVMDIBuilderRef, LLVMMetadataRef};
 use llvm_sys::core::LLVMMetadataAsValue;
 use std::convert::TryInto;
@@ -598,6 +599,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         }
     }
 
+    #[llvm_versions(8.0..=latest)]
     pub fn create_global_variable_expression(
         &self,
         scope: DIScope<'ctx>,
@@ -636,6 +638,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         }
     }
 
+    #[llvm_versions(8.0..=latest)]
     pub fn create_constant_expression(&self,
         value : i64,
     ) -> DIExpression<'ctx> {

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -78,6 +78,19 @@
 //!     /* current_scope */ lexical_block.as_debug_info_scope(),
 //!     /* inlined_at */ None);
 //! builder.set_current_debug_location(&context, loc);
+//! 
+//! //Create global variable
+//! let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::Global), "gv");
+//!    
+//!
+//! let const_v = di.create_constant_expression(10);
+//!
+//! let gv_debug = di.create_global_variable_expression(cu.get_file().as_debug_info_scope(), "gv", "", cu.get_file(), 1, ditype.as_type(), true, Some(const_v), None, 8);
+//!
+//! let meta_value : inkwell::values::BasicMetadataValueEnum = gv_debug.as_metadata_value(&context).into();
+//! let metadata = context.metadata_node(&[meta_value]);
+//! gv.set_metadata(metadata, 0);//dbg
+//! 
 //! ```
 //!
 //! ## Finalize debug info

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -9,6 +9,7 @@ use llvm_sys::core::{LLVMHasUnnamedAddr, LLVMSetUnnamedAddr};
 use llvm_sys::core::{LLVMGetUnnamedAddress, LLVMSetUnnamedAddress};
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMUnnamedAddr;
+#[llvm_versions(8.0..=latest)]
 use llvm_sys::core::LLVMGlobalSetMetadata;
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -20,7 +21,9 @@ use crate::support::{to_c_str, LLVMString};
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value, MetadataValue};
+use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value};
+#[llvm_versions(8.0..=latest)]
+use crate::values::MetadataValue;
 
 // REVIEW: GlobalValues are always PointerValues. With SubTypes, we should
 // compress this into a PointerValue<Global> type
@@ -267,6 +270,7 @@ impl<'ctx> GlobalValue<'ctx> {
     }
 
     /// Sets a metadata of the given type on the GlobalValue
+    #[llvm_versions(8.0..=latest)]
     pub fn set_metadata(self, metadata: MetadataValue<'ctx>, kind_id: u32) {
         unsafe {
             LLVMGlobalSetMetadata(self.as_value_ref(), kind_id, metadata.as_metadata_ref())

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -9,6 +9,7 @@ use llvm_sys::core::{LLVMHasUnnamedAddr, LLVMSetUnnamedAddr};
 use llvm_sys::core::{LLVMGetUnnamedAddress, LLVMSetUnnamedAddress};
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMUnnamedAddr;
+use llvm_sys::core::LLVMGlobalSetMetadata;
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
@@ -19,7 +20,7 @@ use crate::support::{to_c_str, LLVMString};
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value};
+use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value, MetadataValue};
 
 // REVIEW: GlobalValues are always PointerValues. With SubTypes, we should
 // compress this into a PointerValue<Global> type
@@ -262,6 +263,13 @@ impl<'ctx> GlobalValue<'ctx> {
     pub fn set_alignment(self, alignment: u32) {
         unsafe {
             LLVMSetAlignment(self.as_value_ref(), alignment)
+        }
+    }
+
+    /// Sets a metadata of the given type on the GlobalValue
+    pub fn set_metadata(self, metadata: MetadataValue<'ctx>, kind_id: u32) {
+        unsafe {
+            LLVMGlobalSetMetadata(self.as_value_ref(), kind_id, metadata.as_metadata_ref())
         }
     }
 

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -306,7 +306,6 @@ fn test_anonymous_basic_type() {
 #[llvm_versions(8.0..=latest)]
 #[test]
 fn test_global_expressions() {
-
     let context = Context::create();
     let module = context.create_module("bin");
 
@@ -326,7 +325,7 @@ fn test_global_expressions() {
         false,
     );
 
-    let di_type = dibuilder.create_basic_type("type_name",0_u64, 0x00, DIFlags::ZERO);
+    let di_type = dibuilder.create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO);
     let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::Global), "gv");
 
     let const_v = dibuilder.create_constant_expression(10);
@@ -337,15 +336,18 @@ fn test_global_expressions() {
         "", 
         compile_unit.get_file(), 
         1, 
-        di_type.unwrap().as_type()  , 
+        di_type.unwrap().as_type(),
         true,
-        Some(const_v), None, 8);
+        Some(const_v),
+        None,
+        8,
+    );
     
     let metadata = context.metadata_node(&[gv_debug.as_metadata_value(&context).into()]);
 
     gv.set_metadata(metadata, 0);
 
-    //TODO : Metadata set on the global values cannot be retrieved using the C api, 
+    // TODO: Metadata set on the global values cannot be retrieved using the C api, 
     // therefore, it's currently not possible to test that the data was set without generating the IR
     assert!(gv.print_to_string().to_string().contains("!dbg"), format!("expected !dbg but generated gv was {}",gv.print_to_string()));
 }

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -1,8 +1,9 @@
 use inkwell::context::Context;
 use inkwell::debug_info::{
     AsDIScope, DIFlags, DIFlagsConstants, DISubprogram, DWARFEmissionKind, DWARFSourceLanguage,
-    DebugInfoBuilder,
 };
+#[llvm_versions(8.0..=latest)]
+use inkwell::debug_info::DebugInfoBuilder;
 use inkwell::module::FlagBehavior;
 
 #[test]
@@ -302,6 +303,7 @@ fn test_anonymous_basic_type() {
     );
 }
 
+#[llvm_versions(8.0..=latest)]
 #[test]
 fn test_global_expressions() {
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Added support for global variable expressions in debug info, as well as Global variables metadata

This enables adding debug information to global variables so they can be recognized as variables in a debugger

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
[216](https://github.com/TheDan64/inkwell/issues/216)


## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

The C API does not allow retrieving metadata set on global variables (as opposed to instructions). 
The tests will generate an IR of the global variable and make sure the metadata is added to it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
