### PR TITLE
Refactor: use matches! in is_xxx functions instead of if-let expression.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/TheDan64/inkwell/branch/master/graph/badge.svg)](https://codecov.io/gh/TheDan64/inkwell)
 [![lines of code](https://tokei.rs/b1/github/TheDan64/inkwell)](https://github.com/Aaronepower/tokei)
 [![Join the chat at https://gitter.im/inkwell-rs/Lobby](https://badges.gitter.im/inkwell-rs/Lobby.svg)](https://gitter.im/inkwell-rs/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-![Minimum rustc 1.39](https://img.shields.io/badge/rustc-1.39+-brightgreen.svg)
+![Minimum rustc 1.42](https://img.shields.io/badge/rustc-1.42+-brightgreen.svg)
 
 **I**t's a **N**ew **K**ind of **W**rapper for **E**xposing **LL**VM (*S*afely)
 
@@ -13,7 +13,7 @@ Inkwell aims to help you pen your own programming languages by safely wrapping l
 
 ## Requirements
 
-* Rust 1.39+
+* Rust 1.42+
 * Rust Stable, Beta, or Nightly
 * LLVM 3.6, 3.7, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, or 11.0
 

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -191,67 +191,35 @@ impl<'ctx> AnyTypeEnum<'ctx> {
     }
 
     pub fn is_array_type(self) -> bool {
-        if let AnyTypeEnum::ArrayType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::ArrayType(_))
     }
 
     pub fn is_float_type(self) -> bool {
-        if let AnyTypeEnum::FloatType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::FloatType(_))
     }
 
     pub fn is_function_type(self) -> bool {
-        if let AnyTypeEnum::FunctionType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::FunctionType(_))
     }
 
     pub fn is_int_type(self) -> bool {
-        if let AnyTypeEnum::IntType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::IntType(_))
     }
 
     pub fn is_pointer_type(self) -> bool {
-        if let AnyTypeEnum::PointerType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::PointerType(_))
     }
 
     pub fn is_struct_type(self) -> bool {
-        if let AnyTypeEnum::StructType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::StructType(_))
     }
 
     pub fn is_vector_type(self) -> bool {
-        if let AnyTypeEnum::VectorType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::VectorType(_))
     }
 
     pub fn is_void_type(self) -> bool {
-        if let AnyTypeEnum::VoidType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyTypeEnum::VoidType(_))
     }
 
     pub fn size_of(&self) -> Option<IntValue<'ctx>> {

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -317,51 +317,27 @@ impl<'ctx> BasicTypeEnum<'ctx> {
     }
 
     pub fn is_array_type(self) -> bool {
-        if let BasicTypeEnum::ArrayType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicTypeEnum::ArrayType(_))
     }
 
     pub fn is_float_type(self) -> bool {
-        if let BasicTypeEnum::FloatType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicTypeEnum::FloatType(_))
     }
 
     pub fn is_int_type(self) -> bool {
-        if let BasicTypeEnum::IntType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicTypeEnum::IntType(_))
     }
 
     pub fn is_pointer_type(self) -> bool {
-        if let BasicTypeEnum::PointerType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicTypeEnum::PointerType(_))
     }
 
     pub fn is_struct_type(self) -> bool {
-        if let BasicTypeEnum::StructType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicTypeEnum::StructType(_))
     }
 
     pub fn is_vector_type(self) -> bool {
-        if let BasicTypeEnum::VectorType(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicTypeEnum::VectorType(_))
     }
 
     /// Creates a constant `BasicValueZero`.

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -243,51 +243,27 @@ impl<'ctx> BasicValueEnum<'ctx> {
     }
 
     pub fn is_array_value(self) -> bool {
-        if let BasicValueEnum::ArrayValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicValueEnum::ArrayValue(_))
     }
 
     pub fn is_int_value(self) -> bool {
-        if let BasicValueEnum::IntValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicValueEnum::IntValue(_))
     }
 
     pub fn is_float_value(self) -> bool {
-        if let BasicValueEnum::FloatValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicValueEnum::FloatValue(_))
     }
 
     pub fn is_pointer_value(self) -> bool {
-        if let BasicValueEnum::PointerValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicValueEnum::PointerValue(_))
     }
 
     pub fn is_struct_value(self) -> bool {
-        if let BasicValueEnum::StructValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicValueEnum::StructValue(_))
     }
 
     pub fn is_vector_value(self) -> bool {
-        if let BasicValueEnum::VectorValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicValueEnum::VectorValue(_))
     }
 
     pub fn into_array_value(self) -> ArrayValue<'ctx> {

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -385,59 +385,31 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
     }
 
     pub fn is_array_value(self) -> bool {
-        if let BasicMetadataValueEnum::ArrayValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::ArrayValue(_))
     }
 
     pub fn is_int_value(self) -> bool {
-        if let BasicMetadataValueEnum::IntValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::IntValue(_))
     }
 
     pub fn is_float_value(self) -> bool {
-        if let BasicMetadataValueEnum::FloatValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::FloatValue(_))
     }
 
     pub fn is_pointer_value(self) -> bool {
-        if let BasicMetadataValueEnum::PointerValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::PointerValue(_))
     }
 
     pub fn is_struct_value(self) -> bool {
-        if let BasicMetadataValueEnum::StructValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::StructValue(_))
     }
 
     pub fn is_vector_value(self) -> bool {
-        if let BasicMetadataValueEnum::VectorValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::VectorValue(_))
     }
 
     pub fn is_metadata_value(self) -> bool {
-        if let BasicMetadataValueEnum::MetadataValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, BasicMetadataValueEnum::MetadataValue(_))
     }
 
     pub fn into_array_value(self) -> ArrayValue<'ctx> {

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -104,75 +104,39 @@ impl<'ctx> AnyValueEnum<'ctx> {
     }
 
     pub fn is_array_value(self) -> bool {
-        if let AnyValueEnum::ArrayValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::ArrayValue(_))
     }
 
     pub fn is_int_value(self) -> bool {
-        if let AnyValueEnum::IntValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::IntValue(_))
     }
 
     pub fn is_float_value(self) -> bool {
-        if let AnyValueEnum::FloatValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::FloatValue(_))
     }
 
     pub fn is_phi_value(self) -> bool {
-        if let AnyValueEnum::PhiValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::PhiValue(_))
     }
 
     pub fn is_function_value(self) -> bool {
-        if let AnyValueEnum::FunctionValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::FunctionValue(_))
     }
 
     pub fn is_pointer_value(self) -> bool {
-        if let AnyValueEnum::PointerValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::PointerValue(_))
     }
 
     pub fn is_struct_value(self) -> bool {
-        if let AnyValueEnum::StructValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::StructValue(_))
     }
 
     pub fn is_vector_value(self) -> bool {
-        if let AnyValueEnum::VectorValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::VectorValue(_))
     }
 
     pub fn is_instruction_value(self) -> bool {
-        if let AnyValueEnum::InstructionValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AnyValueEnum::InstructionValue(_))
     }
 
     pub fn into_array_value(self) -> ArrayValue<'ctx> {

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -329,19 +329,11 @@ impl<'ctx> AggregateValueEnum<'ctx> {
     }
 
     pub fn is_array_value(self) -> bool {
-        if let AggregateValueEnum::ArrayValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AggregateValueEnum::ArrayValue(_))
     }
 
     pub fn is_struct_value(self) -> bool {
-        if let AggregateValueEnum::StructValue(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, AggregateValueEnum::StructValue(_))
     }
 
     pub fn into_array_value(self) -> ArrayValue<'ctx> {


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description
From 1.42.0, the [matches!](https://doc.rust-lang.org/std/macro.matches.html) macro is provided.

## Related Issue
None

## How This Has Been Tested
It's ok if all existing tests passed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
