### PR TITLE
Invoke & some friends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -252,6 +252,9 @@ impl<'ctx> Builder<'ctx> {
     /// This example shows how to use the C++ personality function:
     ///
     /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
     /// let context = Context::create();
     /// let module = context.create_module("sum");
     /// let builder = context.create_builder();
@@ -347,6 +350,9 @@ impl<'ctx> Builder<'ctx> {
     /// This example shows how to use the C++ personality function:
     ///
     /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
     /// let context = Context::create();
     /// let module = context.create_module("sum");
     /// let builder = context.create_builder();
@@ -402,7 +408,7 @@ impl<'ctx> Builder<'ctx> {
     ///
     ///     // we handle the exception by returning a default value
     ///
-    ///     builder.build_return(Some(f32_type.const_zero));
+    ///     builder.build_return(Some(&f32_type.const_zero()));
     /// }
     /// ```
     pub fn build_catch_all_landing_pad<T>(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination, LLVMBuildInvoke, LLVMBuildResume, LLVMBuildLandingPad, LLVMSetCleanup};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination, LLVMBuildInvoke, LLVMBuildResume, LLVMBuildLandingPad, LLVMSetCleanup, LLVMAddClause};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 #[llvm_versions(8.0..=latest)]
@@ -264,6 +264,40 @@ impl<'ctx> Builder<'ctx> {
 
         unsafe {
             LLVMSetCleanup(value, 1);
+        };
+
+        unsafe {
+            BasicValueEnum::new(value)
+        }
+    }
+
+    pub fn build_catch_all_landing_pad(
+        &self,
+        ty: &dyn BasicType<'ctx>,
+        value: &dyn BasicValue<'ctx>,
+        ptr_ty: PointerType<'ctx>,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
+        let c_string = to_c_str(name);
+        let num_clauses = 1u32;
+
+        let value = unsafe {
+            LLVMBuildLandingPad(
+                self.builder,
+                ty.as_type_ref(),
+                value.as_value_ref(),
+                num_clauses,
+                c_string.as_ptr(),
+            )
+        };
+
+        // we will add one clause, a null pointer of the specified type
+        // NOTE: the ptr type does not actually matter, but we do need a
+        // pointer type to generate the null pointer
+        let null = ptr_ty.const_zero();
+
+        unsafe {
+            LLVMAddClause(value, null.as_value_ref());
         };
 
         unsafe {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! A `Builder` enables you to build instructions.
 
 use either::{Either, Left, Right};
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination};
+use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetElementType, LLVMGetInsertBlock, LLVMGetReturnType, LLVMGetTypeKind, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMTypeOf, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination, LLVMBuildInvoke, LLVMBuildResume, LLVMBuildLandingPad, LLVMSetCleanup};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 #[llvm_versions(8.0..=latest)]
@@ -145,10 +145,7 @@ impl<'ctx> Builder<'ctx> {
                 // If using a pointer value, we must validate it's a valid function ptr
                 let value_ref = val.as_value_ref();
                 let ty_kind = unsafe { LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(value_ref))) };
-                let is_a_fn_ptr = match ty_kind {
-                    LLVMTypeKind::LLVMFunctionTypeKind => true,
-                    _ => false,
-                };
+                let is_a_fn_ptr = matches!(ty_kind, LLVMTypeKind::LLVMFunctionTypeKind);
 
                 // REVIEW: We should probably turn this into a Result?
                 assert!(is_a_fn_ptr, "build_call called with a pointer which is not a function pointer");
@@ -175,6 +172,111 @@ impl<'ctx> Builder<'ctx> {
 
         unsafe {
             CallSiteValue::new(value)
+        }
+    }
+
+    /// Builds an invoke instruction. An invoke is similar to a normal function call, but used to
+    /// call functions that may throw an exception, and then respond to the exception.
+    ///
+    /// When the called function returns normally, the `then` block is evaluated next. If instead
+    /// the function threw an exception, the `catch` block is intered. The first non-phi
+    /// instruction of the catch block must be a `landingpad` instruction.
+    ///
+    /// This function can take either a `FunctionValue` or a `PointerValue`
+    /// which is a function pointer. It will panic if the `PointerValue` is not a function pointer.
+    /// This may be turned into a Result in the future, however.
+    pub fn build_invoke<F>(
+        &self,
+        function: F,
+        args: &[BasicValueEnum<'ctx>],
+        then_block: BasicBlock<'ctx>,
+        catch_block: BasicBlock<'ctx>,
+        name: &str,
+    ) -> CallSiteValue<'ctx>
+    where
+        F: Into<FunctionOrPointerValue<'ctx>>,
+    {
+        let fn_val_ref = match function.into() {
+            Left(val) => val.as_value_ref(),
+            Right(val) => {
+                // If using a pointer value, we must validate it's a valid function ptr
+                let value_ref = val.as_value_ref();
+                let ty_kind = unsafe { LLVMGetTypeKind(LLVMGetElementType(LLVMTypeOf(value_ref))) };
+                let is_a_fn_ptr = matches!(ty_kind, LLVMTypeKind::LLVMFunctionTypeKind);
+
+                // REVIEW: We should probably turn this into a Result?
+                assert!(
+                    is_a_fn_ptr,
+                    "build_call called with a pointer which is not a function pointer"
+                );
+
+                value_ref
+            }
+        };
+
+        // LLVM gets upset when void return calls are named because they don't return anything
+        let name = unsafe {
+            match LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
+                fn_val_ref,
+            )))) {
+                LLVMTypeKind::LLVMVoidTypeKind => "",
+                _ => name,
+            }
+        };
+
+        let c_string = to_c_str(name);
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let value = unsafe {
+            LLVMBuildInvoke(
+                self.builder,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                then_block.basic_block,
+                catch_block.basic_block,
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe {
+            CallSiteValue::new(value)
+        }
+    }
+
+    pub fn build_cleanup_landing_pad(
+        &self,
+        ty: &dyn BasicType<'ctx>,
+        value: &dyn BasicValue<'ctx>,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
+        let c_string = to_c_str(name);
+        let num_clauses = 0u32;
+
+        let value = unsafe {
+            LLVMBuildLandingPad(
+                self.builder,
+                ty.as_type_ref(),
+                value.as_value_ref(),
+                num_clauses,
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe {
+            LLVMSetCleanup(value, 1);
+        };
+
+        unsafe {
+            BasicValueEnum::new(value)
+        }
+    }
+
+    /// Resume propagation of an existing (in-flight) exception whose unwinding was interrupted with a landingpad instruction.
+    pub fn build_resume(&self, value: &dyn BasicValue<'ctx>) -> InstructionValue<'ctx> {
+        let val = unsafe { LLVMBuildResume(self.builder, value.as_value_ref()) };
+
+        unsafe {
+            InstructionValue::new(val)
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -444,7 +444,8 @@ impl<'ctx> Builder<'ctx> {
         //     catch i8* null, !dbg !933
         // ```
         //
-        let i8_type = personality_function.get_type().get_context().i8_type();
+        let context = personality_function.get_type().get_context();
+        let i8_type = context.i8_type();
         let i8_ptr_type = i8_type.ptr_type(crate::AddressSpace::Generic);
         let null = i8_ptr_type.const_zero();
 

--- a/src/values/callable_value.rs
+++ b/src/values/callable_value.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom};
+use std::convert::TryFrom;
 use either::Either;
 
 use crate::values::AsValueRef;
@@ -7,6 +7,12 @@ use crate::values::{FunctionValue, PointerValue, AnyValue};
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::core::{LLVMGetTypeKind, LLVMGetElementType, LLVMTypeOf, LLVMGetReturnType};
 use llvm_sys::LLVMTypeKind;
+
+// imports used in documentation
+#[allow(unused_imports)]
+use crate::builder::Builder;
+#[allow(unused_imports)]
+use std::convert::TryInto;
 
 /// A value that can be called with the [`Builder::build_call`] instruction.
 ///

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -124,7 +124,8 @@ fn test_build_invoke_cleanup_resume() {
         let i32_type = context.i32_type();
         let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
 
-        let res = builder.build_cleanup_landing_pad( exception_type, personality_function, "res");
+        let clauses: &[inkwell::values::PointerValue] = &[];
+        let res = builder.build_landing_pad( exception_type, personality_function, clauses, true, "res");
 
         // do cleanup ...
 
@@ -191,13 +192,91 @@ fn test_build_invoke_catch_all() {
         let i32_type = context.i32_type();
         let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
 
-        let res = builder.build_catch_all_landing_pad(exception_type, personality_function, "res");
+        let null = i8_ptr_type.const_zero();
+        let res = builder.build_landing_pad(exception_type, personality_function, &[null], false, "res");
 
         let fakepi = f32_type.const_zero();
 
         builder.build_return(Some(&fakepi));
     }
 
+    assert!(module.verify().is_ok());
+}
+
+#[test]
+fn landing_pad_filter() { 
+    use inkwell::module::Linkage;
+    use inkwell::values::AnyValue;
+
+    let context = Context::create();
+    let module = context.create_module("sum");
+    let builder = context.create_builder();
+
+    let f32_type = context.f32_type();
+    let fn_type = f32_type.fn_type(&[], false);
+
+    let function = module.add_function("get_pi", fn_type, None);
+    let basic_block = context.append_basic_block(function, "entry");
+
+    builder.position_at_end(basic_block);
+
+    let pi = f32_type.const_float(::std::f64::consts::PI);
+
+    builder.build_return(Some(&pi));
+
+    let function2 = module.add_function("wrapper", fn_type, None);
+    let basic_block2 = context.append_basic_block(function2, "entry");
+
+    builder.position_at_end(basic_block2);
+
+    let then_block = context.append_basic_block(function2, "then_block");
+    let catch_block = context.append_basic_block(function2, "catch_block");
+
+    let pi2_call_site = builder.build_invoke(function, &[], then_block, catch_block, "get_pi");
+
+    assert!(!pi2_call_site.is_tail_call());
+
+    pi2_call_site.set_tail_call(true);
+
+    assert!(pi2_call_site.is_tail_call());
+
+    {
+        builder.position_at_end(then_block);
+
+        let pi2 = pi2_call_site.try_as_basic_value().left().unwrap();
+
+        builder.build_return(Some(&pi2));
+    }
+
+    {
+        builder.position_at_end(catch_block);
+
+        // the personality function used by C++
+        let personality_function = {
+            let name = "__gxx_personality_v0";
+
+            module.add_function(name, context.i64_type().fn_type(&[], false), None)
+        };
+
+        // type of an exception in C++
+        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+        let i32_type = context.i32_type();
+        let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
+
+        // link in the C++ type info for the i32 type
+        let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::Generic), "_ZTIi");
+        type_info_int.set_linkage(Linkage::External);
+
+        // make the filter landing pad
+        let filter_pattern = i8_ptr_type.const_array(&[type_info_int.as_any_value_enum().into_pointer_value()]);
+        let res = builder.build_landing_pad(exception_type, personality_function, &[filter_pattern], false, "res");
+
+        let fakepi = f32_type.const_zero();
+
+        builder.build_return(Some(&fakepi));
+    }
+
+    module.print_to_stderr();
     assert!(module.verify().is_ok());
 }
 

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -128,7 +128,6 @@ fn test_build_invoke_cleanup_resume() {
         builder.build_resume(res);
     }
 
-    dbg!(module.verify());
     assert!(module.verify().is_ok());
 }
 

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -69,21 +69,11 @@ fn test_build_invoke_cleanup_resume() {
     let module = context.create_module("sum");
     let builder = context.create_builder();
 
-    let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
-    let i32_type = context.i32_type();
-    let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
-
-    // the personality function used by c++
-    let personality_function = {
-        let name = "__gxx_personality_v0";
-
-        module.add_function(name, context.i64_type().fn_type(&[], false), None)
-    };
-
     let f32_type = context.f32_type();
     let fn_type = f32_type.fn_type(&[], false);
 
-    let function = module.add_function("get_pi", fn_type, None);
+    // we will pretend this function can throw an exception
+    let function = module.add_function("bomb", fn_type, None);
     let basic_block = context.append_basic_block(function, "entry");
 
     builder.position_at_end(basic_block);
@@ -93,8 +83,6 @@ fn test_build_invoke_cleanup_resume() {
     builder.build_return(Some(&pi));
 
     let function2 = module.add_function("wrapper", fn_type, None);
-    // function2.set_personality_function(personality_function);
-
     let basic_block2 = context.append_basic_block(function2, "entry");
 
     builder.position_at_end(basic_block2);
@@ -102,26 +90,41 @@ fn test_build_invoke_cleanup_resume() {
     let then_block = context.append_basic_block(function2, "then_block");
     let catch_block = context.append_basic_block(function2, "catch_block");
 
-    let pi2_call_site = builder.build_invoke(function, &[], then_block, catch_block, "get_pi");
+    let call_site = builder.build_invoke(function, &[], then_block, catch_block, "get_pi");
 
-    assert!(!pi2_call_site.is_tail_call());
+    assert!(!call_site.is_tail_call());
 
-    pi2_call_site.set_tail_call(true);
+    call_site.set_tail_call(true);
 
-    assert!(pi2_call_site.is_tail_call());
+    assert!(call_site.is_tail_call());
 
     {
         builder.position_at_end(then_block);
 
-        let pi2 = pi2_call_site.try_as_basic_value().left().unwrap();
+        let result = call_site.try_as_basic_value().left().unwrap();
 
-        builder.build_return(Some(&pi2));
+        builder.build_return(Some(&result));
     }
 
     {
         builder.position_at_end(catch_block);
 
-        let res = builder.build_cleanup_landing_pad(exception_type, "res");
+        // the personality function used by C++
+        let personality_function = {
+            let name = "__gxx_personality_v0";
+
+            module.add_function(name, context.i64_type().fn_type(&[], false), None)
+        };
+
+        // type of an exception in C++
+        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+        let i32_type = context.i32_type();
+        let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
+
+        let res = builder.build_cleanup_landing_pad( exception_type, personality_function, "res");
+
+        // do cleanup ...
+
         builder.build_resume(res);
     }
 
@@ -135,17 +138,6 @@ fn test_build_invoke_catch_all() {
     let module = context.create_module("sum");
     let builder = context.create_builder();
 
-    let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
-    let i32_type = context.i32_type();
-    let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
-
-    // the personality function used by c++
-    let personality_function = {
-        let name = "__gxx_personality_v0";
-
-        module.add_function(name, context.i64_type().fn_type(&[], false), None)
-    };
-
     let f32_type = context.f32_type();
     let fn_type = f32_type.fn_type(&[], false);
 
@@ -159,8 +151,6 @@ fn test_build_invoke_catch_all() {
     builder.build_return(Some(&pi));
 
     let function2 = module.add_function("wrapper", fn_type, None);
-    function2.set_personality_function(personality_function);
-
     let basic_block2 = context.append_basic_block(function2, "entry");
 
     builder.position_at_end(basic_block2);
@@ -187,8 +177,22 @@ fn test_build_invoke_catch_all() {
     {
         builder.position_at_end(catch_block);
 
-        let res = builder.build_catch_all_landing_pad(exception_type, "res");
+        // the personality function used by C++
+        let personality_function = {
+            let name = "__gxx_personality_v0";
+
+            module.add_function(name, context.i64_type().fn_type(&[], false), None)
+        };
+
+        // type of an exception in C++
+        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+        let i32_type = context.i32_type();
+        let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
+
+        let res = builder.build_catch_all_landing_pad(exception_type, personality_function, "res");
+
         let fakepi = f32_type.const_zero();
+
         builder.build_return(Some(&fakepi));
     }
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Adds support for the `invoke` instruction, and some support for building landing pads and resuming an exception. This does not cover the full exception functionality, but unless you're building a c++ compiler this should provide most useful features.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
