### PR TITLE
fix(module,values) Fix memory leaks

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -930,20 +930,20 @@ impl<'ctx> Module<'ctx> {
     /// ```
     pub fn get_global_metadata(&self, key: &str) -> Vec<MetadataValue<'ctx>> {
         let c_string = to_c_str(key);
-        let count = self.get_global_metadata_size(key);
+        let count = self.get_global_metadata_size(key) as usize;
 
-        let mut raw_vec: Vec<LLVMValueRef> = Vec::with_capacity(count as usize);
+        let mut raw_vec: Vec<LLVMValueRef> = Vec::with_capacity(count);
         let ptr = raw_vec.as_mut_ptr();
 
         forget(raw_vec);
 
-        let slice = unsafe {
+        let vec = unsafe {
             LLVMGetNamedMetadataOperands(self.module.get(), c_string.as_ptr(), ptr);
 
-            from_raw_parts(ptr, count as usize)
+            Vec::from_raw_parts(ptr, count, count)
         };
 
-        slice.iter().map(|val| MetadataValue::new(*val)).collect()
+        vec.iter().map(|val| MetadataValue::new(*val)).collect()
     }
 
     /// Gets the first `GlobalValue` in a module.

--- a/src/module.rs
+++ b/src/module.rs
@@ -23,7 +23,6 @@ use std::mem::{forget, MaybeUninit};
 use std::path::Path;
 use std::ptr;
 use std::rc::Rc;
-use std::slice::from_raw_parts;
 
 use crate::{AddressSpace, OptimizationLevel};
 #[llvm_versions(7.0..=latest)]

--- a/src/module.rs
+++ b/src/module.rs
@@ -932,15 +932,13 @@ impl<'ctx> Module<'ctx> {
         let c_string = to_c_str(key);
         let count = self.get_global_metadata_size(key) as usize;
 
-        let mut raw_vec: Vec<LLVMValueRef> = Vec::with_capacity(count);
-        let ptr = raw_vec.as_mut_ptr();
+        let mut vec: Vec<LLVMValueRef> = Vec::with_capacity(count);
+        let ptr = vec.as_mut_ptr();
 
-        forget(raw_vec);
-
-        let vec = unsafe {
+        unsafe {
             LLVMGetNamedMetadataOperands(self.module.get(), c_string.as_ptr(), ptr);
 
-            Vec::from_raw_parts(ptr, count, count)
+            vec.set_len(count);
         };
 
         vec.iter().map(|val| MetadataValue::new(*val)).collect()

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -110,15 +110,13 @@ impl<'ctx> MetadataValue<'ctx> {
         }
 
         let count = self.get_node_size() as usize;
-        let mut raw_vec: Vec<LLVMValueRef> = Vec::with_capacity(count);
-        let ptr = raw_vec.as_mut_ptr();
+        let mut vec: Vec<LLVMValueRef> = Vec::with_capacity(count);
+        let ptr = vec.as_mut_ptr();
 
-        forget(raw_vec);
-
-        let vec = unsafe {
+        unsafe {
             LLVMGetMDNodeOperands(self.as_value_ref(), ptr);
 
-            Vec::from_raw_parts(ptr, count, count)
+            vec.set_len(count)
         };
 
         vec.iter()

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -12,8 +12,6 @@ use crate::values::{BasicMetadataValueEnum, Value};
 
 use std::ffi::CStr;
 use std::fmt;
-use std::mem::forget;
-use std::slice::from_raw_parts;
 
 // TODOC: Varies by version
 #[cfg(feature = "llvm3-6")]


### PR DESCRIPTION
## Description

This patch fixes multiple memory leaks.

One pattern I noticed (in `Module::get_global_metadata` and in `MetadataValue::get_node_values`) is the following:

1. Allocate a new `Vec<T>`,
2. Get a mutable pointer to it,
3. Forget the vector,
4. Fill the vector with `LLVM*`,
5. Read back the vector as a slice,
6. Map slice values, and collect them in a newly allocated vector.

Here, the first vector is lost. That's a memory leak.

This patch changes the steps 3 to 6: We use `Vec::with_capacity` to
get a buffer to fill with `LLVM*`, and we set back the length to `count`
with `Vec::set_len` once the buffer is completed. The code is more
Rust-FFI-idiomatic and simpler.

Compiling and running the documentation of the `get_global_metadata`
method, valgrind gives us the following results:

(`master`)

```
==35629== LEAK SUMMARY:
==35629==    definitely lost: 40 bytes in 3 blocks
==35629==    indirectly lost: 0 bytes in 0 blocks
==35629==      possibly lost: 0 bytes in 0 blocks
==35629==    still reachable: 145 bytes in 1 blocks
==35629==         suppressed: 137,663 bytes in 1,484 blocks
```

(after https://github.com/TheDan64/inkwell/pull/225/commits/7c8732191ef778ecb707e08b0568f9bdbf2a7e1d)

```
==35805== LEAK SUMMARY:
==35805==    definitely lost: 24 bytes in 2 blocks
==35805==    indirectly lost: 0 bytes in 0 blocks
==35805==      possibly lost: 0 bytes in 0 blocks
==35805==    still reachable: 145 bytes in 1 blocks
==35805==         suppressed: 137,663 bytes in 1,484 blocks
```

(after https://github.com/TheDan64/inkwell/pull/225/commits/a21147bb65609f6e3cfd8405b78eeb16ff605218)

```
==37629== LEAK SUMMARY:
==37629==    definitely lost: 16 bytes in 1 blocks
==37629==    indirectly lost: 0 bytes in 0 blocks
==37629==      possibly lost: 0 bytes in 0 blocks
==37629==    still reachable: 145 bytes in 1 blocks
==37629==         suppressed: 137,663 bytes in 1,484 blocks
```

(after https://github.com/TheDan64/inkwell/pull/225/commits/e4b3238f5d3a9e23d821babaf206af2648e8db59)

```
==39665== LEAK SUMMARY:
==39665==    definitely lost: 0 bytes in 0 blocks
==39665==    indirectly lost: 0 bytes in 0 blocks
==39665==      possibly lost: 0 bytes in 0 blocks
==39665==    still reachable: 145 bytes in 1 blocks
==39665==         suppressed: 137,663 bytes in 1,484 blocks
```