### PR TITLE
Add BasicTypeEnum::const_zero().

### DIFF
--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -78,7 +78,7 @@ enum_type_set! {
         ArrayType,
         /// A floating point type.
         FloatType,
-        // An integer type.
+        /// An integer type.
         IntType,
         /// A pointer type.
         PointerType,

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -4,7 +4,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::types::{IntType, VoidType, FunctionType, PointerType, VectorType, ArrayType, StructType, FloatType};
 use crate::types::traits::AsTypeRef;
-use crate::values::IntValue;
+use crate::values::{BasicValue, BasicValueEnum, IntValue};
 
 use std::convert::TryFrom;
 
@@ -393,6 +393,28 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             true
         } else {
             false
+        }
+    }
+
+    /// Creates a constant `BasicValueZero`.
+    ///
+    /// # Example
+    /// ```
+    /// use inkwell::context::Context;
+    /// use crate::inkwell::types::BasicType;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type().as_basic_type_enum();
+    /// let f32_zero = f32_type.const_zero();
+    /// ```
+    pub fn const_zero(self) -> BasicValueEnum<'ctx> {
+        match self {
+            BasicTypeEnum::ArrayType(ty) => ty.const_zero().as_basic_value_enum(),
+            BasicTypeEnum::FloatType(ty) => ty.const_zero().as_basic_value_enum(),
+            BasicTypeEnum::IntType(ty) => ty.const_zero().as_basic_value_enum(),
+            BasicTypeEnum::PointerType(ty) => ty.const_zero().as_basic_value_enum(),
+            BasicTypeEnum::StructType(ty) => ty.const_zero().as_basic_value_enum(),
+            BasicTypeEnum::VectorType(ty) => ty.const_zero().as_basic_value_enum(),
         }
     }
 }


### PR DESCRIPTION
## Description

Every BasicType can take on a zero value. Add BasicTypeEnum::const_zero() that returns a BasicValueEnum with the zero in it, of the matching basic type.

## Related Issue

n/a

## How This Has Been Tested

doc test

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
