### PR TITLE
Add print_to_string() to Any{Value,Type}

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -939,6 +939,7 @@ impl Context {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
+    /// use inkwell::values::AnyValue;
     ///
     /// let context = Context::create();
     /// let string = context.const_string(b"my_string", false);

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -3,7 +3,6 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{Type, BasicTypeEnum, PointerType, FunctionType};
 use crate::values::{AsValueRef, ArrayValue, IntValue};
@@ -185,11 +184,6 @@ impl<'ctx> ArrayType<'ctx> {
         unsafe {
             LLVMGetArrayLength(self.as_type_ref())
         }
-    }
-
-    /// Prints the definition of a `ArrayType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.array_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -4,7 +4,6 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{Type, PointerType, FunctionType, BasicTypeEnum, ArrayType, VectorType};
 use crate::values::{AsValueRef, ArrayValue, FloatValue, GenericValue, IntValue};
@@ -102,6 +101,7 @@ impl<'ctx> FloatType<'ctx> {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
+    /// use inkwell::values::AnyValue;
     ///
     /// let context = Context::create();
     /// let f64_type = context.f64_type();
@@ -139,6 +139,7 @@ impl<'ctx> FloatType<'ctx> {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
+    /// use inkwell::values::AnyValue;
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
@@ -212,11 +213,6 @@ impl<'ctx> FloatType<'ctx> {
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {
         self.float_type.ptr_type(address_space)
-    }
-
-    /// Prints the definition of a `FloatType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.float_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -7,9 +7,8 @@ use std::mem::forget;
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{PointerType, Type, BasicTypeEnum};
+use crate::types::{AnyType, PointerType, Type, BasicTypeEnum};
 
 /// A `FunctionType` is the type of a function variable.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -153,11 +152,6 @@ impl<'ctx> FunctionType<'ctx> {
     /// ```
     pub fn get_context(self) -> ContextRef<'ctx> {
         self.fn_type.get_context()
-    }
-
-    /// Prints the definition of a `FunctionType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.fn_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -5,7 +5,6 @@ use regex::Regex;
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{Type, ArrayType, BasicTypeEnum, VectorType, PointerType, FunctionType};
 use crate::values::{AsValueRef, ArrayValue, GenericValue, IntValue};
@@ -100,6 +99,7 @@ impl<'ctx> IntType<'ctx> {
     ///
     /// use inkwell::context::Context;
     /// use inkwell::types::StringRadix;
+    /// use inkwell::values::AnyValue;
     ///
     /// let context = Context::create();
     /// let i8_type = context.i8_type();
@@ -171,6 +171,7 @@ impl<'ctx> IntType<'ctx> {
     ///
     /// ```no_run
     /// use inkwell::context::Context;
+    /// use inkwell::values::AnyValue;
     ///
     /// let context = Context::create();
     /// let i8_type = context.i8_type();
@@ -312,11 +313,6 @@ impl<'ctx> IntType<'ctx> {
         unsafe {
             LLVMGetIntTypeWidth(self.as_type_ref())
         }
-    }
-
-    /// Prints the definition of an `IntType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.int_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -3,7 +3,6 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{AnyTypeEnum, BasicTypeEnum, ArrayType, FunctionType, Type, VectorType};
 use crate::values::{AsValueRef, ArrayValue, PointerValue, IntValue};
@@ -154,11 +153,6 @@ impl<'ctx> PointerType<'ctx> {
         };
 
         AddressSpace::try_from(addr_space).expect("Unexpectedly found invalid AddressSpace value")
-    }
-
-    /// Prints the definition of a `PointerType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.ptr_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -8,7 +8,6 @@ use std::mem::forget;
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{ArrayType, BasicTypeEnum, PointerType, FunctionType, Type};
 use crate::values::{ArrayValue, BasicValueEnum, StructValue, IntValue, AsValueRef};
@@ -322,11 +321,6 @@ impl<'ctx> StructType<'ctx> {
         };
 
         raw_vec.iter().map(|val| BasicTypeEnum::new(*val)).collect()
-    }
-
-    /// Prints the definition of a `StructType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.struct_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -6,6 +6,7 @@ use crate::AddressSpace;
 use crate::types::{IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VectorType, VoidType, Type};
 use crate::types::enums::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::{IntMathValue, FloatMathValue, PointerMathValue, IntValue, FloatValue, PointerValue, VectorValue};
+use crate::support::LLVMString;
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -22,12 +23,16 @@ macro_rules! trait_type_set {
     );
 }
 
-// REVIEW: print_to_string might be a good candidate to live here?
 /// Represents any LLVM type.
 pub trait AnyType<'ctx>: AsTypeRef + Debug {
     /// Returns an `AnyTypeEnum` that represents the current type.
     fn as_any_type_enum(&self) -> AnyTypeEnum<'ctx> {
         AnyTypeEnum::new(self.as_type_ref())
+    }
+
+    /// Prints the definition of a Type to a `LLVMString`.
+    fn print_to_string(&self) -> LLVMString {
+        Type::new(self.as_type_ref()).print_to_string()
     }
 }
 

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -3,7 +3,6 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::{ArrayType, BasicTypeEnum, Type, traits::AsTypeRef, FunctionType, PointerType};
 use crate::values::{AsValueRef, ArrayValue, BasicValue, VectorValue, IntValue};
 
@@ -125,11 +124,6 @@ impl<'ctx> VectorType<'ctx> {
     /// ```
     pub fn const_zero(self) -> VectorValue<'ctx> {
         VectorValue::new(self.vec_type.const_zero())
-    }
-
-    /// Prints the definition of a `VectorType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.vec_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -1,7 +1,6 @@
 use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
-use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{Type, BasicTypeEnum, FunctionType};
 
@@ -69,11 +68,6 @@ impl<'ctx> VoidType<'ctx> {
     /// ```
     pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
         self.void_type.fn_type(param_types, is_var_args)
-    }
-
-    /// Prints the definition of a `VoidType` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.void_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -4,9 +4,8 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt;
 
-use crate::support::LLVMString;
 use crate::types::ArrayType;
-use crate::values::traits::AsValueRef;
+use crate::values::traits::{AnyValue, AsValueRef};
 use crate::values::{Value, InstructionValue};
 
 /// An `ArrayValue` is a block of contiguous constants or variables.
@@ -43,11 +42,6 @@ impl<'ctx> ArrayValue<'ctx> {
     /// Determines whether or not this value is undefined.
     pub fn is_undef(self) -> bool {
         self.array_value.is_undef()
-    }
-
-    /// Prints this `ArrayValue` to a string.
-    pub fn print_to_string(self) -> LLVMString {
-        self.array_value.print_to_string()
     }
 
     /// Prints this `ArrayValue` to standard error.

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -4,7 +4,6 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 
 use crate::FloatPredicate;
-use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value};
@@ -39,10 +38,6 @@ impl<'ctx> FloatValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.float_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.float_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -19,9 +19,9 @@ use crate::basic_block::BasicBlock;
 #[llvm_versions(7.0..=latest)]
 use crate::debug_info::DISubprogram;
 use crate::module::Linkage;
-use crate::support::{to_c_str, LLVMString};
-use crate::types::{FunctionType, PointerType};
-use crate::values::traits::AsValueRef;
+use crate::support::to_c_str;
+use crate::types::{AnyType, FunctionType, PointerType};
+use crate::values::traits::{AnyValue, AsValueRef};
 use crate::values::{BasicValueEnum, GlobalValue, Value};
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
@@ -60,10 +60,6 @@ impl<'ctx> FunctionValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.fn_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.fn_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -6,7 +6,6 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 
 use crate::IntPredicate;
-use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, PointerType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value};
@@ -41,10 +40,6 @@ impl<'ctx> IntValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.int_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.int_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -4,7 +4,6 @@ use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
 use std::ffi::CStr;
 
 use crate::basic_block::BasicBlock;
-use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, InstructionValue, Value};
 
@@ -75,14 +74,6 @@ impl<'ctx> PhiValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.phi_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.phi_value.print_to_string()
-    }
-
-    pub fn print_to_stderr(self) {
-        self.phi_value.print_to_stderr()
     }
 
     // SubType: -> InstructionValue<Phi>

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -3,7 +3,6 @@ use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
 
-use crate::support::LLVMString;
 use crate::types::{AsTypeRef, IntType, PointerType};
 use crate::values::{AsValueRef, InstructionValue, IntValue, Value};
 
@@ -52,10 +51,6 @@ impl<'ctx> PointerValue<'ctx> {
     /// ```
     pub fn is_const(self) -> bool {
         self.ptr_value.is_const()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.ptr_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -2,7 +2,6 @@ use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
 
-use crate::support::LLVMString;
 use crate::types::StructType;
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, Value};
@@ -37,10 +36,6 @@ impl<'ctx> StructValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.struct_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.struct_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 
 use crate::values::{ArrayValue, AggregateValueEnum, BasicValueUse, CallSiteValue, GlobalValue, StructValue, BasicValueEnum, AnyValueEnum, IntValue, FloatValue, PointerValue, PhiValue, VectorValue, FunctionValue, InstructionValue, Value};
 use crate::types::{IntMathType, FloatMathType, PointerMathType, IntType, FloatType, PointerType, VectorType};
+use crate::support::LLVMString;
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -120,6 +121,11 @@ pub trait AnyValue<'ctx>: AsValueRef + Debug {
     /// Returns an enum containing a typed version of `AnyValue`.
     fn as_any_value_enum(&self) -> AnyValueEnum<'ctx> {
         AnyValueEnum::new(self.as_value_ref())
+    }
+
+    /// Prints a value to a `LLVMString`
+    fn print_to_string(&self) -> LLVMString {
+        Value::new(self.as_value_ref()).print_to_string()
     }
 }
 

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -3,7 +3,6 @@ use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
 
-use crate::support::LLVMString;
 use crate::types::{VectorType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValueEnum, BasicValue, InstructionValue, Value, IntValue};
@@ -50,10 +49,6 @@ impl<'ctx> VectorValue<'ctx> {
         unsafe {
             !LLVMIsAConstantDataVector(self.as_value_ref()).is_null()
         }
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.vec_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -5,6 +5,7 @@ use self::inkwell::context::Context;
 use self::inkwell::memory_buffer::MemoryBuffer;
 use self::inkwell::module::Module;
 use self::inkwell::targets::{Target, TargetTriple};
+use self::inkwell::values::AnyValue;
 
 use std::env::temp_dir;
 use std::fs::{File, remove_file};

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -1,5 +1,6 @@
 use inkwell::AddressSpace;
 use inkwell::context::Context;
+use inkwell::values::AnyValue;
 use inkwell::types::BasicType;
 
 #[test]

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -2,8 +2,8 @@ use inkwell::{DLLStorageClass, FloatPredicate, GlobalVisibility, ThreadLocalMode
 use inkwell::attributes::AttributeLoc;
 use inkwell::context::Context;
 use inkwell::module::Linkage::*;
-use inkwell::types::{StringRadix, VectorType};
-use inkwell::values::{BasicValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
+use inkwell::types::{AnyType, StringRadix, VectorType};
+use inkwell::values::{AnyValue, BasicValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
 #[llvm_versions(7.0..=latest)]
 use inkwell::comdat::ComdatSelectionKind;
 


### PR DESCRIPTION
Make it easier to print a BasicValueEnum/BasicTypeEnum