### PR TITLE
Add support for LLVM 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.6-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="3.7"
@@ -55,7 +55,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.7-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="3.8"
@@ -68,7 +68,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.8-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     # 3.9 seems to have a linking issue :/
     # - env:
@@ -83,7 +83,7 @@ matrix:
     #       packages:
     #         - *BASE_PACKAGES
     #         - llvm-3.9-dev
-    #   rust: 1.48.0
+    #   rust: 1.42.0
     #   dist: xenial
     - env:
         - LLVM_VERSION="4.0"
@@ -96,7 +96,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-4.0-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="5.0"
@@ -109,7 +109,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-5.0-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="6.0"
@@ -122,7 +122,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-6.0-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="7.0"
@@ -135,7 +135,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-7-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="8.0"
@@ -148,7 +148,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-8-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: trusty
     - env:
         - LLVM_VERSION="9.0"
@@ -163,7 +163,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-9-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: bionic
     - env:
         - LLVM_VERSION="10.0"
@@ -179,7 +179,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-10-dev
             - libclang-common-10-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: bionic
     - env:
         - LLVM_VERSION="11.0"
@@ -195,7 +195,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-11-dev
             - libclang-common-11-dev
-      rust: 1.48.0
+      rust: 1.42.0
       dist: bionic
     - deploy: # Documentation build; Only latest supported LLVM version for now
         provider: pages
@@ -252,7 +252,7 @@ env:
     - RUSTFLAGS="-C link-dead-code -C target-cpu=native -l ffi"
 
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == 1.48.0 ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" == 1.42.0 ]]; then
     cargo tarpaulin --features "llvm${LLVM_VERSION_DASH}" --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -195,7 +195,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-11-dev
             - libclang-common-11-dev
-      rust: 1.39.0
+      rust: 1.48.0
       dist: bionic
     - deploy: # Documentation build; Only latest supported LLVM version for now
         provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.6-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="3.7"
@@ -55,7 +55,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.7-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="3.8"
@@ -68,7 +68,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-3.8-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     # 3.9 seems to have a linking issue :/
     # - env:
@@ -83,7 +83,7 @@ matrix:
     #       packages:
     #         - *BASE_PACKAGES
     #         - llvm-3.9-dev
-    #   rust: 1.42.0
+    #   rust: 1.48.0
     #   dist: xenial
     - env:
         - LLVM_VERSION="4.0"
@@ -96,7 +96,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-4.0-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="5.0"
@@ -109,7 +109,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-5.0-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="6.0"
@@ -122,7 +122,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-6.0-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="7.0"
@@ -135,7 +135,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-7-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="8.0"
@@ -148,7 +148,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-8-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: trusty
     - env:
         - LLVM_VERSION="9.0"
@@ -163,7 +163,7 @@ matrix:
           packages:
             - *BASE_PACKAGES
             - llvm-9-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: bionic
     - env:
         - LLVM_VERSION="10.0"
@@ -179,7 +179,7 @@ matrix:
             - *BASE_PACKAGES
             - llvm-10-dev
             - libclang-common-10-dev
-      rust: 1.42.0
+      rust: 1.48.0
       dist: bionic
     - env:
         - LLVM_VERSION="11.0"
@@ -252,7 +252,7 @@ env:
     - RUSTFLAGS="-C link-dead-code -C target-cpu=native -l ffi"
 
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == 1.42.0 ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" == 1.48.0 ]]; then
     cargo tarpaulin --features "llvm${LLVM_VERSION_DASH}" --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -181,6 +181,22 @@ matrix:
             - libclang-common-10-dev
       rust: 1.42.0
       dist: bionic
+    - env:
+        - LLVM_VERSION="11.0"
+      <<: *BASE
+      addons:
+        apt:
+          sources:
+            - *BASE_SOURCES
+            - llvm-toolchain-bionic-11
+            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - *BASE_PACKAGES
+            - llvm-11-dev
+            - libclang-common-11-dev
+      rust: 1.39.0
+      dist: bionic
     - deploy: # Documentation build; Only latest supported LLVM version for now
         provider: pages
         skip-cleanup: true
@@ -190,10 +206,10 @@ matrix:
         on:
           branch: master
       before_install:
-        - export PATH=/usr/lib/llvm-10/bin/:$HOME/.local/bin:$PATH
-        - export LLVM_PATH=/usr/share/llvm-10/cmake/
+        - export PATH=/usr/lib/llvm-11/bin/:$HOME/.local/bin:$PATH
+        - export LLVM_PATH=/usr/share/llvm-11/cmake/
       script:
-        - cargo doc --no-default-features --features "target-all,llvm10-0,nightly" --color=always
+        - cargo doc --no-default-features --features "target-all,llvm11-0,nightly" --color=always
         - echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > target/doc/index.html
       rust: nightly
       name: "GitHub IO Documentation Deployment"
@@ -211,8 +227,9 @@ matrix:
             # - llvm-toolchain-trusty-7
             # - llvm-toolchain-trusty-8
             # - llvm-toolchain-bionic-9
-            - llvm-toolchain-bionic-10
-            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+            # llvm-toolchain-bionic-10
+            - llvm-toolchain-bionic-11
+            - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *BASE_PACKAGES
@@ -226,7 +243,8 @@ matrix:
             # - llvm-7-dev
             # - llvm-8-dev
             # - llvm-9-dev
-            - llvm-10-dev
+            # llvm-10-dev
+            - llvm-11-dev
       dist: bionic
 
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ llvm7-0 = ["llvm-sys-70"]
 llvm8-0 = ["llvm-sys-80"]
 llvm9-0 = ["llvm-sys-90"]
 llvm10-0 = ["llvm-sys-100"]
+llvm11-0 = ["llvm-sys-110"]
 # Don't link aganist LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
 # `no-llvm-linking` feature across the board of llvm versions, as it'll cause
@@ -41,6 +42,7 @@ llvm7-0-no-llvm-linking = ["llvm7-0", "llvm-sys-70/no-llvm-linking"]
 llvm8-0-no-llvm-linking = ["llvm8-0", "llvm-sys-80/no-llvm-linking"]
 llvm9-0-no-llvm-linking = ["llvm9-0", "llvm-sys-90/no-llvm-linking"]
 llvm10-0-no-llvm-linking = ["llvm10-0", "llvm-sys-100/no-llvm-linking"]
+llvm11-0-no-llvm-linking = ["llvm11-0", "llvm-sys-110/no-llvm-linking"]
 # Don't force linking to libffi on non-windows platforms. Without this feature
 # inkwell always links to libffi on non-windows platforms.
 no-libffi-linking = []
@@ -96,6 +98,7 @@ llvm-sys-70 = { package = "llvm-sys", version = "70.4", optional = true }
 llvm-sys-80 = { package = "llvm-sys", version = "80.3", optional = true }
 llvm-sys-90 = { package = "llvm-sys", version = "90.2", optional = true }
 llvm-sys-100 = { package = "llvm-sys", version = "100.2", optional = true }
+llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.11"
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inkwell aims to help you pen your own programming languages by safely wrapping l
 
 * Rust 1.39+
 * Rust Stable, Beta, or Nightly
-* LLVM 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, or 10.0
+* LLVM 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, or 11.0
 
 ## Usage
 
@@ -24,7 +24,7 @@ branch with a corresponding LLVM feature flag:
 
 ```toml
 [dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm11-0"] }
 ```
 
 Supported versions:
@@ -42,6 +42,7 @@ Supported versions:
 | 8.0.x        | llvm8-0       |
 | 9.0.x        | llvm9-0       |
 | 10.0.x       | llvm10-0      |
+| 11.0.x       | llvm11-0      |
 
 Please be aware that we may make breaking changes on master from time to time since we are
 pre-v1.0.0, in compliance with semver. Please prefer a crates.io release whenever possible!

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -19,8 +19,8 @@ use syn::spanned::Spanned;
 use syn::{Token, LitFloat, Ident, Item, Field, Variant, Attribute};
 
 // This array should match the LLVM features in the top level Cargo manifest
-const FEATURE_VERSIONS: [&str; 11] =
-    ["llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0"];
+const FEATURE_VERSIONS: [&str; 12] =
+    ["llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0"];
 
 /// Gets the index of the feature version that represents `latest`
 fn get_latest_feature_index(features: &[&str]) -> usize {

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -162,7 +162,6 @@ pub trait AsDIScope<'ctx> {
 }
 
 impl<'ctx> DebugInfoBuilder<'ctx> {
-    #[llvm_versions(3.6..=10.0)]
     pub(crate) fn new(
         module: &Module,
         allow_unresolved: bool,
@@ -178,56 +177,9 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         dwo_id: libc::c_uint,
         split_debug_inlining: bool,
         debug_info_for_profiling: bool,
-    ) -> (Self, DICompileUnit<'ctx>) {
-        let builder = unsafe {
-            if allow_unresolved {
-                LLVMCreateDIBuilder(module.module.get())
-            } else {
-                LLVMCreateDIBuilderDisallowUnresolved(module.module.get())
-            }
-        };
-
-        let builder = DebugInfoBuilder {
-            builder,
-            _marker: PhantomData,
-        };
-
-        let file = builder.create_file(filename, directory);
-
-        let cu = builder.create_compile_unit(
-            language,
-            file,
-            producer,
-            is_optimized,
-            flags,
-            runtime_ver,
-            split_name,
-            kind,
-            dwo_id,
-            split_debug_inlining,
-            debug_info_for_profiling,
-        );
-
-        (builder, cu)
-    }
-
-    #[llvm_versions(11.0)]
-    pub(crate) fn new(
-        module: &Module,
-        allow_unresolved: bool,
-        language: DWARFSourceLanguage,
-        filename: &str,
-        directory: &str,
-        producer: &str,
-        is_optimized: bool,
-        flags: &str,
-        runtime_ver: libc::c_uint,
-        split_name: &str,
-        kind: DWARFEmissionKind,
-        dwo_id: libc::c_uint,
-        split_debug_inlining: bool,
-        debug_info_for_profiling: bool,
+        #[cfg(feature = "llvm11-0")]
         sysroot: &str,
+        #[cfg(feature = "llvm11-0")]
         sdk: &str,
     ) -> (Self, DICompileUnit<'ctx>) {
         let builder = unsafe {
@@ -257,7 +209,9 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             dwo_id,
             split_debug_inlining,
             debug_info_for_profiling,
+            #[cfg(feature = "llvm11-0")]
             sysroot,
+            #[cfg(feature = "llvm11-0")]
             sdk
         );
 
@@ -277,7 +231,6 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     /// * `dwo_id` - The DWOId if this is a split skeleton compile unit.
     /// * `split_debug_inlining` - Whether to emit inline debug info.
     /// * `debug_info_for_profiling` - Whether to emit extra debug info for profile collection.
-    #[llvm_versions(3.6..=10.0)]
     fn create_compile_unit(
         &self,
         language: DWARFSourceLanguage,
@@ -291,9 +244,16 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         dwo_id: libc::c_uint,
         split_debug_inlining: bool,
         debug_info_for_profiling: bool,
+        #[cfg(feature = "llvm11-0")]
+        sysroot: &str,
+        #[cfg(feature = "llvm11-0")]
+        sdk: &str,
     ) -> DICompileUnit<'ctx> {
+
         let metadata_ref = unsafe {
-            LLVMDIBuilderCreateCompileUnit(
+            #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
+                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature= "llvm9-0", feature= "llvm10-0"))]
+            { LLVMDIBuilderCreateCompileUnit(
                 self.builder,
                 language.into(),
                 file.metadata_ref,
@@ -309,51 +269,10 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 dwo_id,
                 split_debug_inlining as _,
                 debug_info_for_profiling as _,
-            )
-        };
+            ) }
 
-        DICompileUnit {
-            file,
-            metadata_ref,
-            _marker: PhantomData,
-        }
-    }
-
-    /// A DICompileUnit provides an anchor for all debugging information generated during this instance of compilation.
-    ///
-    /// * `language` - Source programming language
-    /// * `file` - File info
-    /// * `producer` - Identify the producer of debugging information and code. Usually this is a compiler version string.
-    /// * `is_optimized` - A boolean flag which indicates whether optimization is enabled or not.
-    /// * `flags` - This string lists command line options. This string is directly embedded in debug info output which may be used by a tool analyzing generated debugging information.
-    /// * `runtime_ver` - This indicates runtime version for languages like Objective-C.
-    /// * `split_name` - The name of the file that we'll split debug info out into.
-    /// * `kind` - The kind of debug information to generate.
-    /// * `dwo_id` - The DWOId if this is a split skeleton compile unit.
-    /// * `split_debug_inlining` - Whether to emit inline debug info.
-    /// * `debug_info_for_profiling` - Whether to emit extra debug info for profile collection.
-    /// * `sysroot` The clang system root (value of -isysroot).
-    /// * `sdk` The SDK name. On Darwin, this is the last component of the sysroot.
-    #[llvm_versions(11.0)]
-    fn create_compile_unit(
-        &self,
-        language: DWARFSourceLanguage,
-        file: DIFile<'ctx>,
-        producer: &str,
-        is_optimized: bool,
-        flags: &str,
-        runtime_ver: libc::c_uint,
-        split_name: &str,
-        kind: DWARFEmissionKind,
-        dwo_id: libc::c_uint,
-        split_debug_inlining: bool,
-        debug_info_for_profiling: bool,
-        sysroot: &str,
-        sdk: &str,
-    ) -> DICompileUnit<'ctx> {
-
-        let metadata_ref = unsafe {
-            LLVMDIBuilderCreateCompileUnit(
+            #[cfg(feature = "llvm11-0")]
+             { LLVMDIBuilderCreateCompileUnit(
                 self.builder,
                 language.into(),
                 file.metadata_ref,
@@ -373,7 +292,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 sysroot.len(),
                 sdk.as_ptr() as _,
                 sdk.len(),
-            )
+            )}
         };
 
         DICompileUnit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ extern crate llvm_sys_80 as llvm_sys;
 extern crate llvm_sys_90 as llvm_sys;
 #[cfg(feature="llvm10-0")]
 extern crate llvm_sys_100 as llvm_sys;
+#[cfg(feature="llvm11-0")]
+extern crate llvm_sys_110 as llvm_sys;
 
 use llvm_sys::{LLVMIntPredicate, LLVMRealPredicate, LLVMVisibility, LLVMThreadLocalMode, LLVMDLLStorageClass, LLVMAtomicOrdering, LLVMAtomicRMWBinOp};
 
@@ -100,7 +102,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0"}
+assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///

--- a/src/module.rs
+++ b/src/module.rs
@@ -1354,7 +1354,7 @@ impl<'ctx> Module<'ctx> {
     }
 
     /// Creates a `DebugInfoBuilder` for this `Module`.
-    #[llvm_versions(7.0..=latest)]
+    #[llvm_versions(7.0..=10.0)]
     pub fn create_debug_info_builder(&self,
         allow_unresolved: bool,
         language: DWARFSourceLanguage,
@@ -1372,6 +1372,32 @@ impl<'ctx> Module<'ctx> {
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
         DebugInfoBuilder::new(self, allow_unresolved,
                               language, filename, directory, producer, is_optimized, flags, runtime_ver, split_name, kind, dwo_id, split_debug_inlining, debug_info_for_profiling
+        )
+    }
+
+    /// Creates a `DebugInfoBuilder` for this `Module`.
+    #[llvm_versions(11.0)]
+    pub fn create_debug_info_builder(&self,
+        allow_unresolved: bool,
+        language: DWARFSourceLanguage,
+        filename: &str,
+        directory: &str,
+        producer: &str,
+        is_optimized: bool,
+        flags: &str,
+        runtime_ver: libc::c_uint,
+        split_name: &str,
+        kind: DWARFEmissionKind,
+        dwo_id: libc::c_uint,
+        split_debug_inlining: bool,
+        debug_info_for_profiling: bool,
+        sysroot: &str,
+        sdk: &str,
+    ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
+        DebugInfoBuilder::new(self, allow_unresolved,
+                              language, filename, directory, producer, is_optimized, flags, 
+                              runtime_ver, split_name, kind, dwo_id, split_debug_inlining, 
+                              debug_info_for_profiling, sysroot, sdk
         )
     }
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1354,7 +1354,6 @@ impl<'ctx> Module<'ctx> {
     }
 
     /// Creates a `DebugInfoBuilder` for this `Module`.
-    #[llvm_versions(7.0..=10.0)]
     pub fn create_debug_info_builder(&self,
         allow_unresolved: bool,
         language: DWARFSourceLanguage,
@@ -1369,35 +1368,19 @@ impl<'ctx> Module<'ctx> {
         dwo_id: libc::c_uint,
         split_debug_inlining: bool,
         debug_info_for_profiling: bool,
-    ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
-        DebugInfoBuilder::new(self, allow_unresolved,
-                              language, filename, directory, producer, is_optimized, flags, runtime_ver, split_name, kind, dwo_id, split_debug_inlining, debug_info_for_profiling
-        )
-    }
-
-    /// Creates a `DebugInfoBuilder` for this `Module`.
-    #[llvm_versions(11.0)]
-    pub fn create_debug_info_builder(&self,
-        allow_unresolved: bool,
-        language: DWARFSourceLanguage,
-        filename: &str,
-        directory: &str,
-        producer: &str,
-        is_optimized: bool,
-        flags: &str,
-        runtime_ver: libc::c_uint,
-        split_name: &str,
-        kind: DWARFEmissionKind,
-        dwo_id: libc::c_uint,
-        split_debug_inlining: bool,
-        debug_info_for_profiling: bool,
+        #[cfg(feature="llvm11-0")]
         sysroot: &str,
+        #[cfg(feature="llvm11-0")]
         sdk: &str,
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
         DebugInfoBuilder::new(self, allow_unresolved,
                               language, filename, directory, producer, is_optimized, flags, 
                               runtime_ver, split_name, kind, dwo_id, split_debug_inlining, 
-                              debug_info_for_profiling, sysroot, sdk
+                              debug_info_for_profiling, 
+                              #[cfg(feature="llvm11-0")]
+                              sysroot,
+                              #[cfg(feature="llvm11-0")]
+                              sdk
         )
     }
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1354,6 +1354,7 @@ impl<'ctx> Module<'ctx> {
     }
 
     /// Creates a `DebugInfoBuilder` for this `Module`.
+    #[llvm_versions(7.0..=latest)]
     pub fn create_debug_info_builder(&self,
         allow_unresolved: bool,
         language: DWARFSourceLanguage,

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -103,6 +103,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             LLVMTypeKind::LLVMX86_FP80TypeKind |
             LLVMTypeKind::LLVMFP128TypeKind |
             LLVMTypeKind::LLVMPPC_FP128TypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
+            #[cfg(feature = "llvm11-0")]
+            LLVMTypeKind::LLVMBFloatTypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMLabelTypeKind => panic!("FIXME: Unsupported type: Label"),
             LLVMTypeKind::LLVMIntegerTypeKind => AnyTypeEnum::IntType(IntType::new(type_)),
             LLVMTypeKind::LLVMFunctionTypeKind => AnyTypeEnum::FunctionType(FunctionType::new(type_)),
@@ -110,6 +112,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             LLVMTypeKind::LLVMArrayTypeKind => AnyTypeEnum::ArrayType(ArrayType::new(type_)),
             LLVMTypeKind::LLVMPointerTypeKind => AnyTypeEnum::PointerType(PointerType::new(type_)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
+            #[cfg(feature = "llvm11-0")]
+            LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("FIXME: Unsupported type: Metadata"),
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("FIXME: Unsupported type: MMX"),
             #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
@@ -277,11 +281,15 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             LLVMTypeKind::LLVMX86_FP80TypeKind |
             LLVMTypeKind::LLVMFP128TypeKind |
             LLVMTypeKind::LLVMPPC_FP128TypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
+            #[cfg(feature= "llvm11-0")]
+            LLVMTypeKind::LLVMBFloatTypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMIntegerTypeKind => BasicTypeEnum::IntType(IntType::new(type_)),
             LLVMTypeKind::LLVMStructTypeKind => BasicTypeEnum::StructType(StructType::new(type_)),
             LLVMTypeKind::LLVMPointerTypeKind => BasicTypeEnum::PointerType(PointerType::new(type_)),
             LLVMTypeKind::LLVMArrayTypeKind => BasicTypeEnum::ArrayType(ArrayType::new(type_)),
             LLVMTypeKind::LLVMVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
+            #[cfg(feature= "llvm11-0")]
+            LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => unreachable!("Unsupported basic type: Metadata"),
             LLVMTypeKind::LLVMX86_MMXTypeKind => unreachable!("Unsupported basic type: MMX"),
             LLVMTypeKind::LLVMLabelTypeKind => unreachable!("Unsupported basic type: Label"),

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -268,25 +268,15 @@ impl<'ctx> InstructionValue<'ctx> {
 
     // SubTypes: Only apply to memory access and alloca instructions
     /// Sets alignment on a memory access instruction or alloca.
-    #[llvm_versions(3.6..=10.0)]
     pub fn set_alignment(self, alignment: u32) -> Result<(), &'static str> {
+        #[cfg(feature = "llvm11-0")]
+        {
+            if alignment == 0 {
+                return Err("Alignment cannot be 0");
+            }
+        }
+        //The alignment = 0 check above covers LLVM >= 11, the != 0 check here keeps older versions compatible
         if !alignment.is_power_of_two() && alignment != 0 {
-            return Err("Alignment is not a power of 2!");
-        }
-        if !self.is_a_alloca_inst() && !self.is_a_load_inst() && !self.is_a_store_inst() {
-            return Err("Value is not an alloca, load or store.");
-        }
-        Ok(unsafe { LLVMSetAlignment(self.as_value_ref(), alignment) })
-    }
-    
-    // SubTypes: Only apply to memory access and alloca instructions
-    /// Sets alignment on a memory access instruction or alloca.
-    #[llvm_versions(11.0..=latest)]
-    pub fn set_alignment(self, alignment: u32) -> Result<(), &'static str> {
-        if alignment == 0 {
-            return Err("Alignment cannot be 0");
-        }
-        if !alignment.is_power_of_two(){
             return Err("Alignment is not a power of 2!");
         }
         if !self.is_a_alloca_inst() && !self.is_a_load_inst() && !self.is_a_store_inst() {

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -34,7 +34,7 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 26;
 #[cfg(feature = "llvm9-0")]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 28;
-#[cfg(feature = "llvm10-0")]
+#[cfg(any(feature = "llvm10-0", feature = "llvm11-0"))]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 30;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -15,14 +15,6 @@ fn test_enum_attribute_kinds() {
     // play around with it and determine which ones they are interested in
     // for their particular LLVM version
 
-    // Function Attributes:
-    assert_eq!(Attribute::get_named_enum_kind_id("allocsize"), 2);
-    assert_eq!(Attribute::get_named_enum_kind_id("alwaysinline"), 3);
-    assert_eq!(Attribute::get_named_enum_kind_id("argmemonly"), 4);
-    assert_eq!(Attribute::get_named_enum_kind_id("builtin"), 5);
-    assert_eq!(Attribute::get_named_enum_kind_id("cold"), 7);
-    assert_eq!(Attribute::get_named_enum_kind_id("convergent"), 8);
-
     // REVIEW: The LLVM docs suggest these fn attrs exist, but don't turn up:
     // assert_eq!(Attribute::get_named_enum_kind_id("no-jump-tables"), 19);
     // assert_eq!(Attribute::get_named_enum_kind_id("null-pointer-is-valid"), 31);
@@ -34,12 +26,6 @@ fn test_enum_attribute_kinds() {
     // assert_eq!(Attribute::get_named_enum_kind_id("thunk"), 45);
     // assert_eq!(Attribute::get_named_enum_kind_id("nocf_check"), 45);
     // assert_eq!(Attribute::get_named_enum_kind_id("shadowcallstack"), 45);
-
-    // Parameter Attributes:
-    assert_eq!(Attribute::get_named_enum_kind_id("align"), 1);
-    assert_eq!(Attribute::get_named_enum_kind_id("byval"), 6);
-    assert_eq!(Attribute::get_named_enum_kind_id("dereferenceable"), 9);
-    assert_eq!(Attribute::get_named_enum_kind_id("dereferenceable_or_null"), 10);
 }
 
 #[test]

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -32,6 +32,10 @@ fn test_smoke() {
         0,
         false,
         false,
+        #[cfg(feature = "llvm11-0")]
+        "",
+        #[cfg(feature = "llvm11-0")]
+        "",
     );
 
     let ditype = dibuilder
@@ -106,6 +110,10 @@ fn test_struct_with_placeholders() {
         0,
         false,
         false,
+        #[cfg(feature = "llvm11-0")]
+        "",
+        #[cfg(feature = "llvm11-0")]
+        "",
     );
 
     // Some byte aligned integer types.
@@ -219,6 +227,10 @@ fn test_no_explicit_finalize() {
         0,
         false,
         false,
+        #[cfg(feature = "llvm11-0")]
+        "",
+        #[cfg(feature = "llvm11-0")]
+        "",
     );
 
     drop(dibuilder);
@@ -246,6 +258,10 @@ fn test_replacing_placeholder_with_placeholder() {
         0,
         false,
         false,
+        #[cfg(feature = "llvm11-0")]
+        "",
+        #[cfg(feature = "llvm11-0")]
+        "",
     );
 
     let i32ty = dibuilder
@@ -289,6 +305,10 @@ fn test_anonymous_basic_type() {
         0,
         false,
         false,
+        #[cfg(feature = "llvm11-0")]
+        "",
+        #[cfg(feature = "llvm11-0")]
+        "",
     );
 
     assert_eq!(
@@ -323,6 +343,10 @@ fn test_global_expressions() {
         0,
         false,
         false,
+        #[cfg(feature = "llvm11-0")]
+        "",
+        #[cfg(feature = "llvm11-0")]
+        "",
     );
 
     let di_type = dibuilder.create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO);

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -303,6 +303,7 @@ fn test_volatile_atomicrmw_cmpxchg() {
     assert_eq!(cmpxchg.get_volatile().unwrap(), false);
 }
 
+#[llvm_versions(3.6..=10.0)]
 #[test]
 fn test_mem_instructions() {
     let context = Context::create();
@@ -355,6 +356,67 @@ fn test_mem_instructions() {
 
     assert!(store_instruction.set_alignment(14).is_err());
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);
+
+    let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    assert!(fadd_instruction.get_volatile().is_err());
+    assert!(fadd_instruction.set_volatile(false).is_err());
+    assert!(fadd_instruction.get_alignment().is_err());
+    assert!(fadd_instruction.set_alignment(16).is_err());
+}
+
+#[llvm_versions(11.0..=latest)]
+#[test]
+fn test_mem_instructions() {
+    let context = Context::create();
+    let module = context.create_module("testing");
+    let builder = context.create_builder();
+
+    let void_type = context.void_type();
+    let f32_type = context.f32_type();
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
+
+    let function = module.add_function("mem_inst", fn_type, None);
+    let basic_block = context.append_basic_block(function, "entry");
+
+    builder.position_at_end(basic_block);
+
+    let arg1 = function.get_first_param().unwrap().into_pointer_value();
+    let arg2 = function.get_nth_param(1).unwrap().into_float_value();
+
+    assert!(arg1.get_first_use().is_none());
+    assert!(arg2.get_first_use().is_none());
+
+    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+
+    let store_instruction = builder.build_store(arg1, f32_val);
+    let load = builder.build_load(arg1, "");
+    let load_instruction = load.as_instruction_value().unwrap();
+
+    assert_eq!(store_instruction.get_volatile().unwrap(), false);
+    assert_eq!(load_instruction.get_volatile().unwrap(), false);
+    store_instruction.set_volatile(true).unwrap();
+    load_instruction.set_volatile(true).unwrap();
+    assert_eq!(store_instruction.get_volatile().unwrap(), true);
+    assert_eq!(load_instruction.get_volatile().unwrap(), true);
+    store_instruction.set_volatile(false).unwrap();
+    load_instruction.set_volatile(false).unwrap();
+    assert_eq!(store_instruction.get_volatile().unwrap(), false);
+    assert_eq!(load_instruction.get_volatile().unwrap(), false);
+
+    assert_eq!(store_instruction.get_alignment().unwrap(), 4);
+    assert_eq!(load_instruction.get_alignment().unwrap(), 4);
+    assert!(store_instruction.set_alignment(16).is_ok());
+    assert!(load_instruction.set_alignment(16).is_ok());
+    assert_eq!(store_instruction.get_alignment().unwrap(), 16);
+    assert_eq!(load_instruction.get_alignment().unwrap(), 16);
+    assert!(store_instruction.set_alignment(4).is_ok());
+    assert!(load_instruction.set_alignment(4).is_ok());
+    assert_eq!(store_instruction.get_alignment().unwrap(), 4);
+    assert_eq!(load_instruction.get_alignment().unwrap(), 4);
+
+    assert!(store_instruction.set_alignment(14).is_err());
+    assert_eq!(store_instruction.get_alignment().unwrap(), 4);
 
     let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
     assert!(fadd_instruction.get_volatile().is_err());

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -349,7 +349,6 @@ fn test_mem_instructions() {
     assert!(load_instruction.set_alignment(16).is_ok());
     assert_eq!(store_instruction.get_alignment().unwrap(), 16);
     assert_eq!(load_instruction.get_alignment().unwrap(), 16);
-    println!("--------Here------------");
     assert!(store_instruction.set_alignment(0).is_ok());
     assert!(load_instruction.set_alignment(0).is_ok());
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -349,6 +349,7 @@ fn test_mem_instructions() {
     assert!(load_instruction.set_alignment(16).is_ok());
     assert_eq!(store_instruction.get_alignment().unwrap(), 16);
     assert_eq!(load_instruction.get_alignment().unwrap(), 16);
+    println!("--------Here------------");
     assert!(store_instruction.set_alignment(0).is_ok());
     assert!(load_instruction.set_alignment(0).is_ok());
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -139,9 +139,9 @@ fn test_pass_manager_builder() {
     let module2 = module.clone();
 
     // TODOC: In 3.6, 3.8, & 3.9 it returns false. Seems like a LLVM bug?
-    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
+    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0")))]
     assert!(!module_pass_manager.run_on(&module));
-    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0"))]
+    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0"))]
     assert!(module_pass_manager.run_on(&module));
 
     let lto_pass_manager = PassManager::create(());

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -320,10 +320,10 @@ fn test_verify_fn() {
 
     let function = module.add_function("fn", fn_type, None);
 
-    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
+    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0")))]
     assert!(!function.verify(false));
     // REVIEW: Why does 3.9 -> 8.0 return true here? LLVM bug? Bugfix?
-    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0"))]
+    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0"))]
     assert!(function.verify(false));
 
     let basic_block = context.append_basic_block(function, "entry");
@@ -729,8 +729,8 @@ fn test_globals() {
     assert!(!global.has_unnamed_addr());
     assert!(!global.is_externally_initialized());
     assert_eq!(global.get_name().to_str(), Ok("my_global"));
-    // REVIEW: Segfaults in 4.0 -> 7.0
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0")))]
+    // REVIEW: Segfaults in 4.0 -> 11.0
+    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0")))]
     assert_eq!(global.get_section().to_str(), Ok(""));
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());


### PR DESCRIPTION
## Description
Added support for an LLVM 11 future.
Updated the debug builder API to support the new parameters
Fixed some failing tests
Updated travis config 

## Related Issue
#217 

## How This Has Been Tested
Ran tests for the older features and the new feature
Did not add new tests as no new functionality was added
**2 Tests are still failing on my machine**, one for enums and one for alignment.

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
