### PR TITLE
chore: Run `rustfmt`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
-    if cfg!(all(not(target_os = "windows"), not(feature = "no-libffi-linking"))) {
+    if cfg!(all(
+        not(target_os = "windows"),
+        not(feature = "no-libffi-linking")
+    )) {
         println!("cargo:rustc-link-lib=dylib=ffi");
     }
 }

--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -1,10 +1,10 @@
 extern crate inkwell;
 
-use inkwell::OptimizationLevel;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::execution_engine::{ExecutionEngine, JitFunction};
 use inkwell::module::Module;
+use inkwell::OptimizationLevel;
 
 use std::error::Error;
 
@@ -43,7 +43,6 @@ impl<'ctx> CodeGen<'ctx> {
     }
 }
 
-
 fn main() -> Result<(), Box<dyn Error>> {
     let context = Context::create();
     let module = context.create_module("sum");
@@ -55,7 +54,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         execution_engine,
     };
 
-    let sum = codegen.jit_compile_sum().ok_or("Unable to JIT compile `sum`")?;
+    let sum = codegen
+        .jit_compile_sum()
+        .ok_or("Unable to JIT compile `sum`")?;
 
     let x = 1u64;
     let y = 2u64;

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -12,15 +12,17 @@ use std::iter::IntoIterator;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_quote, parse_macro_input, parenthesized};
-use syn::parse::{Parse, ParseStream, Result, Error};
 use syn::fold::Fold;
+use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::spanned::Spanned;
-use syn::{Token, LitFloat, Ident, Item, Field, Variant, Attribute};
+use syn::{parenthesized, parse_macro_input, parse_quote};
+use syn::{Attribute, Field, Ident, Item, LitFloat, Token, Variant};
 
 // This array should match the LLVM features in the top level Cargo manifest
-const FEATURE_VERSIONS: [&str; 13] =
-    ["llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0"];
+const FEATURE_VERSIONS: [&str; 13] = [
+    "llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0",
+    "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0",
+];
 
 /// Gets the index of the feature version that represents `latest`
 fn get_latest_feature_index(features: &[&str]) -> usize {
@@ -31,8 +33,11 @@ fn get_latest_feature_index(features: &[&str]) -> usize {
 fn get_feature_index(features: &[&str], feature: String, span: Span) -> Result<usize> {
     let feat = feature.as_str();
     match features.iter().position(|&s| s == feat) {
-        None => Err(Error::new(span, format!("Invalid feature version: {}, not defined", feature))),
-        Some(index) => Ok(index)
+        None => Err(Error::new(
+            span,
+            format!("Invalid feature version: {}, not defined", feature),
+        )),
+        Some(index) => Ok(index),
     }
 }
 
@@ -57,7 +62,10 @@ fn get_features(vt: VersionType) -> Result<Vec<&'static str>> {
             let start_index = get_feature_index(&features, start_feature, start_span)?;
             let end_index = get_feature_index(&features, end_feature, end_span)?;
             if end_index < start_index {
-                let message = format!("Invalid version range: {} must be greater than or equal to {}", start, end);
+                let message = format!(
+                    "Invalid version range: {} must be greater than or equal to {}",
+                    start, end
+                );
                 Err(Error::new(end_span, message))
             } else {
                 Ok(features[start_index..=end_index].to_vec())
@@ -67,7 +75,10 @@ fn get_features(vt: VersionType) -> Result<Vec<&'static str>> {
             let feature = f64_to_feature_string(version);
             let index = get_feature_index(&features, feature, span)?;
             if latest == index {
-                let message = format!("Invalid version range: {}..latest produces an empty feature set", version);
+                let message = format!(
+                    "Invalid version range: {}..latest produces an empty feature set",
+                    version
+                );
                 Err(Error::new(span, message))
             } else {
                 Ok(features[index..latest].to_vec())
@@ -79,10 +90,16 @@ fn get_features(vt: VersionType) -> Result<Vec<&'static str>> {
             let start_index = get_feature_index(&features, start_feature, start_span)?;
             let end_index = get_feature_index(&features, end_feature, end_span)?;
             if end_index == start_index {
-                let message = format!("Invalid version range: {}..{} produces an empty feature set", start, end);
+                let message = format!(
+                    "Invalid version range: {}..{} produces an empty feature set",
+                    start, end
+                );
                 Err(Error::new(start_span, message))
             } else if end_index < start_index {
-                let message = format!("Invalid version range: {} must be greater than {}", start, end);
+                let message = format!(
+                    "Invalid version range: {} must be greater than {}",
+                    start, end
+                );
                 Err(Error::new(end_span, message))
             } else {
                 Ok(features[start_index..end_index].to_vec())
@@ -136,7 +153,10 @@ impl Parse for VersionType {
                 } else if lookahead.peek(LitFloat) {
                     let to = input.parse::<LitFloat>().unwrap();
                     let to_val = to.base10_parse().unwrap();
-                    Ok(VersionType::InclusiveRange((from_val, from.span()), (to_val, to.span())))
+                    Ok(VersionType::InclusiveRange(
+                        (from_val, from.span()),
+                        (to_val, to.span()),
+                    ))
                 } else {
                     Err(lookahead.error())
                 }
@@ -153,7 +173,10 @@ impl Parse for VersionType {
                 } else if lookahead.peek(LitFloat) {
                     let to = input.parse::<LitFloat>().unwrap();
                     let to_val = to.base10_parse().unwrap();
-                    Ok(VersionType::ExclusiveRange((from_val, from.span()), (to_val, to.span())))
+                    Ok(VersionType::ExclusiveRange(
+                        (from_val, from.span()),
+                        (to_val, to.span()),
+                    ))
                 } else {
                     Err(lookahead.error())
                 }
@@ -255,7 +278,8 @@ impl Fold for FeatureSet {
             return variant;
         }
 
-        let attrs = variant.attrs
+        let attrs = variant
+            .attrs
             .iter()
             .map(|attr| self.expand_llvm_versions_attr(attr))
             .collect::<Vec<_>>();
@@ -268,7 +292,8 @@ impl Fold for FeatureSet {
             return field;
         }
 
-        let attrs = field.attrs
+        let attrs = field
+            .attrs
             .iter()
             .map(|attr| self.expand_llvm_versions_attr(attr))
             .collect::<Vec<_>>();
@@ -428,7 +453,11 @@ impl Fold for EnumVariants {
         }
 
         // Check for llvm_variant
-        if let Some(attr) = variant.attrs.iter().find(|attr| attr.path.is_ident("llvm_variant")) {
+        if let Some(attr) = variant
+            .attrs
+            .iter()
+            .find(|attr| attr.path.is_ident("llvm_variant"))
+        {
             // Extract attribute meta
             if let Ok(Meta::List(meta)) = attr.parse_meta() {
                 // We should only have one element
@@ -436,9 +465,14 @@ impl Fold for EnumVariants {
                     let variant_meta = meta.nested.first().unwrap();
                     // The element should be an identifier
                     if let NestedMeta::Meta(Meta::Path(name)) = variant_meta {
-                        self.variants.push(EnumVariant::with_name(&variant, name.get_ident().unwrap().clone()));
+                        self.variants.push(EnumVariant::with_name(
+                            &variant,
+                            name.get_ident().unwrap().clone(),
+                        ));
                         // Strip the llvm_variant attribute from the final AST
-                        variant.attrs.retain(|attr| !attr.path.is_ident("llvm_variant"));
+                        variant
+                            .attrs
+                            .retain(|attr| !attr.path.is_ident("llvm_variant"));
                         return variant;
                     }
                 }
@@ -516,7 +550,7 @@ impl Parse for LLVMEnumType {
 /// source variant is named `Return` and mapped manually to `LLVMRet`.
 #[proc_macro_attribute]
 pub fn llvm_enum(attribute_args: TokenStream, attributee: TokenStream) -> TokenStream {
-    use syn::{Path, PatPath, Arm};
+    use syn::{Arm, PatPath, Path};
 
     // Expect something like #[llvm_enum(LLVMOpcode)]
     let llvm_ty = parse_macro_input!(attribute_args as Path);

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,9 +1,13 @@
 //! `Attribute`s are optional modifiers to functions, function parameters, and return types.
 
 #[llvm_versions(3.9..=latest)]
-use llvm_sys::prelude::LLVMAttributeRef;
+use llvm_sys::core::{
+    LLVMGetEnumAttributeKind, LLVMGetEnumAttributeKindForName, LLVMGetEnumAttributeValue,
+    LLVMGetLastEnumAttributeKind, LLVMGetStringAttributeKind, LLVMGetStringAttributeValue,
+    LLVMIsEnumAttribute, LLVMIsStringAttribute,
+};
 #[llvm_versions(3.9..=latest)]
-use llvm_sys::core::{LLVMGetEnumAttributeKindForName, LLVMGetLastEnumAttributeKind, LLVMGetEnumAttributeKind, LLVMGetEnumAttributeValue, LLVMGetStringAttributeKind, LLVMGetStringAttributeValue, LLVMIsEnumAttribute, LLVMIsStringAttribute};
+use llvm_sys::prelude::LLVMAttributeRef;
 
 #[llvm_versions(3.9..=latest)]
 use std::ffi::CStr;
@@ -22,9 +26,7 @@ impl Attribute {
     pub(crate) unsafe fn new(attribute: LLVMAttributeRef) -> Self {
         debug_assert!(!attribute.is_null());
 
-        Attribute {
-            attribute,
-        }
+        Attribute { attribute }
     }
 
     /// Determines whether or not an `Attribute` is an enum. This method will
@@ -42,9 +44,7 @@ impl Attribute {
     /// assert!(enum_attribute.is_enum());
     /// ```
     pub fn is_enum(self) -> bool {
-        unsafe {
-            LLVMIsEnumAttribute(self.attribute) == 1
-        }
+        unsafe { LLVMIsEnumAttribute(self.attribute) == 1 }
     }
 
     /// Determines whether or not an `Attribute` is a string. This method will
@@ -62,9 +62,7 @@ impl Attribute {
     /// assert!(string_attribute.is_string());
     /// ```
     pub fn is_string(self) -> bool {
-        unsafe {
-            LLVMIsStringAttribute(self.attribute) == 1
-        }
+        unsafe { LLVMIsStringAttribute(self.attribute) == 1 }
     }
 
     /// Gets the enum kind id associated with a builtin name.
@@ -102,9 +100,7 @@ impl Attribute {
     pub fn get_enum_kind_id(self) -> u32 {
         assert!(self.is_enum()); // FIXME: SubTypes
 
-        unsafe {
-            LLVMGetEnumAttributeKind(self.attribute)
-        }
+        unsafe { LLVMGetEnumAttributeKind(self.attribute) }
     }
 
     /// Gets the last enum kind id associated with builtin names.
@@ -117,9 +113,7 @@ impl Attribute {
     /// assert_eq!(Attribute::get_last_enum_kind_id(), 56);
     /// ```
     pub fn get_last_enum_kind_id() -> u32 {
-        unsafe {
-            LLVMGetLastEnumAttributeKind()
-        }
+        unsafe { LLVMGetLastEnumAttributeKind() }
     }
 
     /// Gets the value associated with an enum `Attribute`.
@@ -137,9 +131,7 @@ impl Attribute {
     pub fn get_enum_value(self) -> u64 {
         assert!(self.is_enum()); // FIXME: SubTypes
 
-        unsafe {
-            LLVMGetEnumAttributeValue(self.attribute)
-        }
+        unsafe { LLVMGetEnumAttributeValue(self.attribute) }
     }
 
     /// Gets the string kind id associated with a string attribute.
@@ -158,13 +150,9 @@ impl Attribute {
         assert!(self.is_string()); // FIXME: SubTypes
 
         let mut length = 0;
-        let cstr_ptr = unsafe {
-            LLVMGetStringAttributeKind(self.attribute, &mut length)
-        };
+        let cstr_ptr = unsafe { LLVMGetStringAttributeKind(self.attribute, &mut length) };
 
-        unsafe {
-            CStr::from_ptr(cstr_ptr)
-        }
+        unsafe { CStr::from_ptr(cstr_ptr) }
     }
 
     /// Gets the string value associated with a string attribute.
@@ -183,13 +171,9 @@ impl Attribute {
         assert!(self.is_string()); // FIXME: SubTypes
 
         let mut length = 0;
-        let cstr_ptr = unsafe {
-            LLVMGetStringAttributeValue(self.attribute, &mut length)
-        };
+        let cstr_ptr = unsafe { LLVMGetStringAttributeValue(self.attribute, &mut length) };
 
-        unsafe {
-            CStr::from_ptr(cstr_ptr)
-        }
+        unsafe { CStr::from_ptr(cstr_ptr) }
     }
 }
 
@@ -209,10 +193,13 @@ impl AttributeLoc {
         match self {
             AttributeLoc::Return => 0,
             AttributeLoc::Param(index) => {
-                assert!(index <= u32::max_value() - 2, "Param index must be <= u32::max_value() - 2");
+                assert!(
+                    index <= u32::max_value() - 2,
+                    "Param index must be <= u32::max_value() - 2"
+                );
 
                 index + 1
-            },
+            }
             AttributeLoc::Function => u32::max_value(),
         }
     }

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,15 +1,21 @@
 //! A `BasicBlock` is a container of instructions.
 
-use llvm_sys::core::{LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator, LLVMGetNextBasicBlock, LLVMIsABasicBlock, LLVMIsConstant, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDeleteBasicBlock, LLVMGetPreviousBasicBlock, LLVMRemoveBasicBlockFromParent, LLVMGetFirstInstruction, LLVMGetLastInstruction, LLVMGetTypeContext, LLVMBasicBlockAsValue, LLVMReplaceAllUsesWith, LLVMGetFirstUse};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMGetBasicBlockName;
-use llvm_sys::prelude::{LLVMValueRef, LLVMBasicBlockRef};
+use llvm_sys::core::{
+    LLVMBasicBlockAsValue, LLVMDeleteBasicBlock, LLVMGetBasicBlockParent,
+    LLVMGetBasicBlockTerminator, LLVMGetFirstInstruction, LLVMGetFirstUse, LLVMGetLastInstruction,
+    LLVMGetNextBasicBlock, LLVMGetPreviousBasicBlock, LLVMGetTypeContext, LLVMIsABasicBlock,
+    LLVMIsConstant, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMPrintTypeToString,
+    LLVMPrintValueToString, LLVMRemoveBasicBlockFromParent, LLVMReplaceAllUsesWith, LLVMTypeOf,
+};
+use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
 
 use crate::context::ContextRef;
 use crate::values::{BasicValueUse, FunctionValue, InstructionValue};
 
-use std::fmt;
 use std::ffi::CStr;
+use std::fmt;
 use std::marker::PhantomData;
 
 /// A `BasicBlock` is a container of instructions.
@@ -34,7 +40,10 @@ impl<'ctx> BasicBlock<'ctx> {
         // NOTE: There is a LLVMBasicBlockAsValue but it might be the same as casting
         assert!(!LLVMIsABasicBlock(basic_block as LLVMValueRef).is_null());
 
-        Some(BasicBlock { basic_block, _marker: PhantomData })
+        Some(BasicBlock {
+            basic_block,
+            _marker: PhantomData,
+        })
     }
 
     /// Obtains the `FunctionValue` that this `BasicBlock` belongs to, if any.
@@ -60,9 +69,7 @@ impl<'ctx> BasicBlock<'ctx> {
     /// assert!(basic_block.get_parent().is_none());
     /// ```
     pub fn get_parent(self) -> Option<FunctionValue<'ctx>> {
-        unsafe {
-            FunctionValue::new(LLVMGetBasicBlockParent(self.basic_block))
-        }
+        unsafe { FunctionValue::new(LLVMGetBasicBlockParent(self.basic_block)) }
     }
 
     /// Gets the `BasicBlock` preceeding the current one, in its own scope, if any.
@@ -94,9 +101,7 @@ impl<'ctx> BasicBlock<'ctx> {
     pub fn get_previous_basic_block(self) -> Option<BasicBlock<'ctx>> {
         self.get_parent()?;
 
-        unsafe {
-            BasicBlock::new(LLVMGetPreviousBasicBlock(self.basic_block))
-        }
+        unsafe { BasicBlock::new(LLVMGetPreviousBasicBlock(self.basic_block)) }
     }
 
     /// Gets the `BasicBlock` succeeding the current one, in its own scope, if any.
@@ -129,9 +134,7 @@ impl<'ctx> BasicBlock<'ctx> {
     pub fn get_next_basic_block(self) -> Option<BasicBlock<'ctx>> {
         self.get_parent()?;
 
-        unsafe {
-            BasicBlock::new(LLVMGetNextBasicBlock(self.basic_block))
-        }
+        unsafe { BasicBlock::new(LLVMGetNextBasicBlock(self.basic_block)) }
     }
 
     /// Prepends one `BasicBlock` before another.
@@ -164,9 +167,7 @@ impl<'ctx> BasicBlock<'ctx> {
             return Err(());
         }
 
-        unsafe {
-            LLVMMoveBasicBlockBefore(self.basic_block, basic_block.basic_block)
-        }
+        unsafe { LLVMMoveBasicBlockBefore(self.basic_block, basic_block.basic_block) }
 
         Ok(())
     }
@@ -201,9 +202,7 @@ impl<'ctx> BasicBlock<'ctx> {
             return Err(());
         }
 
-        unsafe {
-            LLVMMoveBasicBlockAfter(self.basic_block, basic_block.basic_block)
-        }
+        unsafe { LLVMMoveBasicBlockAfter(self.basic_block, basic_block.basic_block) }
 
         Ok(())
     }
@@ -231,17 +230,13 @@ impl<'ctx> BasicBlock<'ctx> {
     /// assert_eq!(basic_block.get_first_instruction().unwrap().get_opcode(), InstructionOpcode::Return);
     /// ```
     pub fn get_first_instruction(self) -> Option<InstructionValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetFirstInstruction(self.basic_block)
-        };
+        let value = unsafe { LLVMGetFirstInstruction(self.basic_block) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(InstructionValue::new(value))
-        }
+        unsafe { Some(InstructionValue::new(value)) }
     }
 
     /// Obtains the last `InstructionValue` in this `BasicBlock`, if any. A `BasicBlock` must have a last instruction to be valid.
@@ -267,17 +262,13 @@ impl<'ctx> BasicBlock<'ctx> {
     /// assert_eq!(basic_block.get_last_instruction().unwrap().get_opcode(), InstructionOpcode::Return);
     /// ```
     pub fn get_last_instruction(self) -> Option<InstructionValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetLastInstruction(self.basic_block)
-        };
+        let value = unsafe { LLVMGetLastInstruction(self.basic_block) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(InstructionValue::new(value))
-        }
+        unsafe { Some(InstructionValue::new(value)) }
     }
 
     /// Obtains the terminating `InstructionValue` in this `BasicBlock`, if any. A `BasicBlock` must have a terminating instruction to be valid.
@@ -307,17 +298,13 @@ impl<'ctx> BasicBlock<'ctx> {
     // TODOC: Every BB must have a terminating instruction or else it is invalid
     // REVIEW: Unclear how this differs from get_last_instruction
     pub fn get_terminator(self) -> Option<InstructionValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetBasicBlockTerminator(self.basic_block)
-        };
+        let value = unsafe { LLVMGetBasicBlockTerminator(self.basic_block) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(InstructionValue::new(value))
-        }
+        unsafe { Some(InstructionValue::new(value)) }
     }
 
     /// Removes this `BasicBlock` from its parent `FunctionValue`.
@@ -352,9 +339,7 @@ impl<'ctx> BasicBlock<'ctx> {
             return Err(());
         }
 
-        unsafe {
-            LLVMRemoveBasicBlockFromParent(self.basic_block)
-        }
+        unsafe { LLVMRemoveBasicBlockFromParent(self.basic_block) }
 
         Ok(())
     }
@@ -410,7 +395,9 @@ impl<'ctx> BasicBlock<'ctx> {
     /// ```
     pub fn get_context(self) -> ContextRef<'ctx> {
         unsafe {
-            ContextRef::new(LLVMGetTypeContext(LLVMTypeOf(LLVMBasicBlockAsValue(self.basic_block))))
+            ContextRef::new(LLVMGetTypeContext(LLVMTypeOf(LLVMBasicBlockAsValue(
+                self.basic_block,
+            ))))
         }
     }
 
@@ -433,13 +420,9 @@ impl<'ctx> BasicBlock<'ctx> {
     /// ```
     #[llvm_versions(3.9..=latest)]
     pub fn get_name(&self) -> &CStr {
-        let ptr = unsafe {
-            LLVMGetBasicBlockName(self.basic_block)
-        };
+        let ptr = unsafe { LLVMGetBasicBlockName(self.basic_block) };
 
-        unsafe {
-            CStr::from_ptr(ptr)
-        }
+        unsafe { CStr::from_ptr(ptr) }
     }
 
     /// Replaces all uses of this basic block with another.
@@ -502,31 +485,26 @@ impl<'ctx> BasicBlock<'ctx> {
     /// assert!(bb1.get_first_use().is_some());
     /// ```
     pub fn get_first_use(self) -> Option<BasicValueUse<'ctx>> {
-        let use_ = unsafe {
-            LLVMGetFirstUse(LLVMBasicBlockAsValue(self.basic_block))
-        };
+        let use_ = unsafe { LLVMGetFirstUse(LLVMBasicBlockAsValue(self.basic_block)) };
 
         if use_.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(BasicValueUse::new(use_))
-        }
+        unsafe { Some(BasicValueUse::new(use_)) }
     }
 }
 
 impl fmt::Debug for BasicBlock<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let llvm_value = unsafe {
-            CStr::from_ptr(LLVMPrintValueToString(self.basic_block as LLVMValueRef))
-        };
+        let llvm_value =
+            unsafe { CStr::from_ptr(LLVMPrintValueToString(self.basic_block as LLVMValueRef)) };
         let llvm_type = unsafe {
-            CStr::from_ptr(LLVMPrintTypeToString(LLVMTypeOf(self.basic_block as LLVMValueRef)))
+            CStr::from_ptr(LLVMPrintTypeToString(LLVMTypeOf(
+                self.basic_block as LLVMValueRef,
+            )))
         };
-        let is_const = unsafe {
-            LLVMIsConstant(self.basic_block as LLVMValueRef) == 1
-        };
+        let is_const = unsafe { LLVMIsConstant(self.basic_block as LLVMValueRef) == 1 };
 
         f.debug_struct("BasicBlock")
             .field("address", &self.basic_block)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,22 +1,50 @@
 //! A `Builder` enables you to build instructions.
 
-use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFence, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFree, LLVMBuildFSub, LLVMBuildGEP, LLVMBuildICmp, LLVMBuildInsertValue, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildStore, LLVMBuildSub, LLVMBuildUDiv, LLVMBuildUnreachable, LLVMBuildXor, LLVMDisposeBuilder, LLVMGetInsertBlock, LLVMInsertIntoBuilder, LLVMPositionBuilderAtEnd, LLVMBuildExtractElement, LLVMBuildInsertElement, LLVMBuildIntToPtr, LLVMBuildPtrToInt, LLVMInsertIntoBuilderWithName, LLVMClearInsertionPosition, LLVMPositionBuilder, LLVMPositionBuilderBefore, LLVMBuildAggregateRet, LLVMBuildStructGEP, LLVMBuildInBoundsGEP, LLVMBuildPtrDiff, LLVMBuildNSWAdd, LLVMBuildNUWAdd, LLVMBuildNSWSub, LLVMBuildNUWSub, LLVMBuildNSWMul, LLVMBuildNUWMul, LLVMBuildSDiv, LLVMBuildSRem, LLVMBuildURem, LLVMBuildFRem, LLVMBuildNSWNeg, LLVMBuildNUWNeg, LLVMBuildFPToUI, LLVMBuildFPToSI, LLVMBuildSIToFP, LLVMBuildUIToFP, LLVMBuildFPTrunc, LLVMBuildFPExt, LLVMBuildIntCast, LLVMBuildFPCast, LLVMBuildSExtOrBitCast, LLVMBuildZExtOrBitCast, LLVMBuildTruncOrBitCast, LLVMBuildSwitch, LLVMAddCase, LLVMBuildShl, LLVMBuildAShr, LLVMBuildLShr, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildExactSDiv, LLVMBuildTrunc, LLVMBuildSExt, LLVMBuildZExt, LLVMBuildSelect, LLVMBuildAddrSpaceCast, LLVMBuildBitCast, LLVMBuildShuffleVector, LLVMBuildVAArg, LLVMBuildIndirectBr, LLVMAddDestination, LLVMBuildInvoke, LLVMBuildResume, LLVMBuildLandingPad, LLVMSetCleanup, LLVMAddClause};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
+use llvm_sys::core::{
+    LLVMAddCase, LLVMAddClause, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd,
+    LLVMBuildAddrSpaceCast, LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd,
+    LLVMBuildArrayAlloca, LLVMBuildArrayMalloc, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr,
+    LLVMBuildCall, LLVMBuildCast, LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement,
+    LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
+    LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI,
+    LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGEP,
+    LLVMBuildGlobalString, LLVMBuildGlobalStringPtr, LLVMBuildICmp, LLVMBuildInBoundsGEP,
+    LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntCast,
+    LLVMBuildIntToPtr, LLVMBuildInvoke, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr,
+    LLVMBuildLandingPad, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd,
+    LLVMBuildNSWMul, LLVMBuildNSWNeg, LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul,
+    LLVMBuildNUWNeg, LLVMBuildNUWSub, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi,
+    LLVMBuildPointerCast, LLVMBuildPtrDiff, LLVMBuildPtrToInt, LLVMBuildResume, LLVMBuildRet,
+    LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSExtOrBitCast, LLVMBuildSIToFP,
+    LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore,
+    LLVMBuildStructGEP, LLVMBuildSub, LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildTruncOrBitCast,
+    LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable, LLVMBuildVAArg,
+    LLVMBuildXor, LLVMBuildZExt, LLVMBuildZExtOrBitCast, LLVMClearInsertionPosition,
+    LLVMDisposeBuilder, LLVMGetInsertBlock, LLVMInsertIntoBuilder, LLVMInsertIntoBuilderWithName,
+    LLVMPositionBuilder, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMSetCleanup,
+};
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove};
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 
-use crate::{AtomicOrdering, AtomicRMWBinOp, IntPredicate, FloatPredicate};
 use crate::basic_block::BasicBlock;
-use crate::support::to_c_str;
-use crate::values::{AggregateValue, AggregateValueEnum, AsValueRef, FunctionValue, BasicValue, BasicValueEnum, PhiValue, IntValue, PointerValue, VectorValue, InstructionValue, GlobalValue, IntMathValue, FloatMathValue, PointerMathValue, InstructionOpcode, CallSiteValue};
 #[llvm_versions(7.0..=latest)]
 use crate::debug_info::DILocation;
+use crate::support::to_c_str;
+use crate::types::{
+    AsTypeRef, BasicType, FloatMathType, IntMathType, PointerMathType, PointerType,
+};
+use crate::values::CallableValue;
 #[llvm_versions(3.9..=latest)]
 use crate::values::StructValue;
-use crate::values::CallableValue;
-use crate::types::{AsTypeRef, BasicType, IntMathType, FloatMathType, PointerType, PointerMathType};
+use crate::values::{
+    AggregateValue, AggregateValueEnum, AsValueRef, BasicValue, BasicValueEnum, CallSiteValue,
+    FloatMathValue, FunctionValue, GlobalValue, InstructionOpcode, InstructionValue, IntMathValue,
+    IntValue, PhiValue, PointerMathValue, PointerValue, VectorValue,
+};
+use crate::{AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
 
 use std::marker::PhantomData;
 
@@ -62,12 +90,13 @@ impl<'ctx> Builder<'ctx> {
     /// ```
     pub fn build_return(&self, value: Option<&dyn BasicValue<'ctx>>) -> InstructionValue<'ctx> {
         let value = unsafe {
-            value.map_or_else(|| LLVMBuildRetVoid(self.builder), |value| LLVMBuildRet(self.builder, value.as_value_ref()))
+            value.map_or_else(
+                || LLVMBuildRetVoid(self.builder),
+                |value| LLVMBuildRet(self.builder, value.as_value_ref()),
+            )
         };
 
-        unsafe {
-            InstructionValue::new(value)
-        }
+        unsafe { InstructionValue::new(value) }
     }
 
     /// Builds a function return instruction for a return type which is an aggregate type (ie structs and arrays).
@@ -93,21 +122,19 @@ impl<'ctx> Builder<'ctx> {
     /// builder.position_at_end(entry);
     /// builder.build_aggregate_return(&[i32_three.into(), i32_seven.into()]);
     /// ```
-    pub fn build_aggregate_return(&self, values: &[BasicValueEnum<'ctx>]) -> InstructionValue<'ctx> {
-        let mut args: Vec<LLVMValueRef> = values.iter()
-                                                .map(|val| val.as_value_ref())
-                                                .collect();
-        let value = unsafe {
-            LLVMBuildAggregateRet(self.builder, args.as_mut_ptr(), args.len() as u32)
-        };
+    pub fn build_aggregate_return(
+        &self,
+        values: &[BasicValueEnum<'ctx>],
+    ) -> InstructionValue<'ctx> {
+        let mut args: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
+        let value =
+            unsafe { LLVMBuildAggregateRet(self.builder, args.as_mut_ptr(), args.len() as u32) };
 
-        unsafe {
-            InstructionValue::new(value)
-        }
+        unsafe { InstructionValue::new(value) }
     }
 
-    /// Builds a function call instruction. 
-    /// [`FunctionValue`]s can be implicitly converted into a [`CallableValue`]. 
+    /// Builds a function call instruction.
+    /// [`FunctionValue`]s can be implicitly converted into a [`CallableValue`].
     /// See [`CallableValue`] for details on calling a [`PointerValue`] that points to a function.
     ///
     /// [`FunctionValue`]: crate::values::FunctionValue
@@ -136,7 +163,12 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&ret_val));
     /// ```
-    pub fn build_call<F>(&self, function: F, args: &[BasicValueEnum<'ctx>], name: &str) -> CallSiteValue<'ctx>
+    pub fn build_call<F>(
+        &self,
+        function: F,
+        args: &[BasicValueEnum<'ctx>],
+        name: &str,
+    ) -> CallSiteValue<'ctx>
     where
         F: Into<CallableValue<'ctx>>,
     {
@@ -151,16 +183,18 @@ impl<'ctx> Builder<'ctx> {
         };
 
         let c_string = to_c_str(name);
-        let mut args: Vec<LLVMValueRef> = args.iter()
-                                              .map(|val| val.as_value_ref())
-                                              .collect();
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
         let value = unsafe {
-            LLVMBuildCall(self.builder, fn_val_ref, args.as_mut_ptr(), args.len() as u32, c_string.as_ptr())
+            LLVMBuildCall(
+                self.builder,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            CallSiteValue::new(value)
-        }
+        unsafe { CallSiteValue::new(value) }
     }
 
     /// An invoke is similar to a normal function call, but used to
@@ -177,7 +211,7 @@ impl<'ctx> Builder<'ctx> {
     /// [`add_prune_eh_pass`]: crate::passes::PassManager::add_prune_eh_pass
     ///
     /// This example catches C++ exceptions of type `int`, and returns `0` if an exceptions is thrown.
-    /// For usage of a cleanup landing pad and the `resume` instruction, see [`Builder::build_resume`] 
+    /// For usage of a cleanup landing pad and the `resume` instruction, see [`Builder::build_resume`]
     /// ```no_run
     /// use inkwell::context::Context;
     /// use inkwell::AddressSpace;
@@ -277,24 +311,22 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        unsafe {
-            CallSiteValue::new(value)
-        }
+        unsafe { CallSiteValue::new(value) }
     }
 
-    /// Landing pads are places where control flow jumps to if a [`Builder::build_invoke`] triggered an exception. 
+    /// Landing pads are places where control flow jumps to if a [`Builder::build_invoke`] triggered an exception.
     /// The landing pad will match the exception against its *clauses*. Depending on the clause
-    /// that is matched, the exception can then be handled, or resumed after some optional cleanup, 
+    /// that is matched, the exception can then be handled, or resumed after some optional cleanup,
     /// causing the exception to bubble up.
-    /// 
+    ///
     /// Exceptions in LLVM are designed based on the needs of a C++ compiler, but can be used more generally.
     /// Here are some specific examples of landing pads. For a full example of handling an exception, see [`Builder::build_invoke`].
-    /// 
+    ///
     /// * **cleanup**: a cleanup landing pad is always visited when unwinding the stack.
-    ///   A cleanup is extra code that needs to be run when unwinding a scope. C++ destructors are a typical example. 
+    ///   A cleanup is extra code that needs to be run when unwinding a scope. C++ destructors are a typical example.
     ///   In a language with reference counting, the cleanup block can decrement the refcount of values in scope.
     ///   The [`Builder::build_resume`] function has a full example using a cleanup lading pad.
-    /// 
+    ///
     /// ```no_run
     /// use inkwell::context::Context;
     /// use inkwell::AddressSpace;
@@ -303,12 +335,12 @@ impl<'ctx> Builder<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("sum");
     /// let builder = context.create_builder();
-    /// 
+    ///
     /// // type of an exception in C++
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
-    /// 
+    ///
     /// // the personality function used by C++
     /// let personality_function = {
     ///     let name = "__gxx_personality_v0";
@@ -316,14 +348,14 @@ impl<'ctx> Builder<'ctx> {
     ///
     ///     module.add_function(name, context.i64_type().fn_type(&[], false), linkage)
     /// };
-    /// 
+    ///
     /// // make the cleanup landing pad
     /// let res = builder.build_landing_pad( exception_type, personality_function, &[], true, "res");
     /// ```
-    /// 
-    /// * **catch all**: An implementation of the C++ `catch(...)`, which catches all exceptions. 
+    ///
+    /// * **catch all**: An implementation of the C++ `catch(...)`, which catches all exceptions.
     /// A catch clause with a NULL pointer value will match anything.
-    /// 
+    ///
     /// ```no_run
     /// use inkwell::context::Context;
     /// use inkwell::AddressSpace;
@@ -332,12 +364,12 @@ impl<'ctx> Builder<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("sum");
     /// let builder = context.create_builder();
-    /// 
+    ///
     /// // type of an exception in C++
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
-    /// 
+    ///
     /// // the personality function used by C++
     /// let personality_function = {
     ///     let name = "__gxx_personality_v0";
@@ -345,16 +377,16 @@ impl<'ctx> Builder<'ctx> {
     ///
     ///     module.add_function(name, context.i64_type().fn_type(&[], false), linkage)
     /// };
-    /// 
+    ///
     /// // make a null pointer of type i8
     /// let null = i8_ptr_type.const_zero();
-    /// 
+    ///
     /// // make the catch all landing pad
     /// let res = builder.build_landing_pad(exception_type, personality_function, &[null.into()], false, "res");
     /// ```
-    /// 
+    ///
     /// * **catch a type of exception**: Catch a specific type of exception. The example uses C++'s type info.
-    /// 
+    ///
     /// ```no_run
     /// use inkwell::context::Context;
     /// use inkwell::module::Linkage;
@@ -364,12 +396,12 @@ impl<'ctx> Builder<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("sum");
     /// let builder = context.create_builder();
-    /// 
+    ///
     /// // type of an exception in C++
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
-    /// 
+    ///
     /// // the personality function used by C++
     /// let personality_function = {
     ///     let name = "__gxx_personality_v0";
@@ -377,19 +409,19 @@ impl<'ctx> Builder<'ctx> {
     ///
     ///     module.add_function(name, context.i64_type().fn_type(&[], false), linkage)
     /// };
-    /// 
+    ///
     /// // link in the C++ type info for the `int` type
     /// let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::Generic), "_ZTIi");
     /// type_info_int.set_linkage(Linkage::External);
-    /// 
+    ///
     /// // make the catch landing pad
     /// let clause = type_info_int.as_basic_value_enum();
     /// let res = builder.build_landing_pad(exception_type, personality_function, &[clause], false, "res");
     /// ```
-    /// 
+    ///
     /// * **filter**: A filter clause encodes that only some types of exceptions are valid at this
     /// point. A filter clause is made by constructing a clause from a constant array.
-    /// 
+    ///
     /// ```no_run
     /// use inkwell::context::Context;
     /// use inkwell::module::Linkage;
@@ -399,12 +431,12 @@ impl<'ctx> Builder<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("sum");
     /// let builder = context.create_builder();
-    /// 
+    ///
     /// // type of an exception in C++
     /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
-    /// 
+    ///
     /// // the personality function used by C++
     /// let personality_function = {
     ///     let name = "__gxx_personality_v0";
@@ -412,11 +444,11 @@ impl<'ctx> Builder<'ctx> {
     ///
     ///     module.add_function(name, context.i64_type().fn_type(&[], false), linkage)
     /// };
-    /// 
+    ///
     /// // link in the C++ type info for the `int` type
     /// let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::Generic), "_ZTIi");
     /// type_info_int.set_linkage(Linkage::External);
-    /// 
+    ///
     /// // make the filter landing pad
     /// let filter_pattern = i8_ptr_type.const_array(&[type_info_int.as_any_value_enum().into_pointer_value()]);
     /// let res = builder.build_landing_pad(exception_type, personality_function, &[filter_pattern.into()], false, "res");
@@ -427,7 +459,7 @@ impl<'ctx> Builder<'ctx> {
         personality_function: FunctionValue<'ctx>,
         clauses: &[BasicValueEnum<'ctx>],
         is_cleanup: bool,
-        name: &str
+        name: &str,
     ) -> BasicValueEnum<'ctx>
     where
         T: BasicType<'ctx>,
@@ -445,7 +477,6 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-
         for clause in clauses {
             unsafe {
                 LLVMAddClause(value, clause.as_value_ref());
@@ -456,15 +487,13 @@ impl<'ctx> Builder<'ctx> {
             LLVMSetCleanup(value, is_cleanup as _);
         };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
     /// Resume propagation of an existing (in-flight) exception whose unwinding was interrupted with a landingpad instruction.
     ///
-    /// This example uses a cleanup landing pad. A cleanup is extra code that needs to be run when 
-    /// unwinding a scope. C++ destructors are a typical example. In a language with reference counting, 
+    /// This example uses a cleanup landing pad. A cleanup is extra code that needs to be run when
+    /// unwinding a scope. C++ destructors are a typical example. In a language with reference counting,
     /// the cleanup block can decrement the refcount of values in scope.
     ///
     /// ```no_run
@@ -532,23 +561,33 @@ impl<'ctx> Builder<'ctx> {
     ///     builder.build_resume(res);
     /// }
     /// ```
-    pub fn build_resume<V : BasicValue<'ctx>>(&self, value: V) -> InstructionValue<'ctx> {
+    pub fn build_resume<V: BasicValue<'ctx>>(&self, value: V) -> InstructionValue<'ctx> {
         let val = unsafe { LLVMBuildResume(self.builder, value.as_value_ref()) };
 
-        unsafe {
-            InstructionValue::new(val)
-        }
+        unsafe { InstructionValue::new(val) }
     }
 
     // REVIEW: Doesn't GEP work on array too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_gep(&self, ptr: PointerValue<'ctx>, ordered_indexes: &[IntValue<'ctx>], name: &str) -> PointerValue<'ctx> {
+    pub unsafe fn build_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        ordered_indexes: &[IntValue<'ctx>],
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = to_c_str(name);
 
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
-                                                                 .map(|val| val.as_value_ref())
-                                                                 .collect();
-        let value = LLVMBuildGEP(self.builder, ptr.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32, c_string.as_ptr());
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
+            .iter()
+            .map(|val| val.as_value_ref())
+            .collect();
+        let value = LLVMBuildGEP(
+            self.builder,
+            ptr.as_value_ref(),
+            index_values.as_mut_ptr(),
+            index_values.len() as u32,
+            c_string.as_ptr(),
+        );
 
         PointerValue::new(value)
     }
@@ -556,13 +595,25 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Doesn't GEP work on array too?
     // REVIEW: This could be merge in with build_gep via a in_bounds: bool param
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn build_in_bounds_gep(&self, ptr: PointerValue<'ctx>, ordered_indexes: &[IntValue<'ctx>], name: &str) -> PointerValue<'ctx> {
+    pub unsafe fn build_in_bounds_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        ordered_indexes: &[IntValue<'ctx>],
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = to_c_str(name);
 
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
-                                                                 .map(|val| val.as_value_ref())
-                                                                 .collect();
-        let value = LLVMBuildInBoundsGEP(self.builder, ptr.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32, c_string.as_ptr());
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
+            .iter()
+            .map(|val| val.as_value_ref())
+            .collect();
+        let value = LLVMBuildInBoundsGEP(
+            self.builder,
+            ptr.as_value_ref(),
+            index_values.as_mut_ptr(),
+            index_values.len() as u32,
+            c_string.as_ptr(),
+        );
 
         PointerValue::new(value)
     }
@@ -600,7 +651,12 @@ impl<'ctx> Builder<'ctx> {
     /// assert!(builder.build_struct_gep(struct_ptr, 1, "struct_gep").is_ok());
     /// assert!(builder.build_struct_gep(struct_ptr, 2, "struct_gep").is_err());
     /// ```
-    pub fn build_struct_gep(&self, ptr: PointerValue<'ctx>, index: u32, name: &str) -> Result<PointerValue<'ctx>, ()> {
+    pub fn build_struct_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        index: u32,
+        name: &str,
+    ) -> Result<PointerValue<'ctx>, ()> {
         let ptr_ty = ptr.get_type();
         let pointee_ty = ptr_ty.get_element_type();
 
@@ -615,11 +671,11 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let c_string = to_c_str(name);
-        let value = unsafe { LLVMBuildStructGEP(self.builder, ptr.as_value_ref(), index, c_string.as_ptr()) };
+        let value = unsafe {
+            LLVMBuildStructGEP(self.builder, ptr.as_value_ref(), index, c_string.as_ptr())
+        };
 
-        unsafe {
-            Ok(PointerValue::new(value))
-        }
+        unsafe { Ok(PointerValue::new(value)) }
     }
 
     /// Builds an instruction which calculates the difference of two pointers.
@@ -647,15 +703,23 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_ptr_diff(i32_ptr_param1, i32_ptr_param2, "diff");
     /// builder.build_return(None);
     /// ```
-    pub fn build_ptr_diff(&self, lhs_ptr: PointerValue<'ctx>, rhs_ptr: PointerValue<'ctx>, name: &str) -> IntValue<'ctx> {
+    pub fn build_ptr_diff(
+        &self,
+        lhs_ptr: PointerValue<'ctx>,
+        rhs_ptr: PointerValue<'ctx>,
+        name: &str,
+    ) -> IntValue<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildPtrDiff(self.builder, lhs_ptr.as_value_ref(), rhs_ptr.as_value_ref(), c_string.as_ptr())
+            LLVMBuildPtrDiff(
+                self.builder,
+                lhs_ptr.as_value_ref(),
+                rhs_ptr.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            IntValue::new(value)
-        }
+        unsafe { IntValue::new(value) }
     }
 
     // SubTypes: Maybe this should return PhiValue<T>? That way we could force incoming values to be of T::Value?
@@ -665,13 +729,9 @@ impl<'ctx> Builder<'ctx> {
     // REVIEW: Not sure if we can enforce the above somehow via types.
     pub fn build_phi<T: BasicType<'ctx>>(&self, type_: T, name: &str) -> PhiValue<'ctx> {
         let c_string = to_c_str(name);
-        let value = unsafe {
-            LLVMBuildPhi(self.builder, type_.as_type_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildPhi(self.builder, type_.as_type_ref(), c_string.as_ptr()) };
 
-        unsafe {
-            PhiValue::new(value)
-        }
+        unsafe { PhiValue::new(value) }
     }
 
     /// Builds a store instruction. It allows you to store a value of type `T` in a pointer to a type `T`.
@@ -699,14 +759,15 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_store(i32_ptr_param, i32_seven);
     /// builder.build_return(None);
     /// ```
-    pub fn build_store<V: BasicValue<'ctx>>(&self, ptr: PointerValue<'ctx>, value: V) -> InstructionValue<'ctx> {
-        let value = unsafe {
-            LLVMBuildStore(self.builder, value.as_value_ref(), ptr.as_value_ref())
-        };
+    pub fn build_store<V: BasicValue<'ctx>>(
+        &self,
+        ptr: PointerValue<'ctx>,
+        value: V,
+    ) -> InstructionValue<'ctx> {
+        let value =
+            unsafe { LLVMBuildStore(self.builder, value.as_value_ref(), ptr.as_value_ref()) };
 
-        unsafe {
-            InstructionValue::new(value)
-        }
+        unsafe { InstructionValue::new(value) }
     }
 
     /// Builds a load instruction. It allows you to retrieve a value of type `T` from a pointer to a type `T`.
@@ -736,37 +797,37 @@ impl<'ctx> Builder<'ctx> {
     /// ```
     pub fn build_load(&self, ptr: PointerValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
-        let value = unsafe {
-            LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
     // TODOC: Stack allocation
     pub fn build_alloca<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> PointerValue<'ctx> {
         let c_string = to_c_str(name);
-        let value = unsafe {
-            LLVMBuildAlloca(self.builder, ty.as_type_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildAlloca(self.builder, ty.as_type_ref(), c_string.as_ptr()) };
 
-        unsafe {
-            PointerValue::new(value)
-        }
+        unsafe { PointerValue::new(value) }
     }
 
     // TODOC: Stack allocation
-    pub fn build_array_alloca<T: BasicType<'ctx>>(&self, ty: T, size: IntValue<'ctx>, name: &str) -> PointerValue<'ctx> {
+    pub fn build_array_alloca<T: BasicType<'ctx>>(
+        &self,
+        ty: T,
+        size: IntValue<'ctx>,
+        name: &str,
+    ) -> PointerValue<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildArrayAlloca(self.builder, ty.as_type_ref(), size.as_value_ref(), c_string.as_ptr())
+            LLVMBuildArrayAlloca(
+                self.builder,
+                ty.as_type_ref(),
+                size.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            PointerValue::new(value)
-        }
+        unsafe { PointerValue::new(value) }
     }
 
     /// Build a [memcpy](https://llvm.org/docs/LangRef.html#llvm-memcpy-intrinsic) instruction.
@@ -805,9 +866,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        unsafe {
-            Ok(PointerValue::new(value))
-        }
+        unsafe { Ok(PointerValue::new(value)) }
     }
 
     /// Build a [memmove](http://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) instruction.
@@ -828,11 +887,15 @@ impl<'ctx> Builder<'ctx> {
         size: IntValue<'ctx>,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         if !is_alignment_ok(src_align_bytes) {
-            return Err("The src_align_bytes argument to build_memmove was not a power of 2 under 2^64.");
+            return Err(
+                "The src_align_bytes argument to build_memmove was not a power of 2 under 2^64.",
+            );
         }
 
         if !is_alignment_ok(dest_align_bytes) {
-            return Err("The dest_align_bytes argument to build_memmove was not a power of 2 under 2^64.");
+            return Err(
+                "The dest_align_bytes argument to build_memmove was not a power of 2 under 2^64.",
+            );
         }
 
         let value = unsafe {
@@ -846,13 +909,15 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        unsafe {
-            Ok(PointerValue::new(value))
-        }
+        unsafe { Ok(PointerValue::new(value)) }
     }
 
     // TODOC: Heap allocation
-    pub fn build_malloc<T: BasicType<'ctx>>(&self, ty: T, name: &str) -> Result<PointerValue<'ctx>, &'static str> {
+    pub fn build_malloc<T: BasicType<'ctx>>(
+        &self,
+        ty: T,
+        name: &str,
+    ) -> Result<PointerValue<'ctx>, &'static str> {
         // LLVMBulidMalloc segfaults if ty is unsized
         if !ty.is_sized() {
             return Err("Cannot build malloc call for an unsized type");
@@ -860,13 +925,9 @@ impl<'ctx> Builder<'ctx> {
 
         let c_string = to_c_str(name);
 
-        let value = unsafe {
-            LLVMBuildMalloc(self.builder, ty.as_type_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildMalloc(self.builder, ty.as_type_ref(), c_string.as_ptr()) };
 
-        unsafe {
-            Ok(PointerValue::new(value))
-        }
+        unsafe { Ok(PointerValue::new(value)) }
     }
 
     // TODOC: Heap allocation
@@ -874,7 +935,7 @@ impl<'ctx> Builder<'ctx> {
         &self,
         ty: T,
         size: IntValue<'ctx>,
-        name: &str
+        name: &str,
     ) -> Result<PointerValue<'ctx>, &'static str> {
         // LLVMBulidArrayMalloc segfaults if ty is unsized
         if !ty.is_sized() {
@@ -884,19 +945,20 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildArrayMalloc(self.builder, ty.as_type_ref(), size.as_value_ref(), c_string.as_ptr())
+            LLVMBuildArrayMalloc(
+                self.builder,
+                ty.as_type_ref(),
+                size.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            Ok(PointerValue::new(value))
-        }
+        unsafe { Ok(PointerValue::new(value)) }
     }
 
     // SubType: <P>(&self, ptr: PointerValue<P>) -> InstructionValue {
     pub fn build_free(&self, ptr: PointerValue<'ctx>) -> InstructionValue<'ctx> {
-        unsafe {
-            InstructionValue::new(LLVMBuildFree(self.builder, ptr.as_value_ref()))
-        }
+        unsafe { InstructionValue::new(LLVMBuildFree(self.builder, ptr.as_value_ref())) }
     }
 
     pub fn insert_instruction(&self, instruction: &InstructionValue<'ctx>, name: Option<&str>) {
@@ -905,9 +967,13 @@ impl<'ctx> Builder<'ctx> {
                 let c_string = to_c_str(name);
 
                 unsafe {
-                    LLVMInsertIntoBuilderWithName(self.builder, instruction.as_value_ref(), c_string.as_ptr())
+                    LLVMInsertIntoBuilderWithName(
+                        self.builder,
+                        instruction.as_value_ref(),
+                        c_string.as_ptr(),
+                    )
                 }
-            },
+            }
             None => unsafe {
                 LLVMInsertIntoBuilder(self.builder, instruction.as_value_ref());
             },
@@ -915,9 +981,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn get_insert_block(&self) -> Option<BasicBlock<'ctx>> {
-        unsafe {
-            BasicBlock::new(LLVMGetInsertBlock(self.builder))
-        }
+        unsafe { BasicBlock::new(LLVMGetInsertBlock(self.builder)) }
     }
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
@@ -927,7 +991,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildUDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildUDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -939,7 +1008,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -947,11 +1021,21 @@ impl<'ctx> Builder<'ctx> {
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
-    pub fn build_int_exact_signed_div<T: IntMathValue<'ctx>>(&self, lhs: T, rhs: T, name: &str) -> T {
+    pub fn build_int_exact_signed_div<T: IntMathValue<'ctx>>(
+        &self,
+        lhs: T,
+        rhs: T,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildExactSDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildExactSDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -963,12 +1047,16 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildURem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildURem(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
-
 
     // TODO: Possibly make this generic over sign via struct metadata or subtypes
     // SubType: <I>(&self, lhs: &IntValue<I>, rhs: &IntValue<I>, name: &str) -> IntValue<I> {
@@ -976,17 +1064,32 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildSRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSRem(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_s_extend<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+    pub fn build_int_s_extend<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildSExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildSExt(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1001,12 +1104,15 @@ impl<'ctx> Builder<'ctx> {
     ) -> PointerValue<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildAddrSpaceCast(self.builder, ptr_val.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildAddrSpaceCast(
+                self.builder,
+                ptr_val.as_value_ref(),
+                ptr_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            PointerValue::new(value)
-        }
+        unsafe { PointerValue::new(value) }
     }
 
     /// Builds a bitcast instruction. A bitcast reinterprets the bits of one value
@@ -1043,59 +1149,112 @@ impl<'ctx> Builder<'ctx> {
     {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildBitCast(self.builder, val.as_value_ref(), ty.as_type_ref(), c_string.as_ptr())
+            LLVMBuildBitCast(
+                self.builder,
+                val.as_value_ref(),
+                ty.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
-    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
+    pub fn build_int_s_extend_or_bit_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildSExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildSExtOrBitCast(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_z_extend<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = to_c_str(name);
+    pub fn build_int_z_extend<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = to_c_str(name);
 
-       let value = unsafe {
-            LLVMBuildZExt(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildZExt(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = to_c_str(name);
+    pub fn build_int_z_extend_or_bit_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = to_c_str(name);
 
-       let value = unsafe {
-            LLVMBuildZExtOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildZExtOrBitCast(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_truncate<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = to_c_str(name);
+    pub fn build_int_truncate<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = to_c_str(name);
 
-       let value = unsafe {
-            LLVMBuildTrunc(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildTrunc(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_int_truncate_or_bit_cast<T: IntMathValue<'ctx>>(&self, int_value: T, int_type: T::BaseType, name: &str) -> T {
-       let c_string = to_c_str(name);
+    pub fn build_int_truncate_or_bit_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int_value: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
+        let c_string = to_c_str(name);
 
-       let value = unsafe {
-            LLVMBuildTruncOrBitCast(self.builder, int_value.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        let value = unsafe {
+            LLVMBuildTruncOrBitCast(
+                self.builder,
+                int_value.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1105,7 +1264,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFRem(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFRem(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1121,7 +1285,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFPToUI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPToUI(
+                self.builder,
+                float.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
@@ -1136,7 +1305,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFPToSI(self.builder, float.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPToSI(
+                self.builder,
+                float.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
@@ -1152,7 +1326,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildUIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildUIToFP(
+                self.builder,
+                int.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
@@ -1167,48 +1346,93 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildSIToFP(self.builder, int.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildSIToFP(
+                self.builder,
+                int.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as IntMathType>::MathConvType as FloatMathType>::ValueType::new(value)
     }
 
-    pub fn build_float_trunc<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
+    pub fn build_float_trunc<T: FloatMathValue<'ctx>>(
+        &self,
+        float: T,
+        float_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFPTrunc(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPTrunc(
+                self.builder,
+                float.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_float_ext<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
+    pub fn build_float_ext<T: FloatMathValue<'ctx>>(
+        &self,
+        float: T,
+        float_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFPExt(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPExt(
+                self.builder,
+                float.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
-    pub fn build_float_cast<T: FloatMathValue<'ctx>>(&self, float: T, float_type: T::BaseType, name: &str) -> T {
+    pub fn build_float_cast<T: FloatMathValue<'ctx>>(
+        &self,
+        float: T,
+        float_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFPCast(self.builder, float.as_value_ref(), float_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildFPCast(
+                self.builder,
+                float.as_value_ref(),
+                float_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
     }
 
     // SubType: <L, R>(&self, lhs: &IntValue<L>, rhs: &IntType<R>, name: &str) -> IntValue<R> {
-    pub fn build_int_cast<T: IntMathValue<'ctx>>(&self, int: T, int_type: T::BaseType, name: &str) -> T {
+    pub fn build_int_cast<T: IntMathValue<'ctx>>(
+        &self,
+        int: T,
+        int_type: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildIntCast(self.builder, int.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildIntCast(
+                self.builder,
+                int.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1218,7 +1442,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFDiv(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFDiv(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1229,7 +1458,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1241,7 +1475,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildNSWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNSWAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1253,7 +1492,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildNUWAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNUWAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1264,7 +1508,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFAdd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFAdd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1275,7 +1524,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildXor(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildXor(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1286,7 +1540,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildAnd(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildAnd(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1297,7 +1556,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildOr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildOr(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1350,7 +1614,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildShl(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildShl(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1420,14 +1689,30 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&shift));
     /// ```
-    pub fn build_right_shift<T: IntMathValue<'ctx>>(&self, lhs: T, rhs: T, sign_extend: bool, name: &str) -> T {
+    pub fn build_right_shift<T: IntMathValue<'ctx>>(
+        &self,
+        lhs: T,
+        rhs: T,
+        sign_extend: bool,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
             if sign_extend {
-                LLVMBuildAShr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+                LLVMBuildAShr(
+                    self.builder,
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    c_string.as_ptr(),
+                )
             } else {
-                LLVMBuildLShr(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+                LLVMBuildLShr(
+                    self.builder,
+                    lhs.as_value_ref(),
+                    rhs.as_value_ref(),
+                    c_string.as_ptr(),
+                )
             }
         };
 
@@ -1439,7 +1724,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1450,7 +1740,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildNSWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNSWSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1462,7 +1757,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildNUWSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNUWSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1473,7 +1773,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFSub(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFSub(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1484,7 +1789,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1496,7 +1806,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildNSWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNSWMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1508,7 +1823,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildNUWMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildNUWMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1519,7 +1839,12 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFMul(
+                self.builder,
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1534,20 +1859,34 @@ impl<'ctx> Builder<'ctx> {
     ) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildCast(self.builder, op.into(), from_value.as_value_ref(), to_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildCast(
+                self.builder,
+                op.into(),
+                from_value.as_value_ref(),
+                to_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
     // SubType: <F, T>(&self, from: &PointerValue<F>, to: &PointerType<T>, name: &str) -> PointerValue<T> {
-    pub fn build_pointer_cast<T: PointerMathValue<'ctx>>(&self, from: T, to: T::BaseType, name: &str) -> T {
+    pub fn build_pointer_cast<T: PointerMathValue<'ctx>>(
+        &self,
+        from: T,
+        to: T::BaseType,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildPointerCast(self.builder, from.as_value_ref(), to.as_type_ref(), c_string.as_ptr())
+            LLVMBuildPointerCast(
+                self.builder,
+                from.as_value_ref(),
+                to.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1557,11 +1896,23 @@ impl<'ctx> Builder<'ctx> {
     // Note: we need a way to get an appropriate return type, since this method's return value
     // is always a bool (or vector of bools), not necessarily the same as the input value
     // See https://github.com/TheDan64/inkwell/pull/47#discussion_r197599297
-    pub fn build_int_compare<T: IntMathValue<'ctx>>(&self, op: IntPredicate, lhs: T, rhs: T, name: &str) -> T {
+    pub fn build_int_compare<T: IntMathValue<'ctx>>(
+        &self,
+        op: IntPredicate,
+        lhs: T,
+        rhs: T,
+        name: &str,
+    ) -> T {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildICmp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildICmp(
+                self.builder,
+                op.into(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         T::new(value)
@@ -1579,20 +1930,25 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildFCmp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr())
+            LLVMBuildFCmp(
+                self.builder,
+                op.into(),
+                lhs.as_value_ref(),
+                rhs.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as FloatMathType>::MathConvType as IntMathType>::ValueType::new(value)
     }
 
-    pub fn build_unconditional_branch(&self, destination_block: BasicBlock<'ctx>) -> InstructionValue<'ctx> {
-        let value = unsafe {
-            LLVMBuildBr(self.builder, destination_block.basic_block)
-        };
+    pub fn build_unconditional_branch(
+        &self,
+        destination_block: BasicBlock<'ctx>,
+    ) -> InstructionValue<'ctx> {
+        let value = unsafe { LLVMBuildBr(self.builder, destination_block.basic_block) };
 
-        unsafe {
-            InstructionValue::new(value)
-        }
+        unsafe { InstructionValue::new(value) }
     }
 
     pub fn build_conditional_branch(
@@ -1602,12 +1958,15 @@ impl<'ctx> Builder<'ctx> {
         else_block: BasicBlock<'ctx>,
     ) -> InstructionValue<'ctx> {
         let value = unsafe {
-            LLVMBuildCondBr(self.builder, comparison.as_value_ref(), then_block.basic_block, else_block.basic_block)
+            LLVMBuildCondBr(
+                self.builder,
+                comparison.as_value_ref(),
+                then_block.basic_block,
+                else_block.basic_block,
+            )
         };
 
-        unsafe {
-            InstructionValue::new(value)
-        }
+        unsafe { InstructionValue::new(value) }
     }
 
     pub fn build_indirect_branch<BV: BasicValue<'ctx>>(
@@ -1616,27 +1975,25 @@ impl<'ctx> Builder<'ctx> {
         destinations: &[BasicBlock<'ctx>],
     ) -> InstructionValue<'ctx> {
         let value = unsafe {
-            LLVMBuildIndirectBr(self.builder, address.as_value_ref(), destinations.len() as u32)
+            LLVMBuildIndirectBr(
+                self.builder,
+                address.as_value_ref(),
+                destinations.len() as u32,
+            )
         };
 
         for destination in destinations {
-            unsafe {
-                LLVMAddDestination(value, destination.basic_block)
-            }
+            unsafe { LLVMAddDestination(value, destination.basic_block) }
         }
 
-        unsafe {
-            InstructionValue::new(value)
-        }
+        unsafe { InstructionValue::new(value) }
     }
 
     // SubType: <I>(&self, value: &IntValue<I>, name) -> IntValue<I> {
     pub fn build_int_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = to_c_str(name);
 
-        let value = unsafe {
-            LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1646,9 +2003,8 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_nsw_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = to_c_str(name);
 
-        let value = unsafe {
-            LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value =
+            unsafe { LLVMBuildNSWNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1657,9 +2013,8 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_int_nuw_neg<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = to_c_str(name);
 
-        let value = unsafe {
-            LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value =
+            unsafe { LLVMBuildNUWNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1668,9 +2023,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_float_neg<T: FloatMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = to_c_str(name);
 
-        let value = unsafe {
-            LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildFNeg(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1679,9 +2032,7 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_not<T: IntMathValue<'ctx>>(&self, value: T, name: &str) -> T {
         let c_string = to_c_str(name);
 
-        let value = unsafe {
-            LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMBuildNot(self.builder, value.as_value_ref(), c_string.as_ptr()) };
 
         T::new(value)
     }
@@ -1690,14 +2041,16 @@ impl<'ctx> Builder<'ctx> {
     // It'd be great if we could get the BB from the instruction behind the scenes
     pub fn position_at(&self, basic_block: BasicBlock<'ctx>, instruction: &InstructionValue<'ctx>) {
         unsafe {
-            LLVMPositionBuilder(self.builder, basic_block.basic_block, instruction.as_value_ref())
+            LLVMPositionBuilder(
+                self.builder,
+                basic_block.basic_block,
+                instruction.as_value_ref(),
+            )
         }
     }
 
     pub fn position_before(&self, instruction: &InstructionValue<'ctx>) {
-        unsafe {
-            LLVMPositionBuilderBefore(self.builder, instruction.as_value_ref())
-        }
+        unsafe { LLVMPositionBuilderBefore(self.builder, instruction.as_value_ref()) }
     }
 
     pub fn position_at_end(&self, basic_block: BasicBlock<'ctx>) {
@@ -1765,9 +2118,7 @@ impl<'ctx> Builder<'ctx> {
             LLVMBuildExtractValue(self.builder, agg.as_value_ref(), index, c_string.as_ptr())
         };
 
-        unsafe {
-            Some(BasicValueEnum::new(value))
-        }
+        unsafe { Some(BasicValueEnum::new(value)) }
     }
 
     /// Builds an insert value instruction which inserts a `BasicValue` into a struct
@@ -1803,7 +2154,13 @@ impl<'ctx> Builder<'ctx> {
     /// assert!(builder.build_insert_value(array, const_int3, 2, "insert").is_some());
     /// assert!(builder.build_insert_value(array, const_int3, 3, "insert").is_none());
     /// ```
-    pub fn build_insert_value<AV, BV>(&self, agg: AV, value: BV, index: u32, name: &str) -> Option<AggregateValueEnum<'ctx>>
+    pub fn build_insert_value<AV, BV>(
+        &self,
+        agg: AV,
+        value: BV,
+        index: u32,
+        name: &str,
+    ) -> Option<AggregateValueEnum<'ctx>>
     where
         AV: AggregateValue<'ctx>,
         BV: BasicValue<'ctx>,
@@ -1820,12 +2177,16 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildInsertValue(self.builder, agg.as_value_ref(), value.as_value_ref(), index, c_string.as_ptr())
+            LLVMBuildInsertValue(
+                self.builder,
+                agg.as_value_ref(),
+                value.as_value_ref(),
+                index,
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            Some(AggregateValueEnum::new(value))
-        }
+        unsafe { Some(AggregateValueEnum::new(value)) }
     }
 
     /// Builds an extract element instruction which extracts a `BasicValueEnum`
@@ -1852,16 +2213,24 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&extracted));
     /// ```
-    pub fn build_extract_element(&self, vector: VectorValue<'ctx>, index: IntValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
+    pub fn build_extract_element(
+        &self,
+        vector: VectorValue<'ctx>,
+        index: IntValue<'ctx>,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildExtractElement(self.builder, vector.as_value_ref(), index.as_value_ref(), c_string.as_ptr())
+            LLVMBuildExtractElement(
+                self.builder,
+                vector.as_value_ref(),
+                index.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
     /// Builds an insert element instruction which inserts a `BasicValue` into a vector
@@ -1899,66 +2268,83 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildInsertElement(self.builder, vector.as_value_ref(), element.as_value_ref(), index.as_value_ref(), c_string.as_ptr())
+            LLVMBuildInsertElement(
+                self.builder,
+                vector.as_value_ref(),
+                element.as_value_ref(),
+                index.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            VectorValue::new(value)
-        }
+        unsafe { VectorValue::new(value) }
     }
 
     pub fn build_unreachable(&self) -> InstructionValue<'ctx> {
-        let val = unsafe {
-            LLVMBuildUnreachable(self.builder)
-        };
+        let val = unsafe { LLVMBuildUnreachable(self.builder) };
 
-        unsafe {
-            InstructionValue::new(val)
-        }
+        unsafe { InstructionValue::new(val) }
     }
 
     // REVIEW: Not sure if this should return InstructionValue or an actual value
     // TODO: Better name for num?
-    pub fn build_fence(&self, atomic_ordering: AtomicOrdering, num: i32, name: &str) -> InstructionValue<'ctx> {
+    pub fn build_fence(
+        &self,
+        atomic_ordering: AtomicOrdering,
+        num: i32,
+        name: &str,
+    ) -> InstructionValue<'ctx> {
         let c_string = to_c_str(name);
 
-        let val = unsafe {
-            LLVMBuildFence(self.builder, atomic_ordering.into(), num, c_string.as_ptr())
-        };
+        let val =
+            unsafe { LLVMBuildFence(self.builder, atomic_ordering.into(), num, c_string.as_ptr()) };
 
-        unsafe {
-            InstructionValue::new(val)
-        }
+        unsafe { InstructionValue::new(val) }
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_null<T: PointerMathValue<'ctx>>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
+    pub fn build_is_null<T: PointerMathValue<'ctx>>(
+        &self,
+        ptr: T,
+        name: &str,
+    ) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
         let c_string = to_c_str(name);
 
-        let val = unsafe {
-            LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
-        };
+        let val = unsafe { LLVMBuildIsNull(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <P>(&self, ptr: &PointerValue<P>, name) -> IntValue<bool> {
-    pub fn build_is_not_null<T: PointerMathValue<'ctx>>(&self, ptr: T, name: &str) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
+    pub fn build_is_not_null<T: PointerMathValue<'ctx>>(
+        &self,
+        ptr: T,
+        name: &str,
+    ) -> <<T::BaseType as PointerMathType<'ctx>>::PtrConvType as IntMathType<'ctx>>::ValueType {
         let c_string = to_c_str(name);
 
-        let val = unsafe {
-            LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr())
-        };
+        let val =
+            unsafe { LLVMBuildIsNotNull(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(val)
     }
 
     // SubType: <I, P>(&self, int: &IntValue<I>, ptr_type: &PointerType<P>, name) -> PointerValue<P> {
-    pub fn build_int_to_ptr<T: IntMathValue<'ctx>>(&self, int: T, ptr_type: <T::BaseType as IntMathType<'ctx>>::PtrConvType, name: &str) -> <<T::BaseType as IntMathType<'ctx>>::PtrConvType as PointerMathType<'ctx>>::ValueType {
+    pub fn build_int_to_ptr<T: IntMathValue<'ctx>>(
+        &self,
+        int: T,
+        ptr_type: <T::BaseType as IntMathType<'ctx>>::PtrConvType,
+        name: &str,
+    ) -> <<T::BaseType as IntMathType<'ctx>>::PtrConvType as PointerMathType<'ctx>>::ValueType {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildIntToPtr(self.builder, int.as_value_ref(), ptr_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildIntToPtr(
+                self.builder,
+                int.as_value_ref(),
+                ptr_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as IntMathType>::PtrConvType as PointerMathType>::ValueType::new(value)
@@ -1974,54 +2360,77 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildPtrToInt(self.builder, ptr.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+            LLVMBuildPtrToInt(
+                self.builder,
+                ptr.as_value_ref(),
+                int_type.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
         <<T::BaseType as PointerMathType>::PtrConvType as IntMathType>::ValueType::new(value)
     }
 
     pub fn clear_insertion_position(&self) {
-        unsafe {
-            LLVMClearInsertionPosition(self.builder)
-        }
+        unsafe { LLVMClearInsertionPosition(self.builder) }
     }
 
     // REVIEW: Returning InstructionValue is the safe move here; but if the value means something
     // (IE the result of the switch) it should probably return BasicValueEnum?
     // SubTypes: I think value and case values must be the same subtype (maybe). Case value might need to be constants
-    pub fn build_switch(&self, value: IntValue<'ctx>, else_block: BasicBlock<'ctx>, cases: &[(IntValue<'ctx>, BasicBlock<'ctx>)]) -> InstructionValue<'ctx> {
+    pub fn build_switch(
+        &self,
+        value: IntValue<'ctx>,
+        else_block: BasicBlock<'ctx>,
+        cases: &[(IntValue<'ctx>, BasicBlock<'ctx>)],
+    ) -> InstructionValue<'ctx> {
         let switch_value = unsafe {
-            LLVMBuildSwitch(self.builder, value.as_value_ref(), else_block.basic_block, cases.len() as u32)
+            LLVMBuildSwitch(
+                self.builder,
+                value.as_value_ref(),
+                else_block.basic_block,
+                cases.len() as u32,
+            )
         };
 
         for &(value, basic_block) in cases {
-            unsafe {
-                LLVMAddCase(switch_value, value.as_value_ref(), basic_block.basic_block)
-            }
+            unsafe { LLVMAddCase(switch_value, value.as_value_ref(), basic_block.basic_block) }
         }
 
-        unsafe {
-            InstructionValue::new(switch_value)
-        }
+        unsafe { InstructionValue::new(switch_value) }
     }
 
     // SubTypes: condition can only be IntValue<bool> or VectorValue<IntValue<Bool>>
-    pub fn build_select<BV: BasicValue<'ctx>, IMV: IntMathValue<'ctx>>(&self, condition: IMV, then: BV, else_: BV, name: &str) -> BasicValueEnum<'ctx> {
+    pub fn build_select<BV: BasicValue<'ctx>, IMV: IntMathValue<'ctx>>(
+        &self,
+        condition: IMV,
+        then: BV,
+        else_: BV,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildSelect(self.builder, condition.as_value_ref(), then.as_value_ref(), else_.as_value_ref(), c_string.as_ptr())
+            LLVMBuildSelect(
+                self.builder,
+                condition.as_value_ref(),
+                then.as_value_ref(),
+                else_.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
     // The unsafety of this function should be fixable with subtypes. See GH #32
     pub unsafe fn build_global_string(&self, value: &str, name: &str) -> GlobalValue<'ctx> {
         let c_string_value = to_c_str(value);
         let c_string_name = to_c_str(name);
-        let value = LLVMBuildGlobalString(self.builder, c_string_value.as_ptr(), c_string_name.as_ptr());
+        let value = LLVMBuildGlobalString(
+            self.builder,
+            c_string_value.as_ptr(),
+            c_string_name.as_ptr(),
+        );
 
         GlobalValue::new(value)
     }
@@ -2032,39 +2441,59 @@ impl<'ctx> Builder<'ctx> {
         let c_string_value = to_c_str(value);
         let c_string_name = to_c_str(name);
         let value = unsafe {
-            LLVMBuildGlobalStringPtr(self.builder, c_string_value.as_ptr(), c_string_name.as_ptr())
+            LLVMBuildGlobalStringPtr(
+                self.builder,
+                c_string_value.as_ptr(),
+                c_string_name.as_ptr(),
+            )
         };
 
-        unsafe {
-            GlobalValue::new(value)
-        }
+        unsafe { GlobalValue::new(value) }
     }
 
     // REVIEW: Do we need to constrain types here? subtypes?
-    pub fn build_shuffle_vector(&self, left: VectorValue<'ctx>, right: VectorValue<'ctx>, mask: VectorValue<'ctx>, name: &str) -> VectorValue<'ctx> {
+    pub fn build_shuffle_vector(
+        &self,
+        left: VectorValue<'ctx>,
+        right: VectorValue<'ctx>,
+        mask: VectorValue<'ctx>,
+        name: &str,
+    ) -> VectorValue<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe {
-            LLVMBuildShuffleVector(self.builder, left.as_value_ref(), right.as_value_ref(), mask.as_value_ref(), c_string.as_ptr())
+            LLVMBuildShuffleVector(
+                self.builder,
+                left.as_value_ref(),
+                right.as_value_ref(),
+                mask.as_value_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            VectorValue::new(value)
-        }
+        unsafe { VectorValue::new(value) }
     }
 
     // REVIEW: Is return type correct?
     // SubTypes: I think this should be type: BT -> BT::Value
     // https://llvm.org/docs/LangRef.html#i-va-arg
-    pub fn build_va_arg<BT: BasicType<'ctx>>(&self, list: PointerValue<'ctx>, type_: BT, name: &str) -> BasicValueEnum<'ctx> {
+    pub fn build_va_arg<BT: BasicType<'ctx>>(
+        &self,
+        list: PointerValue<'ctx>,
+        type_: BT,
+        name: &str,
+    ) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
-            LLVMBuildVAArg(self.builder, list.as_value_ref(), type_.as_type_ref(), c_string.as_ptr())
+            LLVMBuildVAArg(
+                self.builder,
+                list.as_value_ref(),
+                type_.as_type_ref(),
+                c_string.as_ptr(),
+            )
         };
 
-        unsafe {
-            BasicValueEnum::new(value)
-        }
+        unsafe { BasicValueEnum::new(value) }
     }
 
     /// Builds an atomicrmw instruction. It allows you to atomically modify memory.
@@ -2100,8 +2529,9 @@ impl<'ctx> Builder<'ctx> {
         // TODO: add support for fadd, fsub and xchg on floating point types in LLVM 9+.
 
         // "The type of ‘<value>’ must be an integer type whose bit width is a power of two greater than or equal to eight and less than or equal to a target-specific size limit. The type of the ‘<pointer>’ operand must be a pointer to that type." -- https://releases.llvm.org/3.6.2/docs/LangRef.html#atomicrmw-instruction
-        if value.get_type().get_bit_width() < 8 ||
-           !value.get_type().get_bit_width().is_power_of_two() {
+        if value.get_type().get_bit_width() < 8
+            || !value.get_type().get_bit_width().is_power_of_two()
+        {
             return Err("The bitwidth of value must be a power of 2 and greater than 8.");
         }
         if ptr.get_type().get_element_type() != value.get_type().into() {
@@ -2109,12 +2539,17 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let val = unsafe {
-            LLVMBuildAtomicRMW(self.builder, op.into(), ptr.as_value_ref(), value.as_value_ref(), ordering.into(), false as i32)
+            LLVMBuildAtomicRMW(
+                self.builder,
+                op.into(),
+                ptr.as_value_ref(),
+                value.as_value_ref(),
+                ordering.into(),
+                false as i32,
+            )
         };
 
-        unsafe {
-            Ok(IntValue::new(val))
-        }
+        unsafe { Ok(IntValue::new(val)) }
     }
 
     /// Builds a cmpxchg instruction. It allows you to atomically compare and replace memory.
@@ -2174,12 +2609,18 @@ impl<'ctx> Builder<'ctx> {
         }
 
         let val = unsafe {
-            LLVMBuildAtomicCmpXchg(self.builder, ptr.as_value_ref(), cmp.as_value_ref(), new.as_value_ref(), success.into(), failure.into(), false as i32)
+            LLVMBuildAtomicCmpXchg(
+                self.builder,
+                ptr.as_value_ref(),
+                cmp.as_value_ref(),
+                new.as_value_ref(),
+                success.into(),
+                failure.into(),
+                false as i32,
+            )
         };
 
-        unsafe {
-            Ok(StructValue::new(val))
-        }
+        unsafe { Ok(StructValue::new(val)) }
     }
 
     /// Set the debug info source location of the instruction currently pointed at by the builder
@@ -2202,37 +2643,25 @@ impl<'ctx> Builder<'ctx> {
     /// Get the debug info source location of the instruction currently pointed at by the builder,
     /// if available.
     #[llvm_versions(7.0..=latest)]
-    pub fn get_current_debug_location(
-        &self,
-    ) -> Option<DILocation<'ctx>>
-     {
+    pub fn get_current_debug_location(&self) -> Option<DILocation<'ctx>> {
         use llvm_sys::core::LLVMGetCurrentDebugLocation;
         use llvm_sys::core::LLVMValueAsMetadata;
-        let metadata_ref = unsafe {
-            LLVMGetCurrentDebugLocation(
-                self.builder,
-            )
-        };
+        let metadata_ref = unsafe { LLVMGetCurrentDebugLocation(self.builder) };
         if metadata_ref.is_null() {
             return None;
         }
         Some(DILocation {
-            metadata_ref: unsafe { LLVMValueAsMetadata(metadata_ref)},
+            metadata_ref: unsafe { LLVMValueAsMetadata(metadata_ref) },
             _marker: PhantomData,
         })
     }
 
     /// Unset the debug info source location of the instruction currently pointed at by the
     /// builder. If there isn't any debug info, this is a no-op.
-    pub fn unset_current_debug_location(
-        &self,
-    ) {
+    pub fn unset_current_debug_location(&self) {
         use llvm_sys::core::LLVMSetCurrentDebugLocation;
         unsafe {
-            LLVMSetCurrentDebugLocation(
-                self.builder,
-                std::ptr::null_mut(),
-            );
+            LLVMSetCurrentDebugLocation(self.builder, std::ptr::null_mut());
         }
     }
 }
@@ -2245,7 +2674,6 @@ fn is_alignment_ok(align: u32) -> bool {
     // See https://github.com/TheDan64/inkwell/issues/168
     align > 0 && align.is_power_of_two() && (align as f64).log2() < 64.0
 }
-
 
 impl Drop for Builder<'_> {
     fn drop(&mut self) {

--- a/src/comdat.rs
+++ b/src/comdat.rs
@@ -2,7 +2,9 @@
 // https://llvm.org/doxygen/IR_2Comdat_8h_source.html
 // https://stackoverflow.com/questions/1834597/what-is-the-comdat-section-used-for
 
-use llvm_sys::comdat::{LLVMComdatSelectionKind, LLVMSetComdatSelectionKind, LLVMGetComdatSelectionKind};
+use llvm_sys::comdat::{
+    LLVMComdatSelectionKind, LLVMGetComdatSelectionKind, LLVMSetComdatSelectionKind,
+};
 use llvm_sys::prelude::LLVMComdatRef;
 
 #[llvm_enum(LLVMComdatSelectionKind)]
@@ -39,17 +41,13 @@ impl Comdat {
 
     /// Gets what kind of `Comdat` this is.
     pub fn get_selection_kind(self) -> ComdatSelectionKind {
-        let kind_ptr = unsafe {
-            LLVMGetComdatSelectionKind(self.0)
-        };
+        let kind_ptr = unsafe { LLVMGetComdatSelectionKind(self.0) };
 
         ComdatSelectionKind::new(kind_ptr)
     }
 
     /// Sets what kind of `Comdat` this should be.
     pub fn set_selection_kind(self, kind: ComdatSelectionKind) {
-        unsafe {
-            LLVMSetComdatSelectionKind(self.0, kind.into())
-        }
+        unsafe { LLVMSetComdatSelectionKind(self.0, kind.into()) }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,22 +1,31 @@
 //! A `Context` is an opaque owner and manager of core global data.
 
-use llvm_sys::core::{LLVMAppendBasicBlockInContext, LLVMContextCreate, LLVMContextDispose, LLVMCreateBuilderInContext, LLVMDoubleTypeInContext, LLVMFloatTypeInContext, LLVMFP128TypeInContext, LLVMInsertBasicBlockInContext, LLVMInt16TypeInContext, LLVMInt1TypeInContext, LLVMInt32TypeInContext, LLVMInt64TypeInContext, LLVMInt8TypeInContext, LLVMIntTypeInContext, LLVMModuleCreateWithNameInContext, LLVMStructCreateNamed, LLVMStructTypeInContext, LLVMVoidTypeInContext, LLVMHalfTypeInContext, LLVMGetGlobalContext, LLVMPPCFP128TypeInContext, LLVMConstStructInContext, LLVMMDNodeInContext, LLVMMDStringInContext, LLVMGetMDKindIDInContext, LLVMX86FP80TypeInContext, LLVMConstStringInContext, LLVMContextSetDiagnosticHandler};
-#[llvm_versions(3.9..=latest)]
-use llvm_sys::core::{LLVMCreateEnumAttribute, LLVMCreateStringAttribute};
-#[llvm_versions(3.6..7.0)]
-use llvm_sys::core::{LLVMConstInlineAsm};
-#[llvm_versions(7.0..=latest)]
-use llvm_sys::core::{LLVMGetInlineAsm};
 #[llvm_versions(7.0..=latest)]
 use crate::InlineAsmDialect;
-use llvm_sys::prelude::{LLVMContextRef, LLVMTypeRef, LLVMValueRef, LLVMDiagnosticInfoRef};
-use llvm_sys::ir_reader::LLVMParseIRInContext;
-use llvm_sys::target::{LLVMIntPtrTypeForASInContext, LLVMIntPtrTypeInContext};
 use libc::c_void;
+#[llvm_versions(3.6..7.0)]
+use llvm_sys::core::LLVMConstInlineAsm;
+#[llvm_versions(7.0..=latest)]
+use llvm_sys::core::LLVMGetInlineAsm;
+use llvm_sys::core::{
+    LLVMAppendBasicBlockInContext, LLVMConstStringInContext, LLVMConstStructInContext,
+    LLVMContextCreate, LLVMContextDispose, LLVMContextSetDiagnosticHandler,
+    LLVMCreateBuilderInContext, LLVMDoubleTypeInContext, LLVMFP128TypeInContext,
+    LLVMFloatTypeInContext, LLVMGetGlobalContext, LLVMGetMDKindIDInContext, LLVMHalfTypeInContext,
+    LLVMInsertBasicBlockInContext, LLVMInt16TypeInContext, LLVMInt1TypeInContext,
+    LLVMInt32TypeInContext, LLVMInt64TypeInContext, LLVMInt8TypeInContext, LLVMIntTypeInContext,
+    LLVMMDNodeInContext, LLVMMDStringInContext, LLVMModuleCreateWithNameInContext,
+    LLVMPPCFP128TypeInContext, LLVMStructCreateNamed, LLVMStructTypeInContext,
+    LLVMVoidTypeInContext, LLVMX86FP80TypeInContext,
+};
+#[llvm_versions(3.9..=latest)]
+use llvm_sys::core::{LLVMCreateEnumAttribute, LLVMCreateStringAttribute};
+use llvm_sys::ir_reader::LLVMParseIRInContext;
+use llvm_sys::prelude::{LLVMContextRef, LLVMDiagnosticInfoRef, LLVMTypeRef, LLVMValueRef};
+use llvm_sys::target::{LLVMIntPtrTypeForASInContext, LLVMIntPtrTypeInContext};
 use once_cell::sync::Lazy;
 use parking_lot::{Mutex, MutexGuard};
 
-use crate::AddressSpace;
 #[llvm_versions(3.9..=latest)]
 use crate::attributes::Attribute;
 use crate::basic_block::BasicBlock;
@@ -25,8 +34,14 @@ use crate::memory_buffer::MemoryBuffer;
 use crate::module::Module;
 use crate::support::{to_c_str, LLVMString};
 use crate::targets::TargetData;
-use crate::types::{BasicTypeEnum, FloatType, IntType, StructType, VoidType, AsTypeRef, FunctionType};
-use crate::values::{AsValueRef, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, StructValue, MetadataValue, VectorValue, PointerValue};
+use crate::types::{
+    AsTypeRef, BasicTypeEnum, FloatType, FunctionType, IntType, StructType, VoidType,
+};
+use crate::values::{
+    AsValueRef, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, MetadataValue, PointerValue,
+    StructValue, VectorValue,
+};
+use crate::AddressSpace;
 
 use std::marker::PhantomData;
 use std::mem::{forget, ManuallyDrop};
@@ -41,9 +56,8 @@ use std::thread_local;
 // This is still technically unsafe because another program in the same process
 // could also be accessing the global context via the C API. `get_global` has been
 // marked unsafe for this reason. Iff this isn't the case then this should be fully safe.
-static GLOBAL_CTX: Lazy<Mutex<Context>> = Lazy::new(|| unsafe {
-    Mutex::new(Context::new(LLVMGetGlobalContext()))
-});
+static GLOBAL_CTX: Lazy<Mutex<Context>> =
+    Lazy::new(|| unsafe { Mutex::new(Context::new(LLVMGetGlobalContext())) });
 
 thread_local! {
     pub(crate) static GLOBAL_CTX_LOCK: Lazy<MutexGuard<'static, Context>> = Lazy::new(|| {
@@ -66,9 +80,7 @@ impl Context {
     pub(crate) unsafe fn new(context: LLVMContextRef) -> Self {
         assert!(!context.is_null());
 
-        Context {
-            context,
-        }
+        Context { context }
     }
 
     /// Creates a new `Context`.
@@ -81,9 +93,7 @@ impl Context {
     /// let context = Context::create();
     /// ```
     pub fn create() -> Self {
-        unsafe {
-            Context::new(LLVMContextCreate())
-        }
+        unsafe { Context::new(LLVMContextCreate()) }
     }
 
     /// Gets a `Mutex<Context>` which points to the global context singleton.
@@ -121,9 +131,7 @@ impl Context {
     /// let builder = context.create_builder();
     /// ```
     pub fn create_builder(&self) -> Builder {
-        unsafe {
-            Builder::new(LLVMCreateBuilderInContext(self.context))
-        }
+        unsafe { Builder::new(LLVMCreateBuilderInContext(self.context)) }
     }
 
     /// Creates a new `Module` for a `Context`.
@@ -140,7 +148,10 @@ impl Context {
         let c_string = to_c_str(name);
 
         unsafe {
-            Module::new(LLVMModuleCreateWithNameInContext(c_string.as_ptr(), self.context))
+            Module::new(LLVMModuleCreateWithNameInContext(
+                c_string.as_ptr(),
+                self.context,
+            ))
         }
     }
 
@@ -175,7 +186,12 @@ impl Context {
         let mut err_str = ptr::null_mut();
 
         let code = unsafe {
-            LLVMParseIRInContext(self.context, memory_buffer.memory_buffer, &mut module, &mut err_str)
+            LLVMParseIRInContext(
+                self.context,
+                memory_buffer.memory_buffer,
+                &mut module,
+                &mut err_str,
+            )
         };
 
         forget(memory_buffer);
@@ -186,9 +202,7 @@ impl Context {
             }
         }
 
-        unsafe {
-            Err(LLVMString::new(err_str))
-        }
+        unsafe { Err(LLVMString::new(err_str)) }
     }
 
     /// Creates a inline asm function pointer.
@@ -215,7 +229,15 @@ impl Context {
     /// builder.build_call(callable_value, params, "exit");
     /// builder.build_return(None);
     #[llvm_versions(7.0..=latest)]
-    pub fn create_inline_asm(&self, ty: FunctionType, mut assembly: String, mut constraints: String, sideeffects: bool, alignstack: bool, dialect: Option<InlineAsmDialect>) -> PointerValue {
+    pub fn create_inline_asm(
+        &self,
+        ty: FunctionType,
+        mut assembly: String,
+        mut constraints: String,
+        sideeffects: bool,
+        alignstack: bool,
+        dialect: Option<InlineAsmDialect>,
+    ) -> PointerValue {
         let value = unsafe {
             LLVMGetInlineAsm(
                 ty.as_type_ref(),
@@ -225,13 +247,11 @@ impl Context {
                 constraints.len(),
                 sideeffects as i32,
                 alignstack as i32,
-                dialect.unwrap_or(InlineAsmDialect::ATT).into()
+                dialect.unwrap_or(InlineAsmDialect::ATT).into(),
             )
         };
 
-        unsafe {
-            PointerValue::new(value)
-        }
+        unsafe { PointerValue::new(value) }
     }
     /// Creates a inline asm function pointer.
     ///
@@ -257,20 +277,25 @@ impl Context {
     /// builder.build_call(callable_value, params, "exit");
     /// builder.build_return(None);
     #[llvm_versions(3.6..7.0)]
-    pub fn create_inline_asm(&self, ty: FunctionType, assembly: String, constraints: String, sideeffects: bool, alignstack: bool) -> PointerValue {
+    pub fn create_inline_asm(
+        &self,
+        ty: FunctionType,
+        assembly: String,
+        constraints: String,
+        sideeffects: bool,
+        alignstack: bool,
+    ) -> PointerValue {
         let value = unsafe {
             LLVMConstInlineAsm(
                 ty.as_type_ref(),
                 assembly.as_ptr() as *const ::libc::c_char,
                 constraints.as_ptr() as *const ::libc::c_char,
                 sideeffects as i32,
-                alignstack as i32
+                alignstack as i32,
             )
         };
 
-        unsafe {
-            PointerValue::new(value)
-        }
+        unsafe { PointerValue::new(value) }
     }
 
     /// Gets the `VoidType`. It will be assigned the current context.
@@ -286,9 +311,7 @@ impl Context {
     /// assert_eq!(*void_type.get_context(), context);
     /// ```
     pub fn void_type(&self) -> VoidType {
-        unsafe {
-            VoidType::new(LLVMVoidTypeInContext(self.context))
-        }
+        unsafe { VoidType::new(LLVMVoidTypeInContext(self.context)) }
     }
 
     /// Gets the `IntType` representing 1 bit width. It will be assigned the current context.
@@ -305,9 +328,7 @@ impl Context {
     /// assert_eq!(*bool_type.get_context(), context);
     /// ```
     pub fn bool_type(&self) -> IntType {
-        unsafe {
-            IntType::new(LLVMInt1TypeInContext(self.context))
-        }
+        unsafe { IntType::new(LLVMInt1TypeInContext(self.context)) }
     }
 
     /// Gets the `IntType` representing 8 bit width. It will be assigned the current context.
@@ -324,9 +345,7 @@ impl Context {
     /// assert_eq!(*i8_type.get_context(), context);
     /// ```
     pub fn i8_type(&self) -> IntType {
-        unsafe {
-            IntType::new(LLVMInt8TypeInContext(self.context))
-        }
+        unsafe { IntType::new(LLVMInt8TypeInContext(self.context)) }
     }
 
     /// Gets the `IntType` representing 16 bit width. It will be assigned the current context.
@@ -343,9 +362,7 @@ impl Context {
     /// assert_eq!(*i16_type.get_context(), context);
     /// ```
     pub fn i16_type(&self) -> IntType {
-        unsafe {
-            IntType::new(LLVMInt16TypeInContext(self.context))
-        }
+        unsafe { IntType::new(LLVMInt16TypeInContext(self.context)) }
     }
 
     /// Gets the `IntType` representing 32 bit width. It will be assigned the current context.
@@ -362,9 +379,7 @@ impl Context {
     /// assert_eq!(*i32_type.get_context(), context);
     /// ```
     pub fn i32_type(&self) -> IntType {
-        unsafe {
-            IntType::new(LLVMInt32TypeInContext(self.context))
-        }
+        unsafe { IntType::new(LLVMInt32TypeInContext(self.context)) }
     }
 
     /// Gets the `IntType` representing 64 bit width. It will be assigned the current context.
@@ -381,9 +396,7 @@ impl Context {
     /// assert_eq!(*i64_type.get_context(), context);
     /// ```
     pub fn i64_type(&self) -> IntType {
-        unsafe {
-            IntType::new(LLVMInt64TypeInContext(self.context))
-        }
+        unsafe { IntType::new(LLVMInt64TypeInContext(self.context)) }
     }
 
     /// Gets the `IntType` representing 128 bit width. It will be assigned the current context.
@@ -420,9 +433,7 @@ impl Context {
     /// assert_eq!(*i42_type.get_context(), context);
     /// ```
     pub fn custom_width_int_type(&self, bits: u32) -> IntType {
-        unsafe {
-            IntType::new(LLVMIntTypeInContext(self.context, bits))
-        }
+        unsafe { IntType::new(LLVMIntTypeInContext(self.context, bits)) }
     }
 
     /// Gets the `IntType` representing a bit width of a pointer. It will be assigned the referenced context.
@@ -458,9 +469,7 @@ impl Context {
             None => unsafe { LLVMIntPtrTypeInContext(self.context, target_data.target_data) },
         };
 
-        unsafe {
-            IntType::new(int_type_ptr)
-        }
+        unsafe { IntType::new(int_type_ptr) }
     }
 
     /// Gets the `FloatType` representing a 16 bit width. It will be assigned the current context.
@@ -477,9 +486,7 @@ impl Context {
     /// assert_eq!(*f16_type.get_context(), context);
     /// ```
     pub fn f16_type(&self) -> FloatType {
-        unsafe {
-            FloatType::new(LLVMHalfTypeInContext(self.context))
-        }
+        unsafe { FloatType::new(LLVMHalfTypeInContext(self.context)) }
     }
 
     /// Gets the `FloatType` representing a 32 bit width. It will be assigned the current context.
@@ -496,9 +503,7 @@ impl Context {
     /// assert_eq!(*f32_type.get_context(), context);
     /// ```
     pub fn f32_type<'ctx>(&'ctx self) -> FloatType<'ctx> {
-        unsafe {
-            FloatType::new(LLVMFloatTypeInContext(self.context))
-        }
+        unsafe { FloatType::new(LLVMFloatTypeInContext(self.context)) }
     }
 
     /// Gets the `FloatType` representing a 64 bit width. It will be assigned the current context.
@@ -515,9 +520,7 @@ impl Context {
     /// assert_eq!(*f64_type.get_context(), context);
     /// ```
     pub fn f64_type(&self) -> FloatType {
-        unsafe {
-            FloatType::new(LLVMDoubleTypeInContext(self.context))
-        }
+        unsafe { FloatType::new(LLVMDoubleTypeInContext(self.context)) }
     }
 
     /// Gets the `FloatType` representing a 80 bit width. It will be assigned the current context.
@@ -534,9 +537,7 @@ impl Context {
     /// assert_eq!(*x86_f80_type.get_context(), context);
     /// ```
     pub fn x86_f80_type(&self) -> FloatType {
-        unsafe {
-            FloatType::new(LLVMX86FP80TypeInContext(self.context))
-        }
+        unsafe { FloatType::new(LLVMX86FP80TypeInContext(self.context)) }
     }
 
     /// Gets the `FloatType` representing a 128 bit width. It will be assigned the current context.
@@ -554,9 +555,7 @@ impl Context {
     /// ```
     // IEEE 754-2008’s binary128 floats according to https://internals.rust-lang.org/t/pre-rfc-introduction-of-half-and-quadruple-precision-floats-f16-and-f128/7521
     pub fn f128_type(&self) -> FloatType {
-        unsafe {
-            FloatType::new(LLVMFP128TypeInContext(self.context))
-        }
+        unsafe { FloatType::new(LLVMFP128TypeInContext(self.context)) }
     }
 
     /// Gets the `FloatType` representing a 128 bit width. It will be assigned the current context.
@@ -576,9 +575,7 @@ impl Context {
     /// ```
     // Two 64 bits according to https://internals.rust-lang.org/t/pre-rfc-introduction-of-half-and-quadruple-precision-floats-f16-and-f128/7521
     pub fn ppc_f128_type(&self) -> FloatType {
-        unsafe {
-            FloatType::new(LLVMPPCFP128TypeInContext(self.context))
-        }
+        unsafe { FloatType::new(LLVMPPCFP128TypeInContext(self.context)) }
     }
 
     /// Creates a `StructType` definiton from heterogeneous types in the current `Context`.
@@ -597,11 +594,15 @@ impl Context {
     /// ```
     // REVIEW: AnyType but VoidType? FunctionType?
     pub fn struct_type(&self, field_types: &[BasicTypeEnum], packed: bool) -> StructType {
-        let mut field_types: Vec<LLVMTypeRef> = field_types.iter()
-                                                           .map(|val| val.as_type_ref())
-                                                           .collect();
+        let mut field_types: Vec<LLVMTypeRef> =
+            field_types.iter().map(|val| val.as_type_ref()).collect();
         unsafe {
-            StructType::new(LLVMStructTypeInContext(self.context, field_types.as_mut_ptr(), field_types.len() as u32, packed as i32))
+            StructType::new(LLVMStructTypeInContext(
+                self.context,
+                field_types.as_mut_ptr(),
+                field_types.len() as u32,
+                packed as i32,
+            ))
         }
     }
 
@@ -622,9 +623,7 @@ impl Context {
     pub fn opaque_struct_type(&self, name: &str) -> StructType {
         let c_string = to_c_str(name);
 
-        unsafe {
-            StructType::new(LLVMStructCreateNamed(self.context, c_string.as_ptr()))
-        }
+        unsafe { StructType::new(LLVMStructCreateNamed(self.context, c_string.as_ptr())) }
     }
 
     /// Creates a constant `StructValue` from constant values.
@@ -644,11 +643,14 @@ impl Context {
     /// assert_eq!(const_struct.get_type().get_field_types(), &[i16_type.into(), f32_type.into()]);
     /// ```
     pub fn const_struct(&self, values: &[BasicValueEnum], packed: bool) -> StructValue {
-        let mut args: Vec<LLVMValueRef> = values.iter()
-                                                .map(|val| val.as_value_ref())
-                                                .collect();
+        let mut args: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
-            StructValue::new(LLVMConstStructInContext(self.context, args.as_mut_ptr(), args.len() as u32, packed as i32))
+            StructValue::new(LLVMConstStructInContext(
+                self.context,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                packed as i32,
+            ))
         }
     }
 
@@ -678,8 +680,12 @@ impl Context {
         let c_string = to_c_str(name);
 
         unsafe {
-            BasicBlock::new(LLVMAppendBasicBlockInContext(self.context, function.as_value_ref(), c_string.as_ptr()))
-                .expect("Appending basic block should never fail")
+            BasicBlock::new(LLVMAppendBasicBlockInContext(
+                self.context,
+                function.as_value_ref(),
+                c_string.as_ptr(),
+            ))
+            .expect("Appending basic block should never fail")
         }
     }
 
@@ -715,7 +721,7 @@ impl Context {
                 let parent_fn = basic_block.get_parent().unwrap();
 
                 self.append_basic_block(parent_fn, name)
-            },
+            }
         }
     }
 
@@ -745,8 +751,12 @@ impl Context {
         let c_string = to_c_str(name);
 
         unsafe {
-            BasicBlock::new(LLVMInsertBasicBlockInContext(self.context, basic_block.basic_block, c_string.as_ptr()))
-                .expect("Prepending basic block should never fail")
+            BasicBlock::new(LLVMInsertBasicBlockInContext(
+                self.context,
+                basic_block.basic_block,
+                c_string.as_ptr(),
+            ))
+            .expect("Prepending basic block should never fail")
         }
     }
 
@@ -783,11 +793,14 @@ impl Context {
     // REVIEW: Maybe more helpful to beginners to call this metadata_tuple?
     // REVIEW: Seems to be unassgned to anything
     pub fn metadata_node(&self, values: &[BasicMetadataValueEnum]) -> MetadataValue {
-        let mut tuple_values: Vec<LLVMValueRef> = values.iter()
-                                                        .map(|val| val.as_value_ref())
-                                                        .collect();
+        let mut tuple_values: Vec<LLVMValueRef> =
+            values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
-            MetadataValue::new(LLVMMDNodeInContext(self.context, tuple_values.as_mut_ptr(), tuple_values.len() as u32))
+            MetadataValue::new(LLVMMDNodeInContext(
+                self.context,
+                tuple_values.as_mut_ptr(),
+                tuple_values.len() as u32,
+            ))
         }
     }
 
@@ -823,7 +836,11 @@ impl Context {
         let c_string = to_c_str(string);
 
         unsafe {
-            MetadataValue::new(LLVMMDStringInContext(self.context, c_string.as_ptr(), string.len() as u32))
+            MetadataValue::new(LLVMMDStringInContext(
+                self.context,
+                c_string.as_ptr(),
+                string.len() as u32,
+            ))
         }
     }
 
@@ -846,7 +863,11 @@ impl Context {
     /// ```
     pub fn get_kind_id(&self, key: &str) -> u32 {
         unsafe {
-            LLVMGetMDKindIDInContext(self.context, key.as_ptr() as *const ::libc::c_char, key.len() as u32)
+            LLVMGetMDKindIDInContext(
+                self.context,
+                key.as_ptr() as *const ::libc::c_char,
+                key.len() as u32,
+            )
         }
     }
 
@@ -875,9 +896,7 @@ impl Context {
     /// ```
     #[llvm_versions(3.9..=latest)]
     pub fn create_enum_attribute(&self, kind_id: u32, val: u64) -> Attribute {
-        unsafe {
-            Attribute::new(LLVMCreateEnumAttribute(self.context, kind_id, val))
-        }
+        unsafe { Attribute::new(LLVMCreateEnumAttribute(self.context, kind_id, val)) }
     }
 
     /// Creates a string `Attribute` in this `Context`.
@@ -930,10 +949,12 @@ impl Context {
         }
     }
 
-    pub(crate) fn set_diagnostic_handler(&self, handler: extern "C" fn (LLVMDiagnosticInfoRef, *mut c_void), void_ptr: *mut c_void) {
-        unsafe {
-            LLVMContextSetDiagnosticHandler(self.context, Some(handler), void_ptr)
-        }
+    pub(crate) fn set_diagnostic_handler(
+        &self,
+        handler: extern "C" fn(LLVMDiagnosticInfoRef, *mut c_void),
+        void_ptr: *mut c_void,
+    ) {
+        unsafe { LLVMContextSetDiagnosticHandler(self.context, Some(handler), void_ptr) }
     }
 }
 

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -1,5 +1,11 @@
 use libc::c_int;
-use llvm_sys::execution_engine::{LLVMGetExecutionEngineTargetData, LLVMExecutionEngineRef, LLVMRunFunction, LLVMRunFunctionAsMain, LLVMDisposeExecutionEngine, LLVMGetFunctionAddress, LLVMAddModule, LLVMFindFunction, LLVMLinkInMCJIT, LLVMLinkInInterpreter, LLVMRemoveModule, LLVMGenericValueRef, LLVMFreeMachineCodeForFunction, LLVMAddGlobalMapping, LLVMRunStaticConstructors, LLVMRunStaticDestructors};
+use llvm_sys::execution_engine::{
+    LLVMAddGlobalMapping, LLVMAddModule, LLVMDisposeExecutionEngine, LLVMExecutionEngineRef,
+    LLVMFindFunction, LLVMFreeMachineCodeForFunction, LLVMGenericValueRef,
+    LLVMGetExecutionEngineTargetData, LLVMGetFunctionAddress, LLVMLinkInInterpreter,
+    LLVMLinkInMCJIT, LLVMRemoveModule, LLVMRunFunction, LLVMRunFunctionAsMain,
+    LLVMRunStaticConstructors, LLVMRunStaticDestructors,
+};
 
 use crate::context::Context;
 use crate::module::Module;
@@ -8,11 +14,11 @@ use crate::targets::TargetData;
 use crate::values::{AnyValue, AsValueRef, FunctionValue, GenericValue};
 
 use std::error::Error;
-use std::rc::Rc;
-use std::ops::Deref;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::marker::PhantomData;
-use std::mem::{forget, transmute_copy, size_of, MaybeUninit};
+use std::mem::{forget, size_of, transmute_copy, MaybeUninit};
+use std::ops::Deref;
+use std::rc::Rc;
 
 static EE_INNER_PANIC: &str = "ExecutionEngineInner should exist until Drop";
 
@@ -27,7 +33,9 @@ impl Error for FunctionLookupError {}
 impl FunctionLookupError {
     fn as_str(&self) -> &str {
         match self {
-            FunctionLookupError::JITNotEnabled => "ExecutionEngine does not have JIT functionality enabled",
+            FunctionLookupError::JITNotEnabled => {
+                "ExecutionEngine does not have JIT functionality enabled"
+            }
             FunctionLookupError::FunctionNotFound => "Function not found in ExecutionEngine",
         }
     }
@@ -62,8 +70,12 @@ impl RemoveModuleError {
     fn as_str(&self) -> &str {
         match self {
             RemoveModuleError::ModuleNotOwned => "Module is not owned by an Execution Engine",
-            RemoveModuleError::IncorrectModuleOwner => "Module is not owned by this Execution Engine",
-            RemoveModuleError::LLVMError(string) => string.to_str().unwrap_or("LLVMError with invalid unicode"),
+            RemoveModuleError::IncorrectModuleOwner => {
+                "Module is not owned by this Execution Engine"
+            }
+            RemoveModuleError::LLVMError(string) => {
+                string.to_str().unwrap_or("LLVMError with invalid unicode")
+            }
         }
     }
 }
@@ -90,10 +102,7 @@ pub struct ExecutionEngine<'ctx> {
 }
 
 impl<'ctx> ExecutionEngine<'ctx> {
-    pub(crate) unsafe fn new(
-        execution_engine: Rc<LLVMExecutionEngineRef>,
-        jit_mode: bool,
-    ) -> Self {
+    pub(crate) unsafe fn new(execution_engine: Rc<LLVMExecutionEngineRef>, jit_mode: bool) -> Self {
         assert!(!execution_engine.is_null());
 
         // REVIEW: Will we have to do this for LLVMGetExecutionEngineTargetMachine too?
@@ -118,9 +127,7 @@ impl<'ctx> ExecutionEngine<'ctx> {
     /// This function probably doesn't need to be called, but is here due to
     /// linking(?) requirements. Bad things happen if we don't provide it.
     pub fn link_in_mc_jit() {
-        unsafe {
-            LLVMLinkInMCJIT()
-        }
+        unsafe { LLVMLinkInMCJIT() }
     }
 
     /// This function probably doesn't need to be called, but is here due to
@@ -174,7 +181,11 @@ impl<'ctx> ExecutionEngine<'ctx> {
     /// ```
     pub fn add_global_mapping(&self, value: &dyn AnyValue<'ctx>, addr: usize) {
         unsafe {
-            LLVMAddGlobalMapping(self.execution_engine_inner(), value.as_value_ref(), addr as *mut _)
+            LLVMAddGlobalMapping(
+                self.execution_engine_inner(),
+                value.as_value_ref(),
+                addr as *mut _,
+            )
         }
     }
 
@@ -196,9 +207,7 @@ impl<'ctx> ExecutionEngine<'ctx> {
     /// assert!(ee.add_module(&module).is_err());
     /// ```
     pub fn add_module(&self, module: &Module<'ctx>) -> Result<(), ()> {
-        unsafe {
-            LLVMAddModule(self.execution_engine_inner(), module.module.get())
-        }
+        unsafe { LLVMAddModule(self.execution_engine_inner(), module.module.get()) }
 
         if module.owned_by_ee.borrow().is_some() {
             return Err(());
@@ -211,22 +220,30 @@ impl<'ctx> ExecutionEngine<'ctx> {
 
     pub fn remove_module(&self, module: &Module<'ctx>) -> Result<(), RemoveModuleError> {
         match *module.owned_by_ee.borrow() {
-            Some(ref ee) if ee.execution_engine_inner() != self.execution_engine_inner() =>
-                return Err(RemoveModuleError::IncorrectModuleOwner),
+            Some(ref ee) if ee.execution_engine_inner() != self.execution_engine_inner() => {
+                return Err(RemoveModuleError::IncorrectModuleOwner)
+            }
             None => return Err(RemoveModuleError::ModuleNotOwned),
-            _ => ()
+            _ => (),
         }
 
         let mut new_module = MaybeUninit::uninit();
         let mut err_string = MaybeUninit::uninit();
 
         let code = unsafe {
-            LLVMRemoveModule(self.execution_engine_inner(), module.module.get(), new_module.as_mut_ptr(), err_string.as_mut_ptr())
+            LLVMRemoveModule(
+                self.execution_engine_inner(),
+                module.module.get(),
+                new_module.as_mut_ptr(),
+                err_string.as_mut_ptr(),
+            )
         };
 
         if code == 1 {
             unsafe {
-                return Err(RemoveModuleError::LLVMError(LLVMString::new(err_string.assume_init())));
+                return Err(RemoveModuleError::LLVMError(LLVMString::new(
+                    err_string.assume_init(),
+                )));
             }
         }
 
@@ -295,7 +312,10 @@ impl<'ctx> ExecutionEngine<'ctx> {
     /// method *may* invalidate the function pointer.
     ///
     /// [`UnsafeFunctionPointer`]: trait.UnsafeFunctionPointer.html
-    pub unsafe fn get_function<F>(&self, fn_name: &str) -> Result<JitFunction<'ctx, F>, FunctionLookupError>
+    pub unsafe fn get_function<F>(
+        &self,
+        fn_name: &str,
+    ) -> Result<JitFunction<'ctx, F>, FunctionLookupError>
     where
         F: UnsafeFunctionPointer,
     {
@@ -305,8 +325,11 @@ impl<'ctx> ExecutionEngine<'ctx> {
 
         let address = self.get_function_address(fn_name)?;
 
-        assert_eq!(size_of::<F>(), size_of::<usize>(),
-            "The type `F` must have the same size as a function pointer");
+        assert_eq!(
+            size_of::<F>(),
+            size_of::<usize>(),
+            "The type `F` must have the same size as a function pointer"
+        );
 
         let execution_engine = self.execution_engine.as_ref().expect(EE_INNER_PANIC);
 
@@ -324,13 +347,17 @@ impl<'ctx> ExecutionEngine<'ctx> {
     pub fn get_function_address(&self, fn_name: &str) -> Result<usize, FunctionLookupError> {
         // LLVMGetFunctionAddress segfaults in llvm 5.0 -> 8.0 when fn_name doesn't exist. This is a workaround
         // to see if it exists and avoid the segfault when it doesn't
-        #[cfg(any(feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0"))]
+        #[cfg(any(
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0"
+        ))]
         self.get_function_value(fn_name)?;
 
         let c_string = to_c_str(fn_name);
-        let address = unsafe {
-            LLVMGetFunctionAddress(self.execution_engine_inner(), c_string.as_ptr())
-        };
+        let address =
+            unsafe { LLVMGetFunctionAddress(self.execution_engine_inner(), c_string.as_ptr()) };
 
         // REVIEW: Can also return 0 if no targets are initialized.
         // One option might be to set a (thread local?) global to true if any at all of the targets have been
@@ -346,14 +373,19 @@ impl<'ctx> ExecutionEngine<'ctx> {
     // REVIEW: Not sure if an EE's target data can change.. if so we might want to update the value
     // when making this call
     pub fn get_target_data(&self) -> &TargetData {
-        self.target_data.as_ref().expect("TargetData should always exist until Drop")
+        self.target_data
+            .as_ref()
+            .expect("TargetData should always exist until Drop")
     }
 
     // REVIEW: Can also find nothing if no targeting is initialized. Maybe best to
     // do have a global flag for anything initialized. Catch is that it must be initialized
     // before EE is created
     // REVIEW: Should FunctionValue lifetime be tied to self not 'ctx?
-    pub fn get_function_value(&self, fn_name: &str) -> Result<FunctionValue<'ctx>, FunctionLookupError> {
+    pub fn get_function_value(
+        &self,
+        fn_name: &str,
+    ) -> Result<FunctionValue<'ctx>, FunctionLookupError> {
         if !self.jit_mode {
             return Err(FunctionLookupError::JITNotEnabled);
         }
@@ -362,13 +394,18 @@ impl<'ctx> ExecutionEngine<'ctx> {
         let mut function = MaybeUninit::uninit();
 
         let code = unsafe {
-            LLVMFindFunction(self.execution_engine_inner(), c_string.as_ptr(), function.as_mut_ptr())
+            LLVMFindFunction(
+                self.execution_engine_inner(),
+                c_string.as_ptr(),
+                function.as_mut_ptr(),
+            )
         };
 
         if code == 0 {
             return unsafe {
-                FunctionValue::new(function.assume_init()).ok_or(FunctionLookupError::FunctionNotFound)
-            }
+                FunctionValue::new(function.assume_init())
+                    .ok_or(FunctionLookupError::FunctionNotFound)
+            };
         };
 
         Err(FunctionLookupError::FunctionNotFound)
@@ -376,12 +413,19 @@ impl<'ctx> ExecutionEngine<'ctx> {
 
     // TODOC: Marked as unsafe because input function could very well do something unsafe. It's up to the caller
     // to ensure that doesn't happen by defining their function correctly.
-    pub unsafe fn run_function(&self, function: FunctionValue<'ctx>, args: &[&GenericValue<'ctx>]) -> GenericValue<'ctx> {
-        let mut args: Vec<LLVMGenericValueRef> = args.iter()
-                                                     .map(|val| val.generic_value)
-                                                     .collect();
+    pub unsafe fn run_function(
+        &self,
+        function: FunctionValue<'ctx>,
+        args: &[&GenericValue<'ctx>],
+    ) -> GenericValue<'ctx> {
+        let mut args: Vec<LLVMGenericValueRef> = args.iter().map(|val| val.generic_value).collect();
 
-        let value = LLVMRunFunction(self.execution_engine_inner(), function.as_value_ref(), args.len() as u32, args.as_mut_ptr()); // REVIEW: usize to u32 ok??
+        let value = LLVMRunFunction(
+            self.execution_engine_inner(),
+            function.as_value_ref(),
+            args.len() as u32,
+            args.as_mut_ptr(),
+        ); // REVIEW: usize to u32 ok??
 
         GenericValue::new(value)
     }
@@ -389,13 +433,23 @@ impl<'ctx> ExecutionEngine<'ctx> {
     // TODOC: Marked as unsafe because input function could very well do something unsafe. It's up to the caller
     // to ensure that doesn't happen by defining their function correctly.
     // SubType: Only for JIT EEs?
-    pub unsafe fn run_function_as_main(&self, function: FunctionValue<'ctx>, args: &[&str]) -> c_int {
+    pub unsafe fn run_function_as_main(
+        &self,
+        function: FunctionValue<'ctx>,
+        args: &[&str],
+    ) -> c_int {
         let cstring_args: Vec<_> = args.iter().map(|&arg| to_c_str(arg)).collect();
         let raw_args: Vec<*const _> = cstring_args.iter().map(|arg| arg.as_ptr()).collect();
 
         let environment_variables = vec![]; // TODO: Support envp. Likely needs to be null terminated
 
-        LLVMRunFunctionAsMain(self.execution_engine_inner(), function.as_value_ref(), raw_args.len() as u32, raw_args.as_ptr(), environment_variables.as_ptr()) // REVIEW: usize to u32 cast ok??
+        LLVMRunFunctionAsMain(
+            self.execution_engine_inner(),
+            function.as_value_ref(),
+            raw_args.len() as u32,
+            raw_args.as_ptr(),
+            environment_variables.as_ptr(),
+        ) // REVIEW: usize to u32 cast ok??
     }
 
     pub fn free_fn_machine_code(&self, function: FunctionValue<'ctx>) {
@@ -406,16 +460,12 @@ impl<'ctx> ExecutionEngine<'ctx> {
 
     // REVIEW: Is this actually safe?
     pub fn run_static_constructors(&self) {
-        unsafe {
-            LLVMRunStaticConstructors(self.execution_engine_inner())
-        }
+        unsafe { LLVMRunStaticConstructors(self.execution_engine_inner()) }
     }
 
     // REVIEW: Is this actually safe? Can you double destruct/free?
     pub fn run_static_destructors(&self) {
-        unsafe {
-            LLVMRunStaticDestructors(self.execution_engine_inner())
-        }
+        unsafe { LLVMRunStaticDestructors(self.execution_engine_inner()) }
     }
 }
 
@@ -440,9 +490,7 @@ impl Clone for ExecutionEngine<'_> {
     fn clone(&self) -> Self {
         let execution_engine_rc = self.execution_engine_rc().clone();
 
-        unsafe {
-            ExecutionEngine::new(execution_engine_rc, self.jit_mode)
-        }
+        unsafe { ExecutionEngine::new(execution_engine_rc, self.jit_mode) }
     }
 }
 
@@ -478,9 +526,7 @@ pub struct JitFunction<'ctx, F> {
 
 impl<F> Debug for JitFunction<'_, F> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_tuple("JitFunction")
-            .field(&"<unnamed>")
-            .finish()
+        f.debug_tuple("JitFunction").field(&"<unnamed>").finish()
     }
 }
 
@@ -524,17 +570,26 @@ macro_rules! impl_unsafe_fn {
 
 impl_unsafe_fn!(A, B, C, D, E, F, G, H, I, J, K, L, M);
 
-#[cfg(all(feature = "experimental", not(any(feature = "llvm3-6", feature = "llvm3-7"))))]
+#[cfg(all(
+    feature = "experimental",
+    not(any(feature = "llvm3-6", feature = "llvm3-7"))
+))]
 pub mod experimental {
-    use llvm_sys::error::{LLVMErrorRef, LLVMGetErrorTypeId, LLVMConsumeError, LLVMGetErrorMessage, LLVMErrorTypeId};
-    use llvm_sys::orc::{LLVMOrcCreateInstance, LLVMOrcDisposeInstance, LLVMOrcJITStackRef, LLVMOrcAddEagerlyCompiledIR, LLVMOrcAddLazilyCompiledIR, LLVMOrcGetErrorMsg, LLVMOrcGetMangledSymbol, LLVMOrcDisposeMangledSymbol};
+    use llvm_sys::error::{
+        LLVMConsumeError, LLVMErrorRef, LLVMErrorTypeId, LLVMGetErrorMessage, LLVMGetErrorTypeId,
+    };
+    use llvm_sys::orc::{
+        LLVMOrcAddEagerlyCompiledIR, LLVMOrcAddLazilyCompiledIR, LLVMOrcCreateInstance,
+        LLVMOrcDisposeInstance, LLVMOrcDisposeMangledSymbol, LLVMOrcGetErrorMsg,
+        LLVMOrcGetMangledSymbol, LLVMOrcJITStackRef,
+    };
 
     use crate::module::Module;
     use crate::support::to_c_str;
     use crate::targets::TargetMachine;
 
-    use std::mem::MaybeUninit;
     use std::ffi::{CStr, CString};
+    use std::mem::MaybeUninit;
     use std::ops::Deref;
 
     #[derive(Debug)]
@@ -544,17 +599,13 @@ pub mod experimental {
         type Target = CStr;
 
         fn deref(&self) -> &CStr {
-            unsafe {
-                CStr::from_ptr(self.0)
-            }
+            unsafe { CStr::from_ptr(self.0) }
         }
     }
 
     impl Drop for MangledSymbol {
         fn drop(&mut self) {
-            unsafe {
-                LLVMOrcDisposeMangledSymbol(self.0)
-            }
+            unsafe { LLVMOrcDisposeMangledSymbol(self.0) }
         }
     }
 
@@ -563,10 +614,9 @@ pub mod experimental {
 
     impl LLVMError {
         // Null type id == success
-        pub fn get_type_id(&self) -> LLVMErrorTypeId { // FIXME: Don't expose LLVMErrorTypeId
-            unsafe {
-                LLVMGetErrorTypeId(self.0)
-            }
+        pub fn get_type_id(&self) -> LLVMErrorTypeId {
+            // FIXME: Don't expose LLVMErrorTypeId
+            unsafe { LLVMGetErrorTypeId(self.0) }
         }
     }
 
@@ -582,9 +632,7 @@ pub mod experimental {
 
     impl Drop for LLVMError {
         fn drop(&mut self) {
-            unsafe {
-                LLVMConsumeError(self.0)
-            }
+            unsafe { LLVMConsumeError(self.0) }
         }
     }
 
@@ -594,9 +642,7 @@ pub mod experimental {
 
     impl Orc {
         pub fn create(target_machine: TargetMachine) -> Self {
-            let stack_ref = unsafe {
-                LLVMOrcCreateInstance(target_machine.target_machine)
-            };
+            let stack_ref = unsafe { LLVMOrcCreateInstance(target_machine.target_machine) };
 
             Orc(stack_ref)
         }
@@ -620,16 +666,16 @@ pub mod experimental {
                 panic!("Needs to be optional")
             }
 
-            unsafe {
-                CStr::from_ptr(err_str)
-            }
+            unsafe { CStr::from_ptr(err_str) }
         }
 
         pub fn get_mangled_symbol(&self, symbol: &str) -> MangledSymbol {
             let mut mangled_symbol = MaybeUninit::uninit();
             let c_symbol = to_c_str(symbol);
 
-            unsafe { LLVMOrcGetMangledSymbol(self.0, mangled_symbol.as_mut_ptr(), c_symbol.as_ptr()) };
+            unsafe {
+                LLVMOrcGetMangledSymbol(self.0, mangled_symbol.as_mut_ptr(), c_symbol.as_ptr())
+            };
 
             MangledSymbol(unsafe { mangled_symbol.assume_init() })
         }
@@ -639,29 +685,29 @@ pub mod experimental {
         fn drop(&mut self) {
             // REVIEW: This returns an LLVMErrorRef, not sure what we can do with it...
             // print to stderr maybe?
-            LLVMError(unsafe {
-                LLVMOrcDisposeInstance(self.0)
-            });
+            LLVMError(unsafe { LLVMOrcDisposeInstance(self.0) });
         }
     }
 
     #[test]
     fn test_mangled_str() {
-        use crate::OptimizationLevel;
         use crate::targets::{CodeModel, InitializationConfig, RelocMode, Target};
+        use crate::OptimizationLevel;
 
         Target::initialize_native(&InitializationConfig::default()).unwrap();
 
         let target_triple = TargetMachine::get_default_triple();
         let target = Target::from_triple(&target_triple).unwrap();
-        let target_machine = target.create_target_machine(
-            &target_triple,
-            &"",
-            &"",
-            OptimizationLevel::None,
-            RelocMode::Default,
-            CodeModel::Default,
-        ).unwrap();
+        let target_machine = target
+            .create_target_machine(
+                &target_triple,
+                &"",
+                &"",
+                OptimizationLevel::None,
+                RelocMode::Default,
+                CodeModel::Default,
+            )
+            .unwrap();
         let orc = Orc::create(target_machine);
 
         assert_eq!(orc.get_error().to_str().unwrap(), "");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,31 @@ pub mod support;
 #[deny(missing_docs)]
 pub mod attributes;
 #[deny(missing_docs)]
-#[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-              feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
-pub mod comdat;
-#[deny(missing_docs)]
 pub mod basic_block;
 pub mod builder;
 #[deny(missing_docs)]
+#[cfg(not(any(
+    feature = "llvm3-6",
+    feature = "llvm3-7",
+    feature = "llvm3-8",
+    feature = "llvm3-9",
+    feature = "llvm4-0",
+    feature = "llvm5-0",
+    feature = "llvm6-0"
+)))]
+pub mod comdat;
+#[deny(missing_docs)]
 pub mod context;
 pub mod data_layout;
-#[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+#[cfg(not(any(
+    feature = "llvm3-6",
+    feature = "llvm3-7",
+    feature = "llvm3-8",
+    feature = "llvm3-9",
+    feature = "llvm4-0",
+    feature = "llvm5-0",
+    feature = "llvm6-0"
+)))]
 pub mod debug_info;
 pub mod execution_engine;
 pub mod memory_buffer;
@@ -41,34 +56,37 @@ pub mod types;
 pub mod values;
 
 // Boilerplate to select a desired llvm_sys version at compile & link time.
-#[cfg(feature="llvm3-6")]
-extern crate llvm_sys_36 as llvm_sys;
-#[cfg(feature="llvm3-7")]
-extern crate llvm_sys_37 as llvm_sys;
-#[cfg(feature="llvm3-8")]
-extern crate llvm_sys_38 as llvm_sys;
-#[cfg(feature="llvm3-9")]
-extern crate llvm_sys_39 as llvm_sys;
-#[cfg(feature="llvm4-0")]
-extern crate llvm_sys_40 as llvm_sys;
-#[cfg(feature="llvm5-0")]
-extern crate llvm_sys_50 as llvm_sys;
-#[cfg(feature="llvm6-0")]
-extern crate llvm_sys_60 as llvm_sys;
-#[cfg(feature="llvm7-0")]
-extern crate llvm_sys_70 as llvm_sys;
-#[cfg(feature="llvm8-0")]
-extern crate llvm_sys_80 as llvm_sys;
-#[cfg(feature="llvm9-0")]
-extern crate llvm_sys_90 as llvm_sys;
-#[cfg(feature="llvm10-0")]
+#[cfg(feature = "llvm10-0")]
 extern crate llvm_sys_100 as llvm_sys;
-#[cfg(feature="llvm11-0")]
+#[cfg(feature = "llvm11-0")]
 extern crate llvm_sys_110 as llvm_sys;
-#[cfg(feature="llvm12-0")]
+#[cfg(feature = "llvm12-0")]
 extern crate llvm_sys_120 as llvm_sys;
+#[cfg(feature = "llvm3-6")]
+extern crate llvm_sys_36 as llvm_sys;
+#[cfg(feature = "llvm3-7")]
+extern crate llvm_sys_37 as llvm_sys;
+#[cfg(feature = "llvm3-8")]
+extern crate llvm_sys_38 as llvm_sys;
+#[cfg(feature = "llvm3-9")]
+extern crate llvm_sys_39 as llvm_sys;
+#[cfg(feature = "llvm4-0")]
+extern crate llvm_sys_40 as llvm_sys;
+#[cfg(feature = "llvm5-0")]
+extern crate llvm_sys_50 as llvm_sys;
+#[cfg(feature = "llvm6-0")]
+extern crate llvm_sys_60 as llvm_sys;
+#[cfg(feature = "llvm7-0")]
+extern crate llvm_sys_70 as llvm_sys;
+#[cfg(feature = "llvm8-0")]
+extern crate llvm_sys_80 as llvm_sys;
+#[cfg(feature = "llvm9-0")]
+extern crate llvm_sys_90 as llvm_sys;
 
-use llvm_sys::{LLVMIntPredicate, LLVMRealPredicate, LLVMVisibility, LLVMThreadLocalMode, LLVMDLLStorageClass, LLVMAtomicOrdering, LLVMAtomicRMWBinOp};
+use llvm_sys::{
+    LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMDLLStorageClass, LLVMIntPredicate,
+    LLVMRealPredicate, LLVMThreadLocalMode, LLVMVisibility,
+};
 
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMInlineAsmDialect;
@@ -104,7 +122,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0"}
+assert_unique_used_features! {"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///
@@ -113,10 +131,10 @@ assert_unique_used_features!{"llvm3-6", "llvm3-7", "llvm3-8", "llvm3-9", "llvm4-
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum AddressSpace {
     Generic = 0,
-    Global  = 1,
-    Shared  = 3,
-    Const   = 4,
-    Local   = 5,
+    Global = 1,
+    Shared = 3,
+    Const = 4,
+    Local = 5,
 }
 
 impl TryFrom<u32> for AddressSpace {
@@ -339,9 +357,9 @@ pub enum AtomicRMWBinOp {
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum OptimizationLevel {
-    None       = 0,
-    Less       = 1,
-    Default    = 2,
+    None = 0,
+    Less = 1,
+    Default = 2,
     Aggressive = 3,
 }
 
@@ -381,17 +399,25 @@ pub enum ThreadLocalMode {
 impl ThreadLocalMode {
     pub(crate) fn new(thread_local_mode: LLVMThreadLocalMode) -> Option<Self> {
         match thread_local_mode {
-            LLVMThreadLocalMode::LLVMGeneralDynamicTLSModel => Some(ThreadLocalMode::GeneralDynamicTLSModel),
-            LLVMThreadLocalMode::LLVMLocalDynamicTLSModel => Some(ThreadLocalMode::LocalDynamicTLSModel),
-            LLVMThreadLocalMode::LLVMInitialExecTLSModel => Some(ThreadLocalMode::InitialExecTLSModel),
+            LLVMThreadLocalMode::LLVMGeneralDynamicTLSModel => {
+                Some(ThreadLocalMode::GeneralDynamicTLSModel)
+            }
+            LLVMThreadLocalMode::LLVMLocalDynamicTLSModel => {
+                Some(ThreadLocalMode::LocalDynamicTLSModel)
+            }
+            LLVMThreadLocalMode::LLVMInitialExecTLSModel => {
+                Some(ThreadLocalMode::InitialExecTLSModel)
+            }
             LLVMThreadLocalMode::LLVMLocalExecTLSModel => Some(ThreadLocalMode::LocalExecTLSModel),
-            LLVMThreadLocalMode::LLVMNotThreadLocal => None
+            LLVMThreadLocalMode::LLVMNotThreadLocal => None,
         }
     }
 
     pub(crate) fn as_llvm_mode(self) -> LLVMThreadLocalMode {
         match self {
-            ThreadLocalMode::GeneralDynamicTLSModel => LLVMThreadLocalMode::LLVMGeneralDynamicTLSModel,
+            ThreadLocalMode::GeneralDynamicTLSModel => {
+                LLVMThreadLocalMode::LLVMGeneralDynamicTLSModel
+            }
             ThreadLocalMode::LocalDynamicTLSModel => LLVMThreadLocalMode::LLVMLocalDynamicTLSModel,
             ThreadLocalMode::InitialExecTLSModel => LLVMThreadLocalMode::LLVMInitialExecTLSModel,
             ThreadLocalMode::LocalExecTLSModel => LLVMThreadLocalMode::LLVMLocalExecTLSModel,

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,21 +1,31 @@
 //! A `Module` represets a single code compilation unit.
 
-use llvm_sys::analysis::{LLVMVerifyModule, LLVMVerifierFailureAction};
+use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyModule};
 #[allow(deprecated)]
 use llvm_sys::bit_reader::LLVMParseBitcodeInContext;
 use llvm_sys::bit_writer::{LLVMWriteBitcodeToFile, LLVMWriteBitcodeToMemoryBuffer};
-use llvm_sys::core::{LLVMAddFunction, LLVMAddGlobal, LLVMDumpModule, LLVMGetNamedFunction, LLVMGetTypeByName, LLVMSetDataLayout, LLVMSetTarget, LLVMCloneModule, LLVMDisposeModule, LLVMGetTarget, LLVMGetModuleContext, LLVMGetFirstFunction, LLVMGetLastFunction, LLVMAddGlobalInAddressSpace, LLVMPrintModuleToString, LLVMGetNamedMetadataNumOperands, LLVMAddNamedMetadataOperand, LLVMGetNamedMetadataOperands, LLVMGetFirstGlobal, LLVMGetLastGlobal, LLVMGetNamedGlobal, LLVMPrintModuleToFile};
+use llvm_sys::core::{
+    LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddNamedMetadataOperand,
+    LLVMCloneModule, LLVMDisposeModule, LLVMDumpModule, LLVMGetFirstFunction, LLVMGetFirstGlobal,
+    LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetModuleContext, LLVMGetNamedFunction,
+    LLVMGetNamedGlobal, LLVMGetNamedMetadataNumOperands, LLVMGetNamedMetadataOperands,
+    LLVMGetTarget, LLVMGetTypeByName, LLVMPrintModuleToFile, LLVMPrintModuleToString,
+    LLVMSetDataLayout, LLVMSetTarget,
+};
+#[llvm_versions(7.0..=latest)]
+use llvm_sys::core::{LLVMAddModuleFlag, LLVMGetModuleFlag};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::{LLVMGetModuleIdentifier, LLVMSetModuleIdentifier};
-#[llvm_versions(7.0..=latest)]
-use llvm_sys::core::{LLVMGetModuleFlag, LLVMAddModuleFlag};
-use llvm_sys::execution_engine::{LLVMCreateInterpreterForModule, LLVMCreateJITCompilerForModule, LLVMCreateExecutionEngineForModule};
+use llvm_sys::execution_engine::{
+    LLVMCreateExecutionEngineForModule, LLVMCreateInterpreterForModule,
+    LLVMCreateJITCompilerForModule,
+};
 use llvm_sys::prelude::{LLVMModuleRef, LLVMValueRef};
 use llvm_sys::LLVMLinkage;
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMModuleFlagBehavior;
 
-use std::cell::{Cell, RefCell, Ref};
+use std::cell::{Cell, Ref, RefCell};
 use std::ffi::CStr;
 use std::fs::File;
 use std::marker::PhantomData;
@@ -24,21 +34,21 @@ use std::path::Path;
 use std::ptr;
 use std::rc::Rc;
 
-use crate::{AddressSpace, OptimizationLevel};
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::context::{Context, ContextRef};
 use crate::data_layout::DataLayout;
 #[llvm_versions(7.0..=latest)]
-use crate::debug_info::{DebugInfoBuilder, DICompileUnit, DWARFEmissionKind, DWARFSourceLanguage};
+use crate::debug_info::{DICompileUnit, DWARFEmissionKind, DWARFSourceLanguage, DebugInfoBuilder};
 use crate::execution_engine::ExecutionEngine;
 use crate::memory_buffer::MemoryBuffer;
 use crate::support::{to_c_str, LLVMString};
 use crate::targets::{InitializationConfig, Target, TargetTriple};
 use crate::types::{AsTypeRef, BasicType, FunctionType, StructType};
-use crate::values::{AsValueRef, FunctionValue, GlobalValue, MetadataValue};
 #[llvm_versions(7.0..=latest)]
 use crate::values::BasicValue;
+use crate::values::{AsValueRef, FunctionValue, GlobalValue, MetadataValue};
+use crate::{AddressSpace, OptimizationLevel};
 
 #[llvm_enum(LLVMLinkage)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -188,11 +198,20 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(fn_val.get_name().to_str(), Ok("my_function"));
     /// assert_eq!(fn_val.get_linkage(), Linkage::External);
     /// ```
-    pub fn add_function(&self, name: &str, ty: FunctionType<'ctx>, linkage: Option<Linkage>) -> FunctionValue<'ctx> {
+    pub fn add_function(
+        &self,
+        name: &str,
+        ty: FunctionType<'ctx>,
+        linkage: Option<Linkage>,
+    ) -> FunctionValue<'ctx> {
         let c_string = to_c_str(name);
         let fn_value = unsafe {
-            FunctionValue::new(LLVMAddFunction(self.module.get(), c_string.as_ptr(), ty.as_type_ref()))
-                .expect("add_function should always succeed in adding a new function")
+            FunctionValue::new(LLVMAddFunction(
+                self.module.get(),
+                c_string.as_ptr(),
+                ty.as_type_ref(),
+            ))
+            .expect("add_function should always succeed in adding a new function")
         };
 
         if let Some(linkage) = linkage {
@@ -215,9 +234,7 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(*local_module.get_context(), local_context);
     /// ```
     pub fn get_context(&self) -> ContextRef<'ctx> {
-        unsafe {
-            ContextRef::new(LLVMGetModuleContext(self.module.get()))
-        }
+        unsafe { ContextRef::new(LLVMGetModuleContext(self.module.get())) }
     }
 
     /// Gets the first `FunctionValue` defined in this `Module`.
@@ -239,9 +256,7 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(fn_value, module.get_first_function().unwrap());
     /// ```
     pub fn get_first_function(&self) -> Option<FunctionValue<'ctx>> {
-        unsafe {
-            FunctionValue::new(LLVMGetFirstFunction(self.module.get()))
-        }
+        unsafe { FunctionValue::new(LLVMGetFirstFunction(self.module.get())) }
     }
 
     /// Gets the last `FunctionValue` defined in this `Module`.
@@ -263,9 +278,7 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(fn_value, module.get_last_function().unwrap());
     /// ```
     pub fn get_last_function(&self) -> Option<FunctionValue<'ctx>> {
-        unsafe {
-            FunctionValue::new(LLVMGetLastFunction(self.module.get()))
-        }
+        unsafe { FunctionValue::new(LLVMGetLastFunction(self.module.get())) }
     }
 
     /// Gets a `FunctionValue` defined in this `Module` by its name.
@@ -289,11 +302,8 @@ impl<'ctx> Module<'ctx> {
     pub fn get_function(&self, name: &str) -> Option<FunctionValue<'ctx>> {
         let c_string = to_c_str(name);
 
-        unsafe {
-            FunctionValue::new(LLVMGetNamedFunction(self.module.get(), c_string.as_ptr()))
-        }
+        unsafe { FunctionValue::new(LLVMGetNamedFunction(self.module.get(), c_string.as_ptr())) }
     }
-
 
     /// Gets a named `StructType` from this `Module`'s `Context`.
     ///
@@ -314,17 +324,13 @@ impl<'ctx> Module<'ctx> {
     pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
         let c_string = to_c_str(name);
 
-        let struct_type = unsafe {
-            LLVMGetTypeByName(self.module.get(), c_string.as_ptr())
-        };
+        let struct_type = unsafe { LLVMGetTypeByName(self.module.get(), c_string.as_ptr()) };
 
         if struct_type.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(StructType::new(struct_type))
-        }
+        unsafe { Some(StructType::new(struct_type)) }
     }
 
     /// Assigns a `TargetTriple` to this `Module`.
@@ -347,9 +353,7 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(module.get_triple(), triple);
     /// ```
     pub fn set_triple(&self, triple: &TargetTriple) {
-        unsafe {
-            LLVMSetTarget(self.module.get(), triple.as_ptr())
-        }
+        unsafe { LLVMSetTarget(self.module.get(), triple.as_ptr()) }
     }
 
     /// Gets the `TargetTriple` assigned to this `Module`. If none has been
@@ -374,11 +378,11 @@ impl<'ctx> Module<'ctx> {
     /// ```
     pub fn get_triple(&self) -> TargetTriple {
         // REVIEW: This isn't an owned LLVMString, is it? If so, need to deallocate.
-        let target_str = unsafe {
-            LLVMGetTarget(self.module.get())
-        };
+        let target_str = unsafe { LLVMGetTarget(self.module.get()) };
 
-        TargetTriple::new(LLVMString::create_from_c_str(unsafe { CStr::from_ptr(target_str) }))
+        TargetTriple::new(LLVMString::create_from_c_str(unsafe {
+            CStr::from_ptr(target_str)
+        }))
     }
 
     /// Creates an `ExecutionEngine` from this `Module`.
@@ -399,12 +403,11 @@ impl<'ctx> Module<'ctx> {
     /// ```
     // SubType: ExecutionEngine<Basic?>
     pub fn create_execution_engine(&self) -> Result<ExecutionEngine<'ctx>, LLVMString> {
-        Target::initialize_native(&InitializationConfig::default())
-            .map_err(|mut err_string| {
-                err_string.push('\0');
+        Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
+            err_string.push('\0');
 
-                LLVMString::create_from_str(&err_string)
-            })?;
+            LLVMString::create_from_str(&err_string)
+        })?;
 
         if self.owned_by_ee.borrow().is_some() {
             let string = "This module is already owned by an ExecutionEngine.\0";
@@ -415,7 +418,11 @@ impl<'ctx> Module<'ctx> {
         let mut err_string = MaybeUninit::uninit();
         let code = unsafe {
             // Takes ownership of module
-            LLVMCreateExecutionEngineForModule(execution_engine.as_mut_ptr(), self.module.get(), err_string.as_mut_ptr())
+            LLVMCreateExecutionEngineForModule(
+                execution_engine.as_mut_ptr(),
+                self.module.get(),
+                err_string.as_mut_ptr(),
+            )
         };
 
         if code == 1 {
@@ -450,12 +457,11 @@ impl<'ctx> Module<'ctx> {
     /// ```
     // SubType: ExecutionEngine<Interpreter>
     pub fn create_interpreter_execution_engine(&self) -> Result<ExecutionEngine<'ctx>, LLVMString> {
-        Target::initialize_native(&InitializationConfig::default())
-            .map_err(|mut err_string| {
-                err_string.push('\0');
+        Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
+            err_string.push('\0');
 
-                LLVMString::create_from_str(&err_string)
-            })?;
+            LLVMString::create_from_str(&err_string)
+        })?;
 
         if self.owned_by_ee.borrow().is_some() {
             let string = "This module is already owned by an ExecutionEngine.\0";
@@ -467,7 +473,11 @@ impl<'ctx> Module<'ctx> {
 
         let code = unsafe {
             // Takes ownership of module
-            LLVMCreateInterpreterForModule(execution_engine.as_mut_ptr(), self.module.get(), err_string.as_mut_ptr())
+            LLVMCreateInterpreterForModule(
+                execution_engine.as_mut_ptr(),
+                self.module.get(),
+                err_string.as_mut_ptr(),
+            )
         };
 
         if code == 1 {
@@ -502,13 +512,15 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(*module.get_context(), context);
     /// ```
     // SubType: ExecutionEngine<Jit>
-    pub fn create_jit_execution_engine(&self, opt_level: OptimizationLevel) -> Result<ExecutionEngine<'ctx>, LLVMString> {
-        Target::initialize_native(&InitializationConfig::default())
-            .map_err(|mut err_string| {
-                err_string.push('\0');
+    pub fn create_jit_execution_engine(
+        &self,
+        opt_level: OptimizationLevel,
+    ) -> Result<ExecutionEngine<'ctx>, LLVMString> {
+        Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
+            err_string.push('\0');
 
-                LLVMString::create_from_str(&err_string)
-            })?;
+            LLVMString::create_from_str(&err_string)
+        })?;
 
         if self.owned_by_ee.borrow().is_some() {
             let string = "This module is already owned by an ExecutionEngine.\0";
@@ -520,7 +532,12 @@ impl<'ctx> Module<'ctx> {
 
         let code = unsafe {
             // Takes ownership of module
-            LLVMCreateJITCompilerForModule(execution_engine.as_mut_ptr(), self.module.get(), opt_level as u32, err_string.as_mut_ptr())
+            LLVMCreateJITCompilerForModule(
+                execution_engine.as_mut_ptr(),
+                self.module.get(),
+                opt_level as u32,
+                err_string.as_mut_ptr(),
+            )
         };
 
         if code == 1 {
@@ -553,19 +570,27 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// assert_eq!(module.get_last_global().unwrap(), global);
     /// ```
-    pub fn add_global<T: BasicType<'ctx>>(&self, type_: T, address_space: Option<AddressSpace>, name: &str) -> GlobalValue<'ctx> {
+    pub fn add_global<T: BasicType<'ctx>>(
+        &self,
+        type_: T,
+        address_space: Option<AddressSpace>,
+        name: &str,
+    ) -> GlobalValue<'ctx> {
         let c_string = to_c_str(name);
 
         let value = unsafe {
             match address_space {
-                Some(address_space) => LLVMAddGlobalInAddressSpace(self.module.get(), type_.as_type_ref(), c_string.as_ptr(), address_space as u32),
+                Some(address_space) => LLVMAddGlobalInAddressSpace(
+                    self.module.get(),
+                    type_.as_type_ref(),
+                    c_string.as_ptr(),
+                    address_space as u32,
+                ),
                 None => LLVMAddGlobal(self.module.get(), type_.as_type_ref(), c_string.as_ptr()),
             }
         };
 
-        unsafe {
-            GlobalValue::new(value)
-        }
+        unsafe { GlobalValue::new(value) }
     }
 
     /// Writes a `Module` to a `Path`.
@@ -588,12 +613,12 @@ impl<'ctx> Module<'ctx> {
     /// module.write_bitcode_to_path(&path);
     /// ```
     pub fn write_bitcode_to_path(&self, path: &Path) -> bool {
-        let path_str = path.to_str().expect("Did not find a valid Unicode path string");
+        let path_str = path
+            .to_str()
+            .expect("Did not find a valid Unicode path string");
         let c_string = to_c_str(path_str);
 
-        unsafe {
-            LLVMWriteBitcodeToFile(self.module.get(), c_string.as_ptr()) == 0
-        }
+        unsafe { LLVMWriteBitcodeToFile(self.module.get(), c_string.as_ptr()) == 0 }
     }
 
     // See GH issue #6
@@ -601,13 +626,18 @@ impl<'ctx> Module<'ctx> {
     pub fn write_bitcode_to_file(&self, file: &File, should_close: bool, unbuffered: bool) -> bool {
         #[cfg(unix)]
         {
-            use std::os::unix::io::AsRawFd;
             use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
+            use std::os::unix::io::AsRawFd;
 
             // REVIEW: as_raw_fd docs suggest it only works in *nix
             // Also, should_close should maybe be hardcoded to true?
             unsafe {
-                LLVMWriteBitcodeToFD(self.module.get(), file.as_raw_fd(), should_close as i32, unbuffered as i32) == 0
+                LLVMWriteBitcodeToFD(
+                    self.module.get(),
+                    file.as_raw_fd(),
+                    should_close as i32,
+                    unbuffered as i32,
+                ) == 0
             }
         }
         #[cfg(windows)]
@@ -635,9 +665,7 @@ impl<'ctx> Module<'ctx> {
     /// let buffer = module.write_bitcode_to_memory();
     /// ```
     pub fn write_bitcode_to_memory(&self) -> MemoryBuffer {
-        let memory_buffer = unsafe {
-            LLVMWriteBitcodeToMemoryBuffer(self.module.get())
-        };
+        let memory_buffer = unsafe { LLVMWriteBitcodeToMemoryBuffer(self.module.get()) };
 
         MemoryBuffer::new(memory_buffer)
     }
@@ -652,9 +680,7 @@ impl<'ctx> Module<'ctx> {
 
         let action = LLVMVerifierFailureAction::LLVMReturnStatusAction;
 
-        let code = unsafe {
-            LLVMVerifyModule(self.module.get(), action, err_str.as_mut_ptr())
-        };
+        let code = unsafe { LLVMVerifyModule(self.module.get(), action, err_str.as_mut_ptr()) };
 
         let err_str = unsafe { err_str.assume_init() };
         if code == 1 && !err_str.is_null() {
@@ -678,9 +704,7 @@ impl<'ctx> Module<'ctx> {
             LLVMGetDataLayoutStr(module)
         };
 
-        unsafe {
-            DataLayout::new_borrowed(data_layout)
-        }
+        unsafe { DataLayout::new_borrowed(data_layout) }
     }
 
     /// Gets a smart pointer to the `DataLayout` belonging to a particular `Module`.
@@ -705,7 +729,10 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(*module.get_data_layout(), data_layout);
     /// ```
     pub fn get_data_layout(&self) -> Ref<DataLayout> {
-        Ref::map(self.data_layout.borrow(), |l| l.as_ref().expect("DataLayout should always exist until Drop"))
+        Ref::map(self.data_layout.borrow(), |l| {
+            l.as_ref()
+                .expect("DataLayout should always exist until Drop")
+        })
     }
 
     // REVIEW: Ensure the replaced string ptr still gets cleaned up by the module (I think it does)
@@ -748,18 +775,23 @@ impl<'ctx> Module<'ctx> {
 
     /// Prints the content of the `Module` to a string.
     pub fn print_to_string(&self) -> LLVMString {
-        unsafe {
-            LLVMString::new(LLVMPrintModuleToString(self.module.get()))
-        }
+        unsafe { LLVMString::new(LLVMPrintModuleToString(self.module.get())) }
     }
 
     /// Prints the content of the `Module` to a file.
     pub fn print_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), LLVMString> {
-        let path_str = path.as_ref().to_str().expect("Did not find a valid Unicode path string");
+        let path_str = path
+            .as_ref()
+            .to_str()
+            .expect("Did not find a valid Unicode path string");
         let path = to_c_str(path_str);
         let mut err_string = MaybeUninit::uninit();
         let return_code = unsafe {
-            LLVMPrintModuleToFile(self.module.get(), path.as_ptr() as *const ::libc::c_char, err_string.as_mut_ptr())
+            LLVMPrintModuleToFile(
+                self.module.get(),
+                path.as_ptr() as *const ::libc::c_char,
+                err_string.as_mut_ptr(),
+            )
         };
 
         if return_code == 1 {
@@ -773,24 +805,40 @@ impl<'ctx> Module<'ctx> {
 
     /// Sets the inline assembly for the `Module`.
     pub fn set_inline_assembly(&self, asm: &str) {
-        #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0"))]
+        #[cfg(any(
+            feature = "llvm3-6",
+            feature = "llvm3-7",
+            feature = "llvm3-8",
+            feature = "llvm3-9",
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0"
+        ))]
         {
             use llvm_sys::core::LLVMSetModuleInlineAsm;
 
             let c_string = to_c_str(asm);
 
-            unsafe {
-                LLVMSetModuleInlineAsm(self.module.get(), c_string.as_ptr())
-            }
+            unsafe { LLVMSetModuleInlineAsm(self.module.get(), c_string.as_ptr()) }
         }
-        #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                      feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+        #[cfg(not(any(
+            feature = "llvm3-6",
+            feature = "llvm3-7",
+            feature = "llvm3-8",
+            feature = "llvm3-9",
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0"
+        )))]
         {
             use llvm_sys::core::LLVMSetModuleInlineAsm2;
 
             unsafe {
-                LLVMSetModuleInlineAsm2(self.module.get(), asm.as_ptr() as *const ::libc::c_char, asm.len())
+                LLVMSetModuleInlineAsm2(
+                    self.module.get(),
+                    asm.as_ptr() as *const ::libc::c_char,
+                    asm.len(),
+                )
             }
         }
     }
@@ -839,7 +887,11 @@ impl<'ctx> Module<'ctx> {
         let c_string = to_c_str(key);
 
         unsafe {
-            LLVMAddNamedMetadataOperand(self.module.get(), c_string.as_ptr(), metadata.as_value_ref())
+            LLVMAddNamedMetadataOperand(
+                self.module.get(),
+                c_string.as_ptr(),
+                metadata.as_value_ref(),
+            )
         }
     }
 
@@ -883,9 +935,7 @@ impl<'ctx> Module<'ctx> {
     pub fn get_global_metadata_size(&self, key: &str) -> u32 {
         let c_string = to_c_str(key);
 
-        unsafe {
-            LLVMGetNamedMetadataNumOperands(self.module.get(), c_string.as_ptr())
-        }
+        unsafe { LLVMGetNamedMetadataNumOperands(self.module.get(), c_string.as_ptr()) }
     }
 
     // SubTypes: -> Vec<MetadataValue<Node>>
@@ -938,7 +988,9 @@ impl<'ctx> Module<'ctx> {
             vec.set_len(count);
         };
 
-        vec.iter().map(|val| unsafe { MetadataValue::new(*val) }).collect()
+        vec.iter()
+            .map(|val| unsafe { MetadataValue::new(*val) })
+            .collect()
     }
 
     /// Gets the first `GlobalValue` in a module.
@@ -960,17 +1012,13 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// ```
     pub fn get_first_global(&self) -> Option<GlobalValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetFirstGlobal(self.module.get())
-        };
+        let value = unsafe { LLVMGetFirstGlobal(self.module.get()) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(GlobalValue::new(value))
-        }
+        unsafe { Some(GlobalValue::new(value)) }
     }
 
     /// Gets the last `GlobalValue` in a module.
@@ -992,17 +1040,13 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(module.get_last_global().unwrap(), global);
     /// ```
     pub fn get_last_global(&self) -> Option<GlobalValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetLastGlobal(self.module.get())
-        };
+        let value = unsafe { LLVMGetLastGlobal(self.module.get()) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(GlobalValue::new(value))
-        }
+        unsafe { Some(GlobalValue::new(value)) }
     }
 
     /// Gets a named `GlobalValue` in a module.
@@ -1025,17 +1069,13 @@ impl<'ctx> Module<'ctx> {
     /// ```
     pub fn get_global(&self, name: &str) -> Option<GlobalValue<'ctx>> {
         let c_string = to_c_str(name);
-        let value = unsafe {
-            LLVMGetNamedGlobal(self.module.get(), c_string.as_ptr())
-        };
+        let value = unsafe { LLVMGetNamedGlobal(self.module.get(), c_string.as_ptr()) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(GlobalValue::new(value))
-        }
+        unsafe { Some(GlobalValue::new(value)) }
     }
 
     /// Creates a new `Module` from a `MemoryBuffer`.
@@ -1056,7 +1096,10 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(*module.unwrap().get_context(), context);
     ///
     /// ```
-    pub fn parse_bitcode_from_buffer(buffer: &MemoryBuffer, context: &'ctx Context) -> Result<Self, LLVMString> {
+    pub fn parse_bitcode_from_buffer(
+        buffer: &MemoryBuffer,
+        context: &'ctx Context,
+    ) -> Result<Self, LLVMString> {
         let mut module = MaybeUninit::uninit();
         let mut err_string = MaybeUninit::uninit();
 
@@ -1065,7 +1108,12 @@ impl<'ctx> Module<'ctx> {
         // error diagnostics handler for now.
         #[allow(deprecated)]
         let success = unsafe {
-            LLVMParseBitcodeInContext(context.context, buffer.memory_buffer, module.as_mut_ptr(), err_string.as_mut_ptr())
+            LLVMParseBitcodeInContext(
+                context.context,
+                buffer.memory_buffer,
+                module.as_mut_ptr(),
+                err_string.as_mut_ptr(),
+            )
         };
 
         if success != 0 {
@@ -1074,9 +1122,7 @@ impl<'ctx> Module<'ctx> {
             }
         }
 
-        unsafe {
-            Ok(Module::new(module.assume_init()))
-        }
+        unsafe { Ok(Module::new(module.assume_init())) }
     }
 
     /// A convenience function for creating a `Module` from a file for a given context.
@@ -1097,7 +1143,10 @@ impl<'ctx> Module<'ctx> {
     /// ```
     // LLVMGetBitcodeModuleInContext was a pain to use, so I seem to be able to achieve the same effect
     // by reusing create_from_file instead. This is basically just a convenience function.
-    pub fn parse_bitcode_from_path<P: AsRef<Path>>(path: P, context: &'ctx Context) -> Result<Self, LLVMString> {
+    pub fn parse_bitcode_from_path<P: AsRef<Path>>(
+        path: P,
+        context: &'ctx Context,
+    ) -> Result<Self, LLVMString> {
         let buffer = MemoryBuffer::create_from_file(path.as_ref())?;
 
         Self::parse_bitcode_from_buffer(&buffer, &context)
@@ -1118,13 +1167,9 @@ impl<'ctx> Module<'ctx> {
     #[llvm_versions(3.9..=latest)]
     pub fn get_name(&self) -> &CStr {
         let mut length = 0;
-        let cstr_ptr = unsafe {
-            LLVMGetModuleIdentifier(self.module.get(), &mut length)
-        };
+        let cstr_ptr = unsafe { LLVMGetModuleIdentifier(self.module.get(), &mut length) };
 
-        unsafe {
-            CStr::from_ptr(cstr_ptr)
-        }
+        unsafe { CStr::from_ptr(cstr_ptr) }
     }
 
     /// Assigns the name of this `Module`.
@@ -1144,7 +1189,11 @@ impl<'ctx> Module<'ctx> {
     #[llvm_versions(3.9..=latest)]
     pub fn set_name(&self, name: &str) {
         unsafe {
-            LLVMSetModuleIdentifier(self.module.get(), name.as_ptr() as *const ::libc::c_char, name.len())
+            LLVMSetModuleIdentifier(
+                self.module.get(),
+                name.as_ptr() as *const ::libc::c_char,
+                name.len(),
+            )
         }
     }
 
@@ -1170,13 +1219,9 @@ impl<'ctx> Module<'ctx> {
         use llvm_sys::core::LLVMGetSourceFileName;
 
         let mut len = 0;
-        let ptr = unsafe {
-            LLVMGetSourceFileName(self.module.get(), &mut len)
-        };
+        let ptr = unsafe { LLVMGetSourceFileName(self.module.get(), &mut len) };
 
-        unsafe {
-            CStr::from_ptr(ptr)
-        }
+        unsafe { CStr::from_ptr(ptr) }
     }
 
     /// Sets the source file name. It defaults to the module identifier but is separate from it.
@@ -1201,7 +1246,11 @@ impl<'ctx> Module<'ctx> {
         use llvm_sys::core::LLVMSetSourceFileName;
 
         unsafe {
-            LLVMSetSourceFileName(self.module.get(), file_name.as_ptr() as *const ::libc::c_char, file_name.len())
+            LLVMSetSourceFileName(
+                self.module.get(),
+                file_name.as_ptr() as *const ::libc::c_char,
+                file_name.len(),
+            )
         }
     }
 
@@ -1226,7 +1275,7 @@ impl<'ctx> Module<'ctx> {
 
         #[cfg(any(feature = "llvm3-6", feature = "llvm3-7"))]
         {
-            use llvm_sys::linker::{LLVMLinkerMode, LLVMLinkModules};
+            use llvm_sys::linker::{LLVMLinkModules, LLVMLinkerMode};
 
             let mut err_string = ptr::null_mut();
             // As of 3.7, LLVMLinkerDestroySource is the only option
@@ -1238,9 +1287,7 @@ impl<'ctx> Module<'ctx> {
             forget(other);
 
             if code == 1 {
-                unsafe {
-                    Err(LLVMString::new(err_string))
-                }
+                unsafe { Err(LLVMString::new(err_string)) }
             } else {
                 Ok(())
             }
@@ -1248,30 +1295,27 @@ impl<'ctx> Module<'ctx> {
         #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
         {
             use crate::support::error_handling::get_error_str_diagnostic_handler;
-            use llvm_sys::linker::LLVMLinkModules2;
             use libc::c_void;
+            use llvm_sys::linker::LLVMLinkModules2;
 
             let context = self.get_context();
 
             let mut char_ptr: *mut ::libc::c_char = ptr::null_mut();
-            let char_ptr_ptr = &mut char_ptr as *mut *mut ::libc::c_char as *mut *mut c_void as *mut c_void;
+            let char_ptr_ptr =
+                &mut char_ptr as *mut *mut ::libc::c_char as *mut *mut c_void as *mut c_void;
 
             // Newer LLVM versions don't use an out ptr anymore which was really straightforward...
             // Here we assign an error handler to extract the error message, if any, for us.
             context.set_diagnostic_handler(get_error_str_diagnostic_handler, char_ptr_ptr);
 
-            let code = unsafe {
-                LLVMLinkModules2(self.module.get(), other.module.get())
-            };
+            let code = unsafe { LLVMLinkModules2(self.module.get(), other.module.get()) };
 
             forget(other);
 
             if code == 1 {
                 debug_assert!(!char_ptr.is_null());
 
-                unsafe {
-                    Err(LLVMString::new(char_ptr))
-                }
+                unsafe { Err(LLVMString::new(char_ptr)) }
             } else {
                 Ok(())
             }
@@ -1285,9 +1329,7 @@ impl<'ctx> Module<'ctx> {
         use llvm_sys::comdat::LLVMGetOrInsertComdat;
 
         let c_string = to_c_str(name);
-        let comdat_ptr = unsafe {
-            LLVMGetOrInsertComdat(self.module.get(), c_string.as_ptr())
-        };
+        let comdat_ptr = unsafe { LLVMGetOrInsertComdat(self.module.get(), c_string.as_ptr()) };
 
         Comdat::new(comdat_ptr)
     }
@@ -1301,20 +1343,21 @@ impl<'ctx> Module<'ctx> {
         use llvm_sys::core::LLVMMetadataAsValue;
 
         let flag = unsafe {
-            LLVMGetModuleFlag(self.module.get(), key.as_ptr() as *const ::libc::c_char, key.len())
+            LLVMGetModuleFlag(
+                self.module.get(),
+                key.as_ptr() as *const ::libc::c_char,
+                key.len(),
+            )
         };
 
         if flag.is_null() {
             return None;
         }
 
-        let flag_value = unsafe {
-            LLVMMetadataAsValue(LLVMGetModuleContext(self.module.get()), flag)
-        };
+        let flag_value =
+            unsafe { LLVMMetadataAsValue(LLVMGetModuleContext(self.module.get()), flag) };
 
-        unsafe {
-            Some(MetadataValue::new(flag_value))
-        }
+        unsafe { Some(MetadataValue::new(flag_value)) }
     }
 
     /// Append a `MetadataValue` as a module wide flag. Note that using the same key twice
@@ -1324,7 +1367,13 @@ impl<'ctx> Module<'ctx> {
         let md = flag.as_metadata_ref();
 
         unsafe {
-            LLVMAddModuleFlag(self.module.get(), behavior.into(), key.as_ptr() as *mut ::libc::c_char, key.len(), md)
+            LLVMAddModuleFlag(
+                self.module.get(),
+                behavior.into(),
+                key.as_ptr() as *mut ::libc::c_char,
+                key.len(),
+                md,
+            )
         }
     }
 
@@ -1332,15 +1381,24 @@ impl<'ctx> Module<'ctx> {
     /// will likely invalidate the module.
     // REVIEW: What happens if value is not const?
     #[llvm_versions(7.0..=latest)]
-    pub fn add_basic_value_flag<BV: BasicValue<'ctx>>(&self, key: &str, behavior: FlagBehavior, flag: BV) {
+    pub fn add_basic_value_flag<BV: BasicValue<'ctx>>(
+        &self,
+        key: &str,
+        behavior: FlagBehavior,
+        flag: BV,
+    ) {
         use llvm_sys::core::LLVMValueAsMetadata;
 
-        let md = unsafe {
-            LLVMValueAsMetadata(flag.as_value_ref())
-        };
+        let md = unsafe { LLVMValueAsMetadata(flag.as_value_ref()) };
 
         unsafe {
-            LLVMAddModuleFlag(self.module.get(), behavior.into(), key.as_ptr() as *mut ::libc::c_char, key.len(), md)
+            LLVMAddModuleFlag(
+                self.module.get(),
+                behavior.into(),
+                key.as_ptr() as *mut ::libc::c_char,
+                key.len(),
+                md,
+            )
         }
     }
 
@@ -1349,9 +1407,7 @@ impl<'ctx> Module<'ctx> {
     pub fn strip_debug_info(&self) -> bool {
         use llvm_sys::debuginfo::LLVMStripModuleDebugInfo;
 
-        unsafe {
-            LLVMStripModuleDebugInfo(self.module.get()) == 1
-        }
+        unsafe { LLVMStripModuleDebugInfo(self.module.get()) == 1 }
     }
 
     /// Gets the version of debug metadata contained in this `Module`.
@@ -1359,14 +1415,13 @@ impl<'ctx> Module<'ctx> {
     pub fn get_debug_metadata_version(&self) -> libc::c_uint {
         use llvm_sys::debuginfo::LLVMGetModuleDebugMetadataVersion;
 
-        unsafe {
-            LLVMGetModuleDebugMetadataVersion(self.module.get())
-        }
+        unsafe { LLVMGetModuleDebugMetadataVersion(self.module.get()) }
     }
 
     /// Creates a `DebugInfoBuilder` for this `Module`.
     #[llvm_versions(7.0..=latest)]
-    pub fn create_debug_info_builder(&self,
+    pub fn create_debug_info_builder(
+        &self,
         allow_unresolved: bool,
         language: DWARFSourceLanguage,
         filename: &str,
@@ -1380,19 +1435,28 @@ impl<'ctx> Module<'ctx> {
         dwo_id: libc::c_uint,
         split_debug_inlining: bool,
         debug_info_for_profiling: bool,
-        #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
-        sysroot: &str,
-        #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
-        sdk: &str,
+        #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))] sysroot: &str,
+        #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))] sdk: &str,
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
-        DebugInfoBuilder::new(self, allow_unresolved,
-                              language, filename, directory, producer, is_optimized, flags,
-                              runtime_ver, split_name, kind, dwo_id, split_debug_inlining,
-                              debug_info_for_profiling,
-                              #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
-                              sysroot,
-                              #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
-                              sdk
+        DebugInfoBuilder::new(
+            self,
+            allow_unresolved,
+            language,
+            filename,
+            directory,
+            producer,
+            is_optimized,
+            flags,
+            runtime_ver,
+            split_name,
+            kind,
+            dwo_id,
+            split_debug_inlining,
+            debug_info_for_profiling,
+            #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
+            sysroot,
+            #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
+            sdk,
         )
     }
 }
@@ -1404,9 +1468,7 @@ impl Clone for Module<'_> {
 
         assert!(verify.is_ok(), "Cloning a Module seems to segfault when module is not valid. We are preventing that here. Error: {}", verify.unwrap_err());
 
-        unsafe {
-            Module::new(LLVMCloneModule(self.module.get()))
-        }
+        unsafe { Module::new(LLVMCloneModule(self.module.get())) }
     }
 }
 

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -1,11 +1,46 @@
-use llvm_sys::core::{LLVMDisposePassManager, LLVMInitializeFunctionPassManager, LLVMFinalizeFunctionPassManager, LLVMRunFunctionPassManager, LLVMRunPassManager, LLVMCreatePassManager, LLVMCreateFunctionPassManagerForModule, LLVMGetGlobalPassRegistry};
-use llvm_sys::initialization::{LLVMInitializeCore, LLVMInitializeTransformUtils, LLVMInitializeScalarOpts, LLVMInitializeObjCARCOpts, LLVMInitializeVectorization, LLVMInitializeInstCombine, LLVMInitializeIPO, LLVMInitializeInstrumentation, LLVMInitializeAnalysis, LLVMInitializeIPA, LLVMInitializeCodeGen, LLVMInitializeTarget};
+use llvm_sys::core::{
+    LLVMCreateFunctionPassManagerForModule, LLVMCreatePassManager, LLVMDisposePassManager,
+    LLVMFinalizeFunctionPassManager, LLVMGetGlobalPassRegistry, LLVMInitializeFunctionPassManager,
+    LLVMRunFunctionPassManager, LLVMRunPassManager,
+};
+use llvm_sys::initialization::{
+    LLVMInitializeAnalysis, LLVMInitializeCodeGen, LLVMInitializeCore, LLVMInitializeIPA,
+    LLVMInitializeIPO, LLVMInitializeInstCombine, LLVMInitializeInstrumentation,
+    LLVMInitializeObjCARCOpts, LLVMInitializeScalarOpts, LLVMInitializeTarget,
+    LLVMInitializeTransformUtils, LLVMInitializeVectorization,
+};
 use llvm_sys::prelude::{LLVMPassManagerRef, LLVMPassRegistryRef};
-use llvm_sys::transforms::ipo::{LLVMAddArgumentPromotionPass, LLVMAddConstantMergePass, LLVMAddDeadArgEliminationPass, LLVMAddFunctionAttrsPass, LLVMAddFunctionInliningPass, LLVMAddAlwaysInlinerPass, LLVMAddGlobalDCEPass, LLVMAddGlobalOptimizerPass, LLVMAddIPSCCPPass, LLVMAddInternalizePass, LLVMAddStripDeadPrototypesPass, LLVMAddPruneEHPass, LLVMAddStripSymbolsPass};
-use llvm_sys::transforms::pass_manager_builder::{LLVMPassManagerBuilderRef, LLVMPassManagerBuilderCreate, LLVMPassManagerBuilderDispose, LLVMPassManagerBuilderSetOptLevel, LLVMPassManagerBuilderSetSizeLevel, LLVMPassManagerBuilderSetDisableUnitAtATime, LLVMPassManagerBuilderSetDisableUnrollLoops, LLVMPassManagerBuilderSetDisableSimplifyLibCalls, LLVMPassManagerBuilderUseInlinerWithThreshold, LLVMPassManagerBuilderPopulateFunctionPassManager, LLVMPassManagerBuilderPopulateModulePassManager, LLVMPassManagerBuilderPopulateLTOPassManager};
-use llvm_sys::transforms::scalar::{LLVMAddAggressiveDCEPass, LLVMAddMemCpyOptPass, LLVMAddAlignmentFromAssumptionsPass, LLVMAddCFGSimplificationPass, LLVMAddDeadStoreEliminationPass, LLVMAddScalarizerPass, LLVMAddMergedLoadStoreMotionPass, LLVMAddGVNPass, LLVMAddIndVarSimplifyPass, LLVMAddInstructionCombiningPass, LLVMAddJumpThreadingPass, LLVMAddLICMPass, LLVMAddLoopDeletionPass, LLVMAddLoopIdiomPass, LLVMAddLoopRotatePass, LLVMAddLoopRerollPass, LLVMAddLoopUnrollPass, LLVMAddLoopUnswitchPass, LLVMAddPartiallyInlineLibCallsPass, LLVMAddSCCPPass, LLVMAddScalarReplAggregatesPass, LLVMAddScalarReplAggregatesPassSSA, LLVMAddScalarReplAggregatesPassWithThreshold, LLVMAddSimplifyLibCallsPass, LLVMAddTailCallEliminationPass, LLVMAddDemoteMemoryToRegisterPass, LLVMAddVerifierPass, LLVMAddCorrelatedValuePropagationPass, LLVMAddEarlyCSEPass, LLVMAddLowerExpectIntrinsicPass, LLVMAddTypeBasedAliasAnalysisPass, LLVMAddScopedNoAliasAAPass, LLVMAddBasicAliasAnalysisPass, LLVMAddReassociatePass};
+use llvm_sys::transforms::ipo::{
+    LLVMAddAlwaysInlinerPass, LLVMAddArgumentPromotionPass, LLVMAddConstantMergePass,
+    LLVMAddDeadArgEliminationPass, LLVMAddFunctionAttrsPass, LLVMAddFunctionInliningPass,
+    LLVMAddGlobalDCEPass, LLVMAddGlobalOptimizerPass, LLVMAddIPSCCPPass, LLVMAddInternalizePass,
+    LLVMAddPruneEHPass, LLVMAddStripDeadPrototypesPass, LLVMAddStripSymbolsPass,
+};
+use llvm_sys::transforms::pass_manager_builder::{
+    LLVMPassManagerBuilderCreate, LLVMPassManagerBuilderDispose,
+    LLVMPassManagerBuilderPopulateFunctionPassManager,
+    LLVMPassManagerBuilderPopulateLTOPassManager, LLVMPassManagerBuilderPopulateModulePassManager,
+    LLVMPassManagerBuilderRef, LLVMPassManagerBuilderSetDisableSimplifyLibCalls,
+    LLVMPassManagerBuilderSetDisableUnitAtATime, LLVMPassManagerBuilderSetDisableUnrollLoops,
+    LLVMPassManagerBuilderSetOptLevel, LLVMPassManagerBuilderSetSizeLevel,
+    LLVMPassManagerBuilderUseInlinerWithThreshold,
+};
 #[llvm_versions(3.7..=latest)]
 use llvm_sys::transforms::scalar::LLVMAddBitTrackingDCEPass;
+use llvm_sys::transforms::scalar::{
+    LLVMAddAggressiveDCEPass, LLVMAddAlignmentFromAssumptionsPass, LLVMAddBasicAliasAnalysisPass,
+    LLVMAddCFGSimplificationPass, LLVMAddCorrelatedValuePropagationPass,
+    LLVMAddDeadStoreEliminationPass, LLVMAddDemoteMemoryToRegisterPass, LLVMAddEarlyCSEPass,
+    LLVMAddGVNPass, LLVMAddIndVarSimplifyPass, LLVMAddInstructionCombiningPass,
+    LLVMAddJumpThreadingPass, LLVMAddLICMPass, LLVMAddLoopDeletionPass, LLVMAddLoopIdiomPass,
+    LLVMAddLoopRerollPass, LLVMAddLoopRotatePass, LLVMAddLoopUnrollPass, LLVMAddLoopUnswitchPass,
+    LLVMAddLowerExpectIntrinsicPass, LLVMAddMemCpyOptPass, LLVMAddMergedLoadStoreMotionPass,
+    LLVMAddPartiallyInlineLibCallsPass, LLVMAddReassociatePass, LLVMAddSCCPPass,
+    LLVMAddScalarReplAggregatesPass, LLVMAddScalarReplAggregatesPassSSA,
+    LLVMAddScalarReplAggregatesPassWithThreshold, LLVMAddScalarizerPass,
+    LLVMAddScopedNoAliasAAPass, LLVMAddSimplifyLibCallsPass, LLVMAddTailCallEliminationPass,
+    LLVMAddTypeBasedAliasAnalysisPass, LLVMAddVerifierPass,
+};
 use llvm_sys::transforms::vectorize::{LLVMAddLoopVectorizePass, LLVMAddSLPVectorizePass};
 
 // LLVM12 removes the ConstantPropagation pass
@@ -18,11 +53,11 @@ use llvm_sys::transforms::scalar::LLVMAddConstantPropagationPass;
 #[llvm_versions(12.0..=latest)]
 use llvm_sys::transforms::scalar::LLVMAddInstructionSimplifyPass;
 
-use crate::OptimizationLevel;
 use crate::module::Module;
 #[llvm_versions(3.6..=3.8)]
 use crate::targets::TargetData;
 use crate::values::{AsValueRef, FunctionValue};
+use crate::OptimizationLevel;
 
 use std::borrow::Borrow;
 use std::marker::PhantomData;
@@ -43,24 +78,18 @@ impl PassManagerBuilder {
     }
 
     pub fn create() -> Self {
-        let pass_manager_builder = unsafe {
-            LLVMPassManagerBuilderCreate()
-        };
+        let pass_manager_builder = unsafe { LLVMPassManagerBuilderCreate() };
 
         PassManagerBuilder::new(pass_manager_builder)
     }
 
     pub fn set_optimization_level(&self, opt_level: OptimizationLevel) {
-        unsafe {
-            LLVMPassManagerBuilderSetOptLevel(self.pass_manager_builder, opt_level as u32)
-        }
+        unsafe { LLVMPassManagerBuilderSetOptLevel(self.pass_manager_builder, opt_level as u32) }
     }
 
     // REVIEW: Valid input 0-2 according to llvmlite. Maybe better as an enum?
     pub fn set_size_level(&self, size_level: u32) {
-        unsafe {
-            LLVMPassManagerBuilderSetSizeLevel(self.pass_manager_builder, size_level)
-        }
+        unsafe { LLVMPassManagerBuilderSetSizeLevel(self.pass_manager_builder, size_level) }
     }
 
     pub fn set_disable_unit_at_a_time(&self, disable: bool) {
@@ -77,7 +106,10 @@ impl PassManagerBuilder {
 
     pub fn set_disable_simplify_lib_calls(&self, disable: bool) {
         unsafe {
-            LLVMPassManagerBuilderSetDisableSimplifyLibCalls(self.pass_manager_builder, disable as i32)
+            LLVMPassManagerBuilderSetDisableSimplifyLibCalls(
+                self.pass_manager_builder,
+                disable as i32,
+            )
         }
     }
 
@@ -109,7 +141,10 @@ impl PassManagerBuilder {
     /// ```
     pub fn populate_function_pass_manager(&self, pass_manager: &PassManager<FunctionValue>) {
         unsafe {
-            LLVMPassManagerBuilderPopulateFunctionPassManager(self.pass_manager_builder, pass_manager.pass_manager)
+            LLVMPassManagerBuilderPopulateFunctionPassManager(
+                self.pass_manager_builder,
+                pass_manager.pass_manager,
+            )
         }
     }
 
@@ -135,7 +170,10 @@ impl PassManagerBuilder {
     /// ```
     pub fn populate_module_pass_manager(&self, pass_manager: &PassManager<Module>) {
         unsafe {
-            LLVMPassManagerBuilderPopulateModulePassManager(self.pass_manager_builder, pass_manager.pass_manager)
+            LLVMPassManagerBuilderPopulateModulePassManager(
+                self.pass_manager_builder,
+                pass_manager.pass_manager,
+            )
         }
     }
 
@@ -159,18 +197,26 @@ impl PassManagerBuilder {
     ///
     /// pass_manager_builder.populate_lto_pass_manager(&lpm, false, false);
     /// ```
-    pub fn populate_lto_pass_manager(&self, pass_manager: &PassManager<Module>, internalize: bool, run_inliner: bool) {
+    pub fn populate_lto_pass_manager(
+        &self,
+        pass_manager: &PassManager<Module>,
+        internalize: bool,
+        run_inliner: bool,
+    ) {
         unsafe {
-            LLVMPassManagerBuilderPopulateLTOPassManager(self.pass_manager_builder, pass_manager.pass_manager, internalize as i32, run_inliner as i32)
+            LLVMPassManagerBuilderPopulateLTOPassManager(
+                self.pass_manager_builder,
+                pass_manager.pass_manager,
+                internalize as i32,
+                run_inliner as i32,
+            )
         }
     }
 }
 
 impl Drop for PassManagerBuilder {
     fn drop(&mut self) {
-        unsafe {
-            LLVMPassManagerBuilderDispose(self.pass_manager_builder)
-        }
+        unsafe { LLVMPassManagerBuilderDispose(self.pass_manager_builder) }
     }
 }
 
@@ -181,7 +227,9 @@ pub trait PassManagerSubType {
     type Input;
 
     unsafe fn create<I: Borrow<Self::Input>>(input: I) -> LLVMPassManagerRef;
-    unsafe fn run_in_pass_manager(&self, pass_manager: &PassManager<Self>) -> bool where Self: Sized;
+    unsafe fn run_in_pass_manager(&self, pass_manager: &PassManager<Self>) -> bool
+    where
+        Self: Sized;
 }
 
 impl PassManagerSubType for Module<'_> {
@@ -223,15 +271,11 @@ pub struct PassManager<T> {
 impl PassManager<FunctionValue<'_>> {
     // return true means some pass modified the module, not an error occurred
     pub fn initialize(&self) -> bool {
-        unsafe {
-            LLVMInitializeFunctionPassManager(self.pass_manager) == 1
-        }
+        unsafe { LLVMInitializeFunctionPassManager(self.pass_manager) == 1 }
     }
 
     pub fn finalize(&self) -> bool {
-        unsafe {
-            LLVMFinalizeFunctionPassManager(self.pass_manager) == 1
-        }
+        unsafe { LLVMFinalizeFunctionPassManager(self.pass_manager) == 1 }
     }
 }
 
@@ -246,9 +290,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     }
 
     pub fn create<I: Borrow<T::Input>>(input: I) -> PassManager<T> {
-        let pass_manager = unsafe {
-            T::create(input)
-        };
+        let pass_manager = unsafe { T::create(input) };
 
         PassManager::new(pass_manager)
     }
@@ -256,18 +298,14 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// This method returns true if any of the passes modified the function or module
     /// and false otherwise.
     pub fn run_on(&self, input: &T) -> bool {
-        unsafe {
-            input.run_in_pass_manager(self)
-        }
+        unsafe { input.run_in_pass_manager(self) }
     }
 
     #[llvm_versions(3.6..=3.8)]
     pub fn add_target_data(&self, target_data: &TargetData) {
         use llvm_sys::target::LLVMAddTargetData;
 
-        unsafe {
-            LLVMAddTargetData(target_data.target_data, self.pass_manager)
-        }
+        unsafe { LLVMAddTargetData(target_data.target_data, self.pass_manager) }
     }
 
     /// This pass promotes "by reference" arguments to be "by value" arguments.
@@ -289,9 +327,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// This case would be best handled when and if LLVM starts supporting multiple
     /// return values from functions.
     pub fn add_argument_promotion_pass(&self) {
-        unsafe {
-            LLVMAddArgumentPromotionPass(self.pass_manager)
-        }
+        unsafe { LLVMAddArgumentPromotionPass(self.pass_manager) }
     }
 
     /// Merges duplicate global constants together into a single constant that is
@@ -299,9 +335,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// of string constants into the program, regardless of whether or not an existing
     /// string is available.
     pub fn add_constant_merge_pass(&self) {
-        unsafe {
-            LLVMAddConstantMergePass(self.pass_manager)
-        }
+        unsafe { LLVMAddConstantMergePass(self.pass_manager) }
     }
 
     /// This pass deletes dead arguments from internal functions. Dead argument
@@ -312,9 +346,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// This pass is often useful as a cleanup pass to run after aggressive
     /// interprocedural passes, which add possibly-dead arguments.
     pub fn add_dead_arg_elimination_pass(&self) {
-        unsafe {
-            LLVMAddDeadArgEliminationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddDeadArgEliminationPass(self.pass_manager) }
     }
 
     /// A simple interprocedural pass which walks the call-graph, looking for
@@ -326,23 +358,17 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// from the function or stored in a global. This pass is implemented
     /// as a bottom-up traversal of the call-graph.
     pub fn add_function_attrs_pass(&self) {
-        unsafe {
-            LLVMAddFunctionAttrsPass(self.pass_manager)
-        }
+        unsafe { LLVMAddFunctionAttrsPass(self.pass_manager) }
     }
 
     /// Bottom-up inlining of functions into callees.
     pub fn add_function_inlining_pass(&self) {
-        unsafe {
-            LLVMAddFunctionInliningPass(self.pass_manager)
-        }
+        unsafe { LLVMAddFunctionInliningPass(self.pass_manager) }
     }
 
     /// A custom inliner that handles only functions that are marked as “always inline”.
     pub fn add_always_inliner_pass(&self) {
-        unsafe {
-            LLVMAddAlwaysInlinerPass(self.pass_manager)
-        }
+        unsafe { LLVMAddAlwaysInlinerPass(self.pass_manager) }
     }
 
     /// This transform is designed to eliminate unreachable internal
@@ -352,18 +378,14 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// whatever is left over. This allows it to delete recursive
     /// chunks of the program which are unreachable.
     pub fn add_global_dce_pass(&self) {
-        unsafe {
-            LLVMAddGlobalDCEPass(self.pass_manager)
-        }
+        unsafe { LLVMAddGlobalDCEPass(self.pass_manager) }
     }
 
     /// This pass transforms simple global variables that never have
     /// their address taken. If obviously true, it marks read/write
     /// globals as constant, deletes variables only stored to, etc.
     pub fn add_global_optimizer_pass(&self) {
-        unsafe {
-            LLVMAddGlobalOptimizerPass(self.pass_manager)
-        }
+        unsafe { LLVMAddGlobalOptimizerPass(self.pass_manager) }
     }
 
     /// This pass implements an extremely simple interprocedural
@@ -377,9 +399,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// [`add_instruction_simplify_pass`].
     #[llvm_versions(3.6..=11.0)]
     pub fn add_ip_constant_propagation_pass(&self) {
-        unsafe {
-            LLVMAddIPConstantPropagationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddIPConstantPropagationPass(self.pass_manager) }
     }
 
     /// This file implements a simple interprocedural pass which
@@ -388,17 +408,13 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// an exception. It implements this as a bottom-up traversal
     /// of the call-graph.
     pub fn add_prune_eh_pass(&self) {
-        unsafe {
-            LLVMAddPruneEHPass(self.pass_manager)
-        }
+        unsafe { LLVMAddPruneEHPass(self.pass_manager) }
     }
 
     /// An interprocedural variant of [Sparse Conditional Constant
     /// Propagation](https://llvm.org/docs/Passes.html#passes-sccp).
     pub fn add_ipsccp_pass(&self) {
-        unsafe {
-            LLVMAddIPSCCPPass(self.pass_manager)
-        }
+        unsafe { LLVMAddIPSCCPPass(self.pass_manager) }
     }
 
     /// This pass loops over all of the functions in the input module,
@@ -406,9 +422,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// other functions and all global variables with initializers are
     /// marked as internal.
     pub fn add_internalize_pass(&self, all_but_main: bool) {
-        unsafe {
-            LLVMAddInternalizePass(self.pass_manager, all_but_main as u32)
-        }
+        unsafe { LLVMAddInternalizePass(self.pass_manager, all_but_main as u32) }
     }
 
     /// This pass loops over all of the functions in the input module,
@@ -416,9 +430,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// are declarations of functions for which no implementation is available
     /// (i.e., declarations for unused library functions).
     pub fn add_strip_dead_prototypes_pass(&self) {
-        unsafe {
-            LLVMAddStripDeadPrototypesPass(self.pass_manager)
-        }
+        unsafe { LLVMAddStripDeadPrototypesPass(self.pass_manager) }
     }
 
     /// Performs code stripping. This transformation can delete:
@@ -432,9 +444,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// would be used, such as reducing code size or making it harder
     /// to reverse engineer code.
     pub fn add_strip_symbol_pass(&self) {
-        unsafe {
-            LLVMAddStripSymbolsPass(self.pass_manager)
-        }
+        unsafe { LLVMAddStripSymbolsPass(self.pass_manager) }
     }
 
     /// This pass combines instructions inside basic blocks to form
@@ -454,23 +464,17 @@ impl<T: PassManagerSubType> PassManager<T> {
     pub fn add_bb_vectorize_pass(&self) {
         use llvm_sys::transforms::vectorize::LLVMAddBBVectorizePass;
 
-        unsafe {
-            LLVMAddBBVectorizePass(self.pass_manager)
-        }
+        unsafe { LLVMAddBBVectorizePass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_loop_vectorize_pass(&self) {
-        unsafe {
-            LLVMAddLoopVectorizePass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopVectorizePass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_slp_vectorize_pass(&self) {
-        unsafe {
-            LLVMAddSLPVectorizePass(self.pass_manager)
-        }
+        unsafe { LLVMAddSLPVectorizePass(self.pass_manager) }
     }
 
     /// ADCE aggressively tries to eliminate code. This pass is similar
@@ -479,24 +483,18 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// similar to [SCCP](https://llvm.org/docs/Passes.html#passes-sccp),
     /// except applied to the liveness of values.
     pub fn add_aggressive_dce_pass(&self) {
-        unsafe {
-            LLVMAddAggressiveDCEPass(self.pass_manager)
-        }
+        unsafe { LLVMAddAggressiveDCEPass(self.pass_manager) }
     }
 
     #[llvm_versions(3.7..=latest)]
     /// No LLVM documentation is available at this time.
     pub fn add_bit_tracking_dce_pass(&self) {
-        unsafe {
-            LLVMAddBitTrackingDCEPass(self.pass_manager)
-        }
+        unsafe { LLVMAddBitTrackingDCEPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_alignment_from_assumptions_pass(&self) {
-        unsafe {
-            LLVMAddAlignmentFromAssumptionsPass(self.pass_manager)
-        }
+        unsafe { LLVMAddAlignmentFromAssumptionsPass(self.pass_manager) }
     }
 
     /// Performs dead code elimination and basic block merging. Specifically:
@@ -506,39 +504,29 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// * Eliminates PHI nodes for basic blocks with a single predecessor.
     /// * Eliminates a basic block that only contains an unconditional branch.
     pub fn add_cfg_simplification_pass(&self) {
-        unsafe {
-            LLVMAddCFGSimplificationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddCFGSimplificationPass(self.pass_manager) }
     }
 
     /// A trivial dead store elimination that only considers basic-block local redundant stores.
     pub fn add_dead_store_elimination_pass(&self) {
-        unsafe {
-            LLVMAddDeadStoreEliminationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddDeadStoreEliminationPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_scalarizer_pass(&self) {
-        unsafe {
-            LLVMAddScalarizerPass(self.pass_manager)
-        }
+        unsafe { LLVMAddScalarizerPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_merged_load_store_motion_pass(&self) {
-        unsafe {
-            LLVMAddMergedLoadStoreMotionPass(self.pass_manager)
-        }
+        unsafe { LLVMAddMergedLoadStoreMotionPass(self.pass_manager) }
     }
 
     /// This pass performs global value numbering to eliminate
     /// fully and partially redundant instructions. It also
     /// performs redundant load elimination.
     pub fn add_gvn_pass(&self) {
-        unsafe {
-            LLVMAddGVNPass(self.pass_manager)
-        }
+        unsafe { LLVMAddGVNPass(self.pass_manager) }
     }
 
     /// This pass performs global value numbering to eliminate
@@ -550,9 +538,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     pub fn add_new_gvn_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddNewGVNPass;
 
-        unsafe {
-            LLVMAddNewGVNPass(self.pass_manager)
-        }
+        unsafe { LLVMAddNewGVNPass(self.pass_manager) }
     }
 
     /// This transformation analyzes and transforms the induction variables (and
@@ -595,9 +581,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// targets where it is profitable, the loop could be transformed to count
     /// down to zero (the "do loop" optimization).
     pub fn add_ind_var_simplify_pass(&self) {
-        unsafe {
-            LLVMAddIndVarSimplifyPass(self.pass_manager)
-        }
+        unsafe { LLVMAddIndVarSimplifyPass(self.pass_manager) }
     }
 
     /// Combine instructions to form fewer, simple instructions. This pass
@@ -641,9 +625,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// calls are simplified is controlled by the [-functionattrs](https://llvm.org/docs/Passes.html#passes-functionattrs)
     /// pass and LLVM’s knowledge of library calls on different targets.
     pub fn add_instruction_combining_pass(&self) {
-        unsafe {
-            LLVMAddInstructionCombiningPass(self.pass_manager)
-        }
+        unsafe { LLVMAddInstructionCombiningPass(self.pass_manager) }
     }
 
     /// Jump threading tries to find distinct threads of control flow
@@ -666,9 +648,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// In this case, the unconditional branch at the end of the first
     /// if can be revectored to the false side of the second if.
     pub fn add_jump_threading_pass(&self) {
-        unsafe {
-            LLVMAddJumpThreadingPass(self.pass_manager)
-        }
+        unsafe { LLVMAddJumpThreadingPass(self.pass_manager) }
     }
 
     /// This pass performs loop invariant code motion,
@@ -704,9 +684,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// alloca'd variable. We then use the mem2reg functionality
     /// to construct the appropriate SSA form for the variable.
     pub fn add_licm_pass(&self) {
-        unsafe {
-            LLVMAddLICMPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLICMPass(self.pass_manager) }
     }
 
     /// This file implements the Dead Loop Deletion Pass.
@@ -715,30 +693,22 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// effects or volatile instructions, and do not contribute
     /// to the computation of the function’s return value.
     pub fn add_loop_deletion_pass(&self) {
-        unsafe {
-            LLVMAddLoopDeletionPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopDeletionPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_loop_idiom_pass(&self) {
-        unsafe {
-            LLVMAddLoopIdiomPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopIdiomPass(self.pass_manager) }
     }
 
     /// A simple loop rotation transformation.
     pub fn add_loop_rotate_pass(&self) {
-        unsafe {
-            LLVMAddLoopRotatePass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopRotatePass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_loop_reroll_pass(&self) {
-        unsafe {
-            LLVMAddLoopRerollPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopRerollPass(self.pass_manager) }
     }
 
     /// This pass implements a simple loop unroller.
@@ -747,9 +717,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// pass, allowing it to determine the trip counts
     /// of loops easily.
     pub fn add_loop_unroll_pass(&self) {
-        unsafe {
-            LLVMAddLoopUnrollPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopUnrollPass(self.pass_manager) }
     }
 
     /// This pass transforms loops that contain branches on
@@ -775,26 +743,20 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// out of the loop, to make the unswitching opportunity
     /// obvious.
     pub fn add_loop_unswitch_pass(&self) {
-        unsafe {
-            LLVMAddLoopUnswitchPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopUnswitchPass(self.pass_manager) }
     }
 
     /// This pass performs various transformations related
     /// to eliminating memcpy calls, or transforming sets
     /// of stores into memsets.
     pub fn add_memcpy_optimize_pass(&self) {
-        unsafe {
-            LLVMAddMemCpyOptPass(self.pass_manager)
-        }
+        unsafe { LLVMAddMemCpyOptPass(self.pass_manager) }
     }
 
     /// This pass performs partial inlining, typically by inlining
     /// an if statement that surrounds the body of the function.
     pub fn add_partially_inline_lib_calls_pass(&self) {
-        unsafe {
-            LLVMAddPartiallyInlineLibCallsPass(self.pass_manager)
-        }
+        unsafe { LLVMAddPartiallyInlineLibCallsPass(self.pass_manager) }
     }
 
     /// Rewrites switch instructions with a sequence of branches,
@@ -806,9 +768,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         #[llvm_versions(7.0..=latest)]
         use llvm_sys::transforms::util::LLVMAddLowerSwitchPass;
 
-        unsafe {
-            LLVMAddLowerSwitchPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLowerSwitchPass(self.pass_manager) }
     }
 
     /// This file promotes memory references to be register references.
@@ -823,9 +783,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         #[llvm_versions(7.0..=latest)]
         use llvm_sys::transforms::util::LLVMAddPromoteMemoryToRegisterPass;
 
-        unsafe {
-            LLVMAddPromoteMemoryToRegisterPass(self.pass_manager)
-        }
+        unsafe { LLVMAddPromoteMemoryToRegisterPass(self.pass_manager) }
     }
 
     /// This pass reassociates commutative expressions in an order that is designed
@@ -839,9 +797,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// (starting at 2), which effectively gives values in deep loops higher
     /// rank than values not in loops.
     pub fn add_reassociate_pass(&self) {
-        unsafe {
-            LLVMAddReassociatePass(self.pass_manager)
-        }
+        unsafe { LLVMAddReassociatePass(self.pass_manager) }
     }
 
     /// Sparse conditional constant propagation and merging, which can
@@ -855,16 +811,12 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// Note that this pass has a habit of making definitions be dead.
     /// It is a good idea to run a DCE pass sometime after running this pass.
     pub fn add_sccp_pass(&self) {
-        unsafe {
-            LLVMAddSCCPPass(self.pass_manager)
-        }
+        unsafe { LLVMAddSCCPPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_scalar_repl_aggregates_pass(&self) {
-        unsafe {
-            LLVMAddScalarReplAggregatesPass(self.pass_manager)
-        }
+        unsafe { LLVMAddScalarReplAggregatesPass(self.pass_manager) }
     }
 
     /// The well-known scalar replacement of aggregates transformation.
@@ -873,23 +825,17 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// member if possible. Then, if possible, it transforms the individual
     /// alloca instructions into nice clean scalar SSA form.
     pub fn add_scalar_repl_aggregates_pass_ssa(&self) {
-        unsafe {
-            LLVMAddScalarReplAggregatesPassSSA(self.pass_manager)
-        }
+        unsafe { LLVMAddScalarReplAggregatesPassSSA(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_scalar_repl_aggregates_pass_with_threshold(&self, threshold: i32) {
-        unsafe {
-            LLVMAddScalarReplAggregatesPassWithThreshold(self.pass_manager, threshold)
-        }
+        unsafe { LLVMAddScalarReplAggregatesPassWithThreshold(self.pass_manager, threshold) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_simplify_lib_calls_pass(&self) {
-        unsafe {
-            LLVMAddSimplifyLibCallsPass(self.pass_manager)
-        }
+        unsafe { LLVMAddSimplifyLibCallsPass(self.pass_manager) }
     }
 
     /// This file transforms calls of the current function (self recursion) followed
@@ -913,9 +859,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// 4. If it can prove that callees do not access theier caller stack frame,
     /// they are marked as eligible for tail call elimination (by the code generator).
     pub fn add_tail_call_elimination_pass(&self) {
-        unsafe {
-            LLVMAddTailCallEliminationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddTailCallEliminationPass(self.pass_manager) }
     }
 
     /// This pass implements constant propagation and merging. It looks for instructions
@@ -939,9 +883,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// [`add_instruction_simplify_pass`].
     #[llvm_versions(3.6..=11.0)]
     pub fn add_constant_propagation_pass(&self) {
-        unsafe {
-            LLVMAddConstantPropagationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddConstantPropagationPass(self.pass_manager) }
     }
 
     /// This pass implements constant propagation and merging. It looks for instructions
@@ -962,9 +904,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// run a Dead Instruction Elimination pass sometime after running this pass.
     #[llvm_versions(12.0..=latest)]
     pub fn add_instruction_simplify_pass(&self) {
-        unsafe {
-            LLVMAddInstructionSimplifyPass(self.pass_manager)
-        }
+        unsafe { LLVMAddInstructionSimplifyPass(self.pass_manager) }
     }
 
     /// This file promotes memory references to be register references.
@@ -974,9 +914,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// rewrite loads and stores as appropriate. This is just the standard SSA
     /// construction algorithm to construct “pruned” SSA form.
     pub fn add_demote_memory_to_register_pass(&self) {
-        unsafe {
-            LLVMAddDemoteMemoryToRegisterPass(self.pass_manager)
-        }
+        unsafe { LLVMAddDemoteMemoryToRegisterPass(self.pass_manager) }
     }
 
     /// Verifies an LLVM IR code. This is useful to run after an optimization
@@ -1031,23 +969,17 @@ impl<T: PassManagerSubType> PassManager<T> {
     ///
     /// Note that this does not provide full security verification (like Java), but instead just tries to ensure that code is well-formed.
     pub fn add_verifier_pass(&self) {
-        unsafe {
-            LLVMAddVerifierPass(self.pass_manager)
-        }
+        unsafe { LLVMAddVerifierPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_correlated_value_propagation_pass(&self) {
-        unsafe {
-            LLVMAddCorrelatedValuePropagationPass(self.pass_manager)
-        }
+        unsafe { LLVMAddCorrelatedValuePropagationPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_early_cse_pass(&self) {
-        unsafe {
-            LLVMAddEarlyCSEPass(self.pass_manager)
-        }
+        unsafe { LLVMAddEarlyCSEPass(self.pass_manager) }
     }
 
     #[llvm_versions(4.0..=latest)]
@@ -1055,104 +987,80 @@ impl<T: PassManagerSubType> PassManager<T> {
     pub fn add_early_cse_mem_ssa_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddEarlyCSEMemSSAPass;
 
-        unsafe {
-            LLVMAddEarlyCSEMemSSAPass(self.pass_manager)
-        }
+        unsafe { LLVMAddEarlyCSEMemSSAPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_lower_expect_intrinsic_pass(&self) {
-        unsafe {
-            LLVMAddLowerExpectIntrinsicPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLowerExpectIntrinsicPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_type_based_alias_analysis_pass(&self) {
-        unsafe {
-            LLVMAddTypeBasedAliasAnalysisPass(self.pass_manager)
-        }
+        unsafe { LLVMAddTypeBasedAliasAnalysisPass(self.pass_manager) }
     }
 
     /// No LLVM documentation is available at this time.
     pub fn add_scoped_no_alias_aa_pass(&self) {
-        unsafe {
-            LLVMAddScopedNoAliasAAPass(self.pass_manager)
-        }
+        unsafe { LLVMAddScopedNoAliasAAPass(self.pass_manager) }
     }
 
     /// A basic alias analysis pass that implements identities
     /// (two different globals cannot alias, etc), but does no
     /// stateful analysis.
     pub fn add_basic_alias_analysis_pass(&self) {
-        unsafe {
-            LLVMAddBasicAliasAnalysisPass(self.pass_manager)
-        }
+        unsafe { LLVMAddBasicAliasAnalysisPass(self.pass_manager) }
     }
 
     #[llvm_versions(7.0..=latest)]
     pub fn add_aggressive_inst_combiner_pass(&self) {
-        #[cfg(feature = "llvm7-0")]
-        use llvm_sys::transforms::scalar::LLVMAddAggressiveInstCombinerPass;
         #[cfg(not(feature = "llvm7-0"))]
         use llvm_sys::transforms::aggressive_instcombine::LLVMAddAggressiveInstCombinerPass;
+        #[cfg(feature = "llvm7-0")]
+        use llvm_sys::transforms::scalar::LLVMAddAggressiveInstCombinerPass;
 
-        unsafe {
-            LLVMAddAggressiveInstCombinerPass(self.pass_manager)
-        }
+        unsafe { LLVMAddAggressiveInstCombinerPass(self.pass_manager) }
     }
 
     #[llvm_versions(7.0..=latest)]
     pub fn add_loop_unroll_and_jam_pass(&self) {
         use llvm_sys::transforms::scalar::LLVMAddLoopUnrollAndJamPass;
 
-        unsafe {
-            LLVMAddLoopUnrollAndJamPass(self.pass_manager)
-        }
+        unsafe { LLVMAddLoopUnrollAndJamPass(self.pass_manager) }
     }
 
     #[llvm_versions(8.0..=latest)]
     pub fn add_coroutine_early_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroEarlyPass;
 
-        unsafe {
-            LLVMAddCoroEarlyPass(self.pass_manager)
-        }
+        unsafe { LLVMAddCoroEarlyPass(self.pass_manager) }
     }
 
     #[llvm_versions(8.0..=latest)]
     pub fn add_coroutine_split_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroSplitPass;
 
-        unsafe {
-            LLVMAddCoroSplitPass(self.pass_manager)
-        }
+        unsafe { LLVMAddCoroSplitPass(self.pass_manager) }
     }
 
     #[llvm_versions(8.0..=latest)]
     pub fn add_coroutine_elide_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroElidePass;
 
-        unsafe {
-            LLVMAddCoroElidePass(self.pass_manager)
-        }
+        unsafe { LLVMAddCoroElidePass(self.pass_manager) }
     }
 
     #[llvm_versions(8.0..=latest)]
     pub fn add_coroutine_cleanup_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroCleanupPass;
 
-        unsafe {
-            LLVMAddCoroCleanupPass(self.pass_manager)
-        }
+        unsafe { LLVMAddCoroCleanupPass(self.pass_manager) }
     }
 }
 
 impl<T> Drop for PassManager<T> {
     fn drop(&mut self) {
-        unsafe {
-            LLVMDisposePassManager(self.pass_manager)
-        }
+        unsafe { LLVMDisposePassManager(self.pass_manager) }
     }
 }
 
@@ -1165,98 +1073,68 @@ impl PassRegistry {
     pub fn new(pass_registry: LLVMPassRegistryRef) -> PassRegistry {
         assert!(!pass_registry.is_null());
 
-        PassRegistry {
-            pass_registry,
-        }
+        PassRegistry { pass_registry }
     }
 
     pub fn get_global() -> PassRegistry {
-        let pass_registry = unsafe {
-            LLVMGetGlobalPassRegistry()
-        };
+        let pass_registry = unsafe { LLVMGetGlobalPassRegistry() };
 
         PassRegistry::new(pass_registry)
     }
 
     pub fn initialize_core(&self) {
-        unsafe {
-            LLVMInitializeCore(self.pass_registry)
-        }
+        unsafe { LLVMInitializeCore(self.pass_registry) }
     }
 
     pub fn initialize_transform_utils(&self) {
-        unsafe {
-            LLVMInitializeTransformUtils(self.pass_registry)
-        }
+        unsafe { LLVMInitializeTransformUtils(self.pass_registry) }
     }
 
     pub fn initialize_scalar_opts(&self) {
-        unsafe {
-            LLVMInitializeScalarOpts(self.pass_registry)
-        }
+        unsafe { LLVMInitializeScalarOpts(self.pass_registry) }
     }
 
     pub fn initialize_obj_carc_opts(&self) {
-        unsafe {
-            LLVMInitializeObjCARCOpts(self.pass_registry)
-        }
+        unsafe { LLVMInitializeObjCARCOpts(self.pass_registry) }
     }
 
     pub fn initialize_vectorization(&self) {
-        unsafe {
-            LLVMInitializeVectorization(self.pass_registry)
-        }
+        unsafe { LLVMInitializeVectorization(self.pass_registry) }
     }
 
     pub fn initialize_inst_combine(&self) {
-        unsafe {
-            LLVMInitializeInstCombine(self.pass_registry)
-        }
+        unsafe { LLVMInitializeInstCombine(self.pass_registry) }
     }
 
     // Let us begin our initial public offering
     pub fn initialize_ipo(&self) {
-        unsafe {
-            LLVMInitializeIPO(self.pass_registry)
-        }
+        unsafe { LLVMInitializeIPO(self.pass_registry) }
     }
 
     pub fn initialize_instrumentation(&self) {
-        unsafe {
-            LLVMInitializeInstrumentation(self.pass_registry)
-        }
+        unsafe { LLVMInitializeInstrumentation(self.pass_registry) }
     }
 
     pub fn initialize_analysis(&self) {
-        unsafe {
-            LLVMInitializeAnalysis(self.pass_registry)
-        }
+        unsafe { LLVMInitializeAnalysis(self.pass_registry) }
     }
 
     pub fn initialize_ipa(&self) {
-        unsafe {
-            LLVMInitializeIPA(self.pass_registry)
-        }
+        unsafe { LLVMInitializeIPA(self.pass_registry) }
     }
 
     pub fn initialize_codegen(&self) {
-        unsafe {
-            LLVMInitializeCodeGen(self.pass_registry)
-        }
+        unsafe { LLVMInitializeCodeGen(self.pass_registry) }
     }
 
     pub fn initialize_target(&self) {
-        unsafe {
-            LLVMInitializeTarget(self.pass_registry)
-        }
+        unsafe { LLVMInitializeTarget(self.pass_registry) }
     }
 
     #[llvm_versions(7.0..=latest)]
     pub fn initialize_aggressive_inst_combiner(&self) {
         use llvm_sys::initialization::LLVMInitializeAggressiveInstCombiner;
 
-        unsafe {
-            LLVMInitializeAggressiveInstCombiner(self.pass_registry)
-        }
+        unsafe { LLVMInitializeAggressiveInstCombiner(self.pass_registry) }
     }
 }

--- a/src/support/error_handling.rs
+++ b/src/support/error_handling.rs
@@ -1,13 +1,13 @@
 //! This module contains some supplemental functions for dealing with errors.
 
+use libc::c_void;
+use llvm_sys::core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity};
 #[llvm_versions(3.6..3.8)]
 use llvm_sys::core::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler};
 #[llvm_versions(3.8..=latest)]
 use llvm_sys::error_handling::{LLVMInstallFatalErrorHandler, LLVMResetFatalErrorHandler};
-use llvm_sys::core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity};
 use llvm_sys::prelude::LLVMDiagnosticInfoRef;
 use llvm_sys::LLVMDiagnosticSeverity;
-use libc::c_void;
 
 // REVIEW: Maybe it's possible to have a safe wrapper? If we can
 // wrap the provided function input ptr into a &CStr somehow
@@ -28,9 +28,7 @@ pub unsafe fn install_fatal_error_handler(handler: extern "C" fn(*const ::libc::
 
 /// Resets LLVM's fatal error handler back to the default
 pub fn reset_fatal_error_handler() {
-    unsafe {
-        LLVMResetFatalErrorHandler()
-    }
+    unsafe { LLVMResetFatalErrorHandler() }
 }
 
 pub(crate) struct DiagnosticInfo {
@@ -39,15 +37,11 @@ pub(crate) struct DiagnosticInfo {
 
 impl DiagnosticInfo {
     pub(crate) fn new(diagnostic_info: LLVMDiagnosticInfoRef) -> Self {
-        DiagnosticInfo {
-            diagnostic_info,
-        }
+        DiagnosticInfo { diagnostic_info }
     }
 
     pub(crate) fn get_description(&self) -> *mut ::libc::c_char {
-        unsafe {
-            LLVMGetDiagInfoDescription(self.diagnostic_info)
-        }
+        unsafe { LLVMGetDiagInfoDescription(self.diagnostic_info) }
     }
 
     pub(crate) fn severity_is_error(&self) -> bool {
@@ -65,7 +59,10 @@ impl DiagnosticInfo {
 //
 // https://github.com/llvm-mirror/llvm/blob/master/tools/llvm-c-test/diagnostic.c was super useful
 // for figuring out how to get this to work
-pub(crate) extern "C" fn get_error_str_diagnostic_handler(diagnostic_info: LLVMDiagnosticInfoRef, void_ptr: *mut c_void) {
+pub(crate) extern "C" fn get_error_str_diagnostic_handler(
+    diagnostic_info: LLVMDiagnosticInfoRef,
+    void_ptr: *mut c_void,
+) {
     let diagnostic_info = DiagnosticInfo::new(diagnostic_info);
 
     if diagnostic_info.severity_is_error() {

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -7,8 +7,8 @@ use llvm_sys::support::LLVMLoadLibraryPermanently;
 
 use std::borrow::Cow;
 use std::error::Error;
+use std::ffi::{CStr, CString};
 use std::fmt::{self, Debug, Display, Formatter};
-use std::ffi::{CString, CStr};
 use std::ops::Deref;
 
 /// An owned LLVM String. Also known as a LLVM Message
@@ -19,9 +19,7 @@ pub struct LLVMString {
 
 impl LLVMString {
     pub(crate) unsafe fn new(ptr: *const c_char) -> Self {
-        LLVMString {
-            ptr,
-        }
+        LLVMString { ptr }
     }
 
     /// This is a convenience method for creating a Rust `String`,
@@ -35,18 +33,14 @@ impl LLVMString {
 
     /// This method will allocate a c string through LLVM
     pub(crate) fn create_from_c_str(string: &CStr) -> LLVMString {
-        unsafe {
-            LLVMString::new(LLVMCreateMessage(string.as_ptr() as *const _))
-        }
+        unsafe { LLVMString::new(LLVMCreateMessage(string.as_ptr() as *const _)) }
     }
 
     /// This method will allocate a c string through LLVM
     pub(crate) fn create_from_str(string: &str) -> LLVMString {
         debug_assert_eq!(string.as_bytes()[string.as_bytes().len() - 1], 0);
 
-        unsafe {
-            LLVMString::new(LLVMCreateMessage(string.as_ptr() as *const _))
-        }
+        unsafe { LLVMString::new(LLVMCreateMessage(string.as_ptr() as *const _)) }
     }
 }
 
@@ -54,9 +48,7 @@ impl Deref for LLVMString {
     type Target = CStr;
 
     fn deref(&self) -> &Self::Target {
-        unsafe {
-            CStr::from_ptr(self.ptr)
-        }
+        unsafe { CStr::from_ptr(self.ptr) }
     }
 }
 
@@ -80,7 +72,8 @@ impl PartialEq for LLVMString {
 
 impl Error for LLVMString {
     fn description(&self) -> &str {
-        self.to_str().expect("Could not convert LLVMString to str (likely invalid unicode)")
+        self.to_str()
+            .expect("Could not convert LLVMString to str (likely invalid unicode)")
     }
 
     fn cause(&self) -> Option<&dyn Error> {
@@ -110,9 +103,7 @@ impl LLVMStringOrRaw {
     pub fn as_str(&self) -> &CStr {
         match self {
             LLVMStringOrRaw::Owned(llvm_string) => llvm_string.deref(),
-            LLVMStringOrRaw::Borrowed(ptr) => unsafe {
-                CStr::from_ptr(*ptr)
-            },
+            LLVMStringOrRaw::Borrowed(ptr) => unsafe { CStr::from_ptr(*ptr) },
         }
     }
 }
@@ -134,9 +125,7 @@ pub unsafe fn shutdown_llvm() {
 pub fn load_library_permanently(filename: &str) -> bool {
     let filename = to_c_str(filename);
 
-    unsafe {
-        LLVMLoadLibraryPermanently(filename.as_ptr()) == 1
-    }
+    unsafe { LLVMLoadLibraryPermanently(filename.as_ptr()) == 1 }
 }
 
 /// Determines whether or not LLVM has been configured to run in multithreaded mode. (Inkwell currently does
@@ -144,9 +133,7 @@ pub fn load_library_permanently(filename: &str) -> bool {
 pub fn is_multithreaded() -> bool {
     use llvm_sys::core::LLVMIsMultithreaded;
 
-    unsafe {
-        LLVMIsMultithreaded() == 1
-    }
+    unsafe { LLVMIsMultithreaded() == 1 }
 }
 
 pub fn enable_llvm_pretty_stack_trace() {
@@ -155,9 +142,7 @@ pub fn enable_llvm_pretty_stack_trace() {
     #[llvm_versions(3.8..=latest)]
     use llvm_sys::error_handling::LLVMEnablePrettyStackTrace;
 
-    unsafe {
-        LLVMEnablePrettyStackTrace()
-    }
+    unsafe { LLVMEnablePrettyStackTrace() }
 }
 
 /// This function takes in a Rust string and either:
@@ -175,9 +160,7 @@ pub(crate) fn to_c_str<'s>(mut s: &'s str) -> Cow<'s, CStr> {
         return Cow::from(CString::new(s).expect("unreachable since null bytes are checked"));
     }
 
-    unsafe {
-        Cow::from(CStr::from_ptr(s.as_ptr() as *const _))
-    }
+    unsafe { Cow::from(CStr::from_ptr(s.as_ptr() as *const _)) }
 }
 
 #[test]

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,10 +1,10 @@
 use llvm_sys::target::{
     LLVMABIAlignmentOfType, LLVMABISizeOfType, LLVMByteOrder, LLVMByteOrdering,
     LLVMCallFrameAlignmentOfType, LLVMCopyStringRepOfTargetData, LLVMCreateTargetData,
-    LLVMDisposeTargetData, LLVMElementAtOffset,
-    LLVMIntPtrTypeForASInContext, LLVMIntPtrTypeInContext, LLVMOffsetOfElement, LLVMPointerSize,
-    LLVMPointerSizeForAS, LLVMPreferredAlignmentOfGlobal, LLVMPreferredAlignmentOfType,
-    LLVMSizeOfTypeInBits, LLVMStoreSizeOfType, LLVMTargetDataRef,
+    LLVMDisposeTargetData, LLVMElementAtOffset, LLVMIntPtrTypeForASInContext,
+    LLVMIntPtrTypeInContext, LLVMOffsetOfElement, LLVMPointerSize, LLVMPointerSizeForAS,
+    LLVMPreferredAlignmentOfGlobal, LLVMPreferredAlignmentOfType, LLVMSizeOfTypeInBits,
+    LLVMStoreSizeOfType, LLVMTargetDataRef,
 };
 #[llvm_versions(4.0..=latest)]
 use llvm_sys::target_machine::LLVMCreateTargetDataLayout;
@@ -102,16 +102,14 @@ pub struct TargetTriple {
 
 impl TargetTriple {
     pub(crate) fn new(triple: LLVMString) -> TargetTriple {
-        TargetTriple {
-            triple,
-        }
+        TargetTriple { triple }
     }
 
     pub fn create(triple: &str) -> TargetTriple {
         let c_string = to_c_str(triple);
 
         TargetTriple {
-            triple: LLVMString::create_from_c_str(&c_string)
+            triple: LLVMString::create_from_c_str(&c_string),
         }
     }
 
@@ -948,9 +946,7 @@ impl Target {
             return None;
         }
 
-        unsafe {
-            Some(TargetMachine::new(target_machine))
-        }
+        unsafe { Some(TargetMachine::new(target_machine)) }
     }
 
     pub fn get_first() -> Option<Self> {
@@ -963,9 +959,7 @@ impl Target {
             return None;
         }
 
-        unsafe {
-            Some(Target::new(target))
-        }
+        unsafe { Some(Target::new(target)) }
     }
 
     pub fn get_next(&self) -> Option<Self> {
@@ -975,9 +969,7 @@ impl Target {
             return None;
         }
 
-        unsafe {
-            Some(Target::new(target))
-        }
+        unsafe { Some(Target::new(target)) }
     }
 
     pub fn get_name(&self) -> &CStr {
@@ -1004,9 +996,7 @@ impl Target {
             return None;
         }
 
-        unsafe {
-            Some(Target::new(target))
-        }
+        unsafe { Some(Target::new(target)) }
     }
 
     pub fn from_triple(triple: &TargetTriple) -> Result<Self, LLVMString> {
@@ -1015,7 +1005,9 @@ impl Target {
 
         let code = {
             let _guard = TARGET_LOCK.read();
-            unsafe { LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, err_string.as_mut_ptr()) }
+            unsafe {
+                LLVMGetTargetFromTriple(triple.as_ptr(), &mut target, err_string.as_mut_ptr())
+            }
         };
 
         if code == 1 {
@@ -1024,9 +1016,7 @@ impl Target {
             }
         }
 
-        unsafe {
-            Ok(Target::new(target))
-        }
+        unsafe { Ok(Target::new(target)) }
     }
 
     pub fn has_jit(&self) -> bool {
@@ -1055,9 +1045,7 @@ impl TargetMachine {
     }
 
     pub fn get_target(&self) -> Target {
-        unsafe {
-            Target::new(LLVMGetTargetMachineTarget(self.target_machine))
-        }
+        unsafe { Target::new(LLVMGetTargetMachineTarget(self.target_machine)) }
     }
 
     pub fn get_triple(&self) -> TargetTriple {
@@ -1101,9 +1089,7 @@ impl TargetMachine {
     pub fn get_host_cpu_name() -> LLVMString {
         use llvm_sys::target_machine::LLVMGetHostCPUName;
 
-        unsafe {
-            LLVMString::new(LLVMGetHostCPUName())
-        }
+        unsafe { LLVMString::new(LLVMGetHostCPUName()) }
     }
 
     /// Gets a comma separated list of supported features by the host CPU.
@@ -1115,15 +1101,11 @@ impl TargetMachine {
     pub fn get_host_cpu_features() -> LLVMString {
         use llvm_sys::target_machine::LLVMGetHostCPUFeatures;
 
-        unsafe {
-            LLVMString::new(LLVMGetHostCPUFeatures())
-        }
+        unsafe { LLVMString::new(LLVMGetHostCPUFeatures()) }
     }
 
     pub fn get_cpu(&self) -> LLVMString {
-        unsafe {
-            LLVMString::new(LLVMGetTargetMachineCPU(self.target_machine))
-        }
+        unsafe { LLVMString::new(LLVMGetTargetMachineCPU(self.target_machine)) }
     }
 
     pub fn get_feature_string(&self) -> &CStr {
@@ -1133,9 +1115,7 @@ impl TargetMachine {
     /// Create TargetData from this target machine
     #[llvm_versions(4.0..=latest)]
     pub fn get_target_data(&self) -> TargetData {
-        unsafe {
-            TargetData::new(LLVMCreateTargetDataLayout(self.target_machine))
-        }
+        unsafe { TargetData::new(LLVMCreateTargetDataLayout(self.target_machine)) }
     }
 
     pub fn set_asm_verbosity(&self, verbosity: bool) {
@@ -1304,9 +1284,7 @@ impl TargetData {
     pub(crate) unsafe fn new(target_data: LLVMTargetDataRef) -> TargetData {
         assert!(!target_data.is_null());
 
-        TargetData {
-            target_data,
-        }
+        TargetData { target_data }
     }
 
     /// Gets the `IntType` representing a bit width of a pointer. It will be assigned the referenced context.
@@ -1326,7 +1304,9 @@ impl TargetData {
     /// let target_data = execution_engine.get_target_data();
     /// let int_type = target_data.ptr_sized_int_type_in_context(&context, None);
     /// ```
-    #[deprecated(note = "This method will be removed in the future. Please use Context::ptr_sized_int_type instead.")]
+    #[deprecated(
+        note = "This method will be removed in the future. Please use Context::ptr_sized_int_type instead."
+    )]
     pub fn ptr_sized_int_type_in_context<'ctx>(
         &self,
         context: &'ctx Context,
@@ -1343,15 +1323,11 @@ impl TargetData {
             None => unsafe { LLVMIntPtrTypeInContext(context.context, self.target_data) },
         };
 
-        unsafe {
-            IntType::new(int_type_ptr)
-        }
+        unsafe { IntType::new(int_type_ptr) }
     }
 
     pub fn get_data_layout(&self) -> DataLayout {
-        unsafe {
-            DataLayout::new_owned(LLVMCopyStringRepOfTargetData(self.target_data))
-        }
+        unsafe { DataLayout::new_owned(LLVMCopyStringRepOfTargetData(self.target_data)) }
     }
 
     // REVIEW: Does this only work if Sized?
@@ -1363,9 +1339,7 @@ impl TargetData {
     pub fn create(str_repr: &str) -> TargetData {
         let c_string = to_c_str(str_repr);
 
-        unsafe {
-            TargetData::new(LLVMCreateTargetData(c_string.as_ptr()))
-        }
+        unsafe { TargetData::new(LLVMCreateTargetData(c_string.as_ptr())) }
     }
 
     pub fn get_byte_ordering(&self) -> ByteOrdering {

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -1,11 +1,11 @@
 use llvm_sys::core::{LLVMConstArray, LLVMGetArrayLength};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{Type, BasicTypeEnum, PointerType, FunctionType};
-use crate::values::{AsValueRef, ArrayValue, IntValue};
+use crate::types::{BasicTypeEnum, FunctionType, PointerType, Type};
+use crate::values::{ArrayValue, AsValueRef, IntValue};
+use crate::AddressSpace;
 
 /// An `ArrayType` is the type of contiguous constants or variables.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -103,7 +103,11 @@ impl<'ctx> ArrayType<'ctx> {
     /// let i8_array_type = i8_type.array_type(3);
     /// let fn_type = i8_array_type.fn_type(&[], false);
     /// ```
-    pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+    pub fn fn_type(
+        self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
         self.array_type.fn_type(param_types, is_var_args)
     }
 
@@ -141,11 +145,13 @@ impl<'ctx> ArrayType<'ctx> {
     /// assert!(f32_array_array.is_const());
     /// ```
     pub fn const_array(self, values: &[ArrayValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter()
-                                                  .map(|val| val.as_value_ref())
-                                                  .collect();
+        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
-            ArrayValue::new(LLVMConstArray(self.as_type_ref(), values.as_mut_ptr(), values.len() as u32))
+            ArrayValue::new(LLVMConstArray(
+                self.as_type_ref(),
+                values.as_mut_ptr(),
+                values.len() as u32,
+            ))
         }
     }
 
@@ -162,9 +168,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// let i8_array_zero = i8_array_type.const_zero();
     /// ```
     pub fn const_zero(self) -> ArrayValue<'ctx> {
-        unsafe {
-            ArrayValue::new(self.array_type.const_zero())
-        }
+        unsafe { ArrayValue::new(self.array_type.const_zero()) }
     }
 
     /// Gets the length of this `ArrayType`.
@@ -181,9 +185,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// assert_eq!(i8_array_type.len(), 3);
     /// ```
     pub fn len(self) -> u32 {
-        unsafe {
-            LLVMGetArrayLength(self.as_type_ref())
-        }
+        unsafe { LLVMGetArrayLength(self.as_type_ref()) }
     }
 
     // See Type::print_to_stderr note on 5.0+ status
@@ -207,9 +209,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// assert!(i8_array_undef.is_undef());
     /// ```
     pub fn get_undef(self) -> ArrayValue<'ctx> {
-        unsafe {
-            ArrayValue::new(self.array_type.get_undef())
-        }
+        unsafe { ArrayValue::new(self.array_type.get_undef()) }
     }
 
     // SubType: ArrayType<BT> -> BT?
@@ -229,7 +229,6 @@ impl<'ctx> ArrayType<'ctx> {
     pub fn get_element_type(self) -> BasicTypeEnum<'ctx> {
         self.array_type.get_element_type().to_basic_type_enum()
     }
-
 }
 
 impl AsTypeRef for ArrayType<'_> {

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -1,9 +1,11 @@
 use llvm_sys::core::LLVMGetTypeKind;
-use llvm_sys::LLVMTypeKind;
 use llvm_sys::prelude::LLVMTypeRef;
+use llvm_sys::LLVMTypeKind;
 
-use crate::types::{IntType, VoidType, FunctionType, PointerType, VectorType, ArrayType, StructType, FloatType};
 use crate::types::traits::AsTypeRef;
+use crate::types::{
+    ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, VectorType, VoidType,
+};
 use crate::values::{BasicValue, BasicValueEnum, IntValue};
 
 use std::convert::TryFrom;
@@ -93,23 +95,27 @@ impl<'ctx> AnyTypeEnum<'ctx> {
     pub(crate) unsafe fn new(type_: LLVMTypeRef) -> Self {
         match LLVMGetTypeKind(type_) {
             LLVMTypeKind::LLVMVoidTypeKind => AnyTypeEnum::VoidType(VoidType::new(type_)),
-            LLVMTypeKind::LLVMHalfTypeKind |
-            LLVMTypeKind::LLVMFloatTypeKind |
-            LLVMTypeKind::LLVMDoubleTypeKind |
-            LLVMTypeKind::LLVMX86_FP80TypeKind |
-            LLVMTypeKind::LLVMFP128TypeKind |
-            LLVMTypeKind::LLVMPPC_FP128TypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
+            LLVMTypeKind::LLVMHalfTypeKind
+            | LLVMTypeKind::LLVMFloatTypeKind
+            | LLVMTypeKind::LLVMDoubleTypeKind
+            | LLVMTypeKind::LLVMX86_FP80TypeKind
+            | LLVMTypeKind::LLVMFP128TypeKind
+            | LLVMTypeKind::LLVMPPC_FP128TypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
             LLVMTypeKind::LLVMBFloatTypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMLabelTypeKind => panic!("FIXME: Unsupported type: Label"),
             LLVMTypeKind::LLVMIntegerTypeKind => AnyTypeEnum::IntType(IntType::new(type_)),
-            LLVMTypeKind::LLVMFunctionTypeKind => AnyTypeEnum::FunctionType(FunctionType::new(type_)),
+            LLVMTypeKind::LLVMFunctionTypeKind => {
+                AnyTypeEnum::FunctionType(FunctionType::new(type_))
+            }
             LLVMTypeKind::LLVMStructTypeKind => AnyTypeEnum::StructType(StructType::new(type_)),
             LLVMTypeKind::LLVMArrayTypeKind => AnyTypeEnum::ArrayType(ArrayType::new(type_)),
             LLVMTypeKind::LLVMPointerTypeKind => AnyTypeEnum::PointerType(PointerType::new(type_)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
             #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
-            LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
+            LLVMTypeKind::LLVMScalableVectorTypeKind => {
+                AnyTypeEnum::VectorType(VectorType::new(type_))
+            }
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("FIXME: Unsupported type: Metadata"),
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("FIXME: Unsupported type: MMX"),
             #[cfg(feature = "llvm12-0")]
@@ -121,9 +127,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
 
     /// This will panic if type is a void or function type.
     pub(crate) fn to_basic_type_enum(&self) -> BasicTypeEnum<'ctx> {
-        unsafe {
-            BasicTypeEnum::new(self.as_type_ref())
-        }
+        unsafe { BasicTypeEnum::new(self.as_type_ref()) }
     }
 
     pub fn into_array_type(self) -> ArrayType<'ctx> {
@@ -239,21 +243,27 @@ impl<'ctx> AnyTypeEnum<'ctx> {
 impl<'ctx> BasicTypeEnum<'ctx> {
     pub(crate) unsafe fn new(type_: LLVMTypeRef) -> Self {
         match LLVMGetTypeKind(type_) {
-            LLVMTypeKind::LLVMHalfTypeKind |
-            LLVMTypeKind::LLVMFloatTypeKind |
-            LLVMTypeKind::LLVMDoubleTypeKind |
-            LLVMTypeKind::LLVMX86_FP80TypeKind |
-            LLVMTypeKind::LLVMFP128TypeKind |
-            LLVMTypeKind::LLVMPPC_FP128TypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
+            LLVMTypeKind::LLVMHalfTypeKind
+            | LLVMTypeKind::LLVMFloatTypeKind
+            | LLVMTypeKind::LLVMDoubleTypeKind
+            | LLVMTypeKind::LLVMX86_FP80TypeKind
+            | LLVMTypeKind::LLVMFP128TypeKind
+            | LLVMTypeKind::LLVMPPC_FP128TypeKind => {
+                BasicTypeEnum::FloatType(FloatType::new(type_))
+            }
             #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
             LLVMTypeKind::LLVMBFloatTypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMIntegerTypeKind => BasicTypeEnum::IntType(IntType::new(type_)),
             LLVMTypeKind::LLVMStructTypeKind => BasicTypeEnum::StructType(StructType::new(type_)),
-            LLVMTypeKind::LLVMPointerTypeKind => BasicTypeEnum::PointerType(PointerType::new(type_)),
+            LLVMTypeKind::LLVMPointerTypeKind => {
+                BasicTypeEnum::PointerType(PointerType::new(type_))
+            }
             LLVMTypeKind::LLVMArrayTypeKind => BasicTypeEnum::ArrayType(ArrayType::new(type_)),
             LLVMTypeKind::LLVMVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
             #[cfg(any(feature = "llvm11-0", feature = "llvm12-0"))]
-            LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
+            LLVMTypeKind::LLVMScalableVectorTypeKind => {
+                BasicTypeEnum::VectorType(VectorType::new(type_))
+            }
             LLVMTypeKind::LLVMMetadataTypeKind => unreachable!("Unsupported basic type: Metadata"),
             // see https://llvm.org/docs/LangRef.html#x86-mmx-type
             LLVMTypeKind::LLVMX86_MMXTypeKind => unreachable!("Unsupported basic type: MMX"),
@@ -262,7 +272,9 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             LLVMTypeKind::LLVMX86_AMXTypeKind => unreachable!("Unsupported basic type: AMX"),
             LLVMTypeKind::LLVMLabelTypeKind => unreachable!("Unsupported basic type: Label"),
             LLVMTypeKind::LLVMVoidTypeKind => unreachable!("Unsupported basic type: VoidType"),
-            LLVMTypeKind::LLVMFunctionTypeKind => unreachable!("Unsupported basic type: FunctionType"),
+            LLVMTypeKind::LLVMFunctionTypeKind => {
+                unreachable!("Unsupported basic type: FunctionType")
+            }
             #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7")))]
             LLVMTypeKind::LLVMTokenTypeKind => unreachable!("Unsupported basic type: Token"),
         }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -1,12 +1,12 @@
-use llvm_sys::core::{LLVMConstReal, LLVMConstRealOfStringAndSize, LLVMConstArray};
+use llvm_sys::core::{LLVMConstArray, LLVMConstReal, LLVMConstRealOfStringAndSize};
 use llvm_sys::execution_engine::LLVMCreateGenericValueOfFloat;
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{Type, PointerType, FunctionType, BasicTypeEnum, ArrayType, VectorType};
-use crate::values::{AsValueRef, ArrayValue, FloatValue, GenericValue, IntValue};
+use crate::types::{ArrayType, BasicTypeEnum, FunctionType, PointerType, Type, VectorType};
+use crate::values::{ArrayValue, AsValueRef, FloatValue, GenericValue, IntValue};
+use crate::AddressSpace;
 
 /// A `FloatType` is the type of a floating point constant or variable.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -34,7 +34,11 @@ impl<'ctx> FloatType<'ctx> {
     /// let f32_type = context.f32_type();
     /// let fn_type = f32_type.fn_type(&[], false);
     /// ```
-    pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+    pub fn fn_type(
+        self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
         self.float_type.fn_type(param_types, is_var_args)
     }
 
@@ -87,9 +91,7 @@ impl<'ctx> FloatType<'ctx> {
     /// let f32_value = f32_type.const_float(42.);
     /// ```
     pub fn const_float(self, value: f64) -> FloatValue<'ctx> {
-        unsafe {
-            FloatValue::new(LLVMConstReal(self.float_type.ty, value))
-        }
+        unsafe { FloatValue::new(LLVMConstReal(self.float_type.ty, value)) }
     }
 
     /// Create a `FloatValue` from a string. LLVM provides no error handling here,
@@ -125,7 +127,11 @@ impl<'ctx> FloatType<'ctx> {
     /// ```
     pub fn const_float_from_string(self, slice: &str) -> FloatValue<'ctx> {
         unsafe {
-            FloatValue::new(LLVMConstRealOfStringAndSize(self.as_type_ref(), slice.as_ptr() as *const ::libc::c_char, slice.len() as u32))
+            FloatValue::new(LLVMConstRealOfStringAndSize(
+                self.as_type_ref(),
+                slice.as_ptr() as *const ::libc::c_char,
+                slice.len() as u32,
+            ))
         }
     }
 
@@ -144,9 +150,7 @@ impl<'ctx> FloatType<'ctx> {
     /// assert_eq!(f32_zero.print_to_string().to_string(), "float 0.000000e+00");
     /// ```
     pub fn const_zero(self) -> FloatValue<'ctx> {
-        unsafe {
-            FloatValue::new(self.float_type.const_zero())
-        }
+        unsafe { FloatValue::new(self.float_type.const_zero()) }
     }
 
     /// Gets the size of this `FloatType`. Value may vary depending on the target architecture.
@@ -233,16 +237,12 @@ impl<'ctx> FloatType<'ctx> {
     /// assert!(f32_undef.is_undef());
     /// ```
     pub fn get_undef(&self) -> FloatValue<'ctx> {
-        unsafe {
-            FloatValue::new(self.float_type.get_undef())
-        }
+        unsafe { FloatValue::new(self.float_type.get_undef()) }
     }
 
     /// Creates a `GenericValue` for use with `ExecutionEngine`s.
     pub fn create_generic_value(self, value: f64) -> GenericValue<'ctx> {
-        unsafe {
-            GenericValue::new(LLVMCreateGenericValueOfFloat(self.as_type_ref(), value))
-        }
+        unsafe { GenericValue::new(LLVMCreateGenericValueOfFloat(self.as_type_ref(), value)) }
     }
 
     /// Creates a constant `ArrayValue`.
@@ -260,11 +260,13 @@ impl<'ctx> FloatType<'ctx> {
     /// assert!(f32_array.is_const());
     /// ```
     pub fn const_array(self, values: &[FloatValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter()
-                                                  .map(|val| val.as_value_ref())
-                                                  .collect();
+        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
-            ArrayValue::new(LLVMConstArray(self.as_type_ref(), values.as_mut_ptr(), values.len() as u32))
+            ArrayValue::new(LLVMConstArray(
+                self.as_type_ref(),
+                values.as_mut_ptr(),
+                values.len() as u32,
+            ))
         }
     }
 }

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -1,14 +1,17 @@
-use llvm_sys::LLVMTypeKind;
-use llvm_sys::core::{LLVMGetParamTypes, LLVMIsFunctionVarArg, LLVMCountParamTypes, LLVMGetReturnType, LLVMGetTypeKind};
+use llvm_sys::core::{
+    LLVMCountParamTypes, LLVMGetParamTypes, LLVMGetReturnType, LLVMGetTypeKind,
+    LLVMIsFunctionVarArg,
+};
 use llvm_sys::prelude::LLVMTypeRef;
+use llvm_sys::LLVMTypeKind;
 
 use std::fmt;
 use std::mem::forget;
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{AnyType, PointerType, Type, BasicTypeEnum};
+use crate::types::{AnyType, BasicTypeEnum, PointerType, Type};
+use crate::AddressSpace;
 
 /// A `FunctionType` is the type of a function variable.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -21,7 +24,7 @@ impl<'ctx> FunctionType<'ctx> {
         assert!(!fn_type.is_null());
 
         FunctionType {
-            fn_type: Type::new(fn_type)
+            fn_type: Type::new(fn_type),
         }
     }
 
@@ -58,9 +61,7 @@ impl<'ctx> FunctionType<'ctx> {
     /// assert!(fn_type.is_var_arg());
     /// ```
     pub fn is_var_arg(self) -> bool {
-        unsafe {
-            LLVMIsFunctionVarArg(self.as_type_ref()) != 0
-        }
+        unsafe { LLVMIsFunctionVarArg(self.as_type_ref()) != 0 }
     }
 
     /// Gets param types this `FunctionType` has.
@@ -91,7 +92,10 @@ impl<'ctx> FunctionType<'ctx> {
             Vec::from_raw_parts(ptr, count as usize, count as usize)
         };
 
-        raw_vec.iter().map(|val| unsafe { BasicTypeEnum::new(*val) }).collect()
+        raw_vec
+            .iter()
+            .map(|val| unsafe { BasicTypeEnum::new(*val) })
+            .collect()
     }
 
     /// Counts the number of param types this `FunctionType` has.
@@ -108,9 +112,7 @@ impl<'ctx> FunctionType<'ctx> {
     /// assert_eq!(fn_type.count_param_types(), 1);
     /// ```
     pub fn count_param_types(self) -> u32 {
-        unsafe {
-            LLVMCountParamTypes(self.as_type_ref())
-        }
+        unsafe { LLVMCountParamTypes(self.as_type_ref()) }
     }
 
     // REVIEW: Always false -> const fn?
@@ -175,21 +177,15 @@ impl<'ctx> FunctionType<'ctx> {
     /// assert_eq!(fn_type.get_return_type().unwrap().into_float_type(), f32_type);
     /// ```
     pub fn get_return_type(self) -> Option<BasicTypeEnum<'ctx>> {
-        let ty = unsafe {
-            LLVMGetReturnType(self.as_type_ref())
-        };
+        let ty = unsafe { LLVMGetReturnType(self.as_type_ref()) };
 
-        let kind = unsafe {
-            LLVMGetTypeKind(ty)
-        };
+        let kind = unsafe { LLVMGetTypeKind(ty) };
 
         if let LLVMTypeKind::LLVMVoidTypeKind = kind {
             return None;
         }
 
-        unsafe {
-            Some(BasicTypeEnum::new(ty))
-        }
+        unsafe { Some(BasicTypeEnum::new(ty)) }
     }
 
     // REVIEW: Can you do undef for functions?

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -1,13 +1,16 @@
-use llvm_sys::core::{LLVMConstInt, LLVMConstAllOnes, LLVMGetIntTypeWidth, LLVMConstIntOfStringAndSize, LLVMConstIntOfArbitraryPrecision, LLVMConstArray};
+use llvm_sys::core::{
+    LLVMConstAllOnes, LLVMConstArray, LLVMConstInt, LLVMConstIntOfArbitraryPrecision,
+    LLVMConstIntOfStringAndSize, LLVMGetIntTypeWidth,
+};
 use llvm_sys::execution_engine::LLVMCreateGenericValueOfInt;
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use regex::Regex;
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{Type, ArrayType, BasicTypeEnum, VectorType, PointerType, FunctionType};
-use crate::values::{AsValueRef, ArrayValue, GenericValue, IntValue};
+use crate::types::{ArrayType, BasicTypeEnum, FunctionType, PointerType, Type, VectorType};
+use crate::values::{ArrayValue, AsValueRef, GenericValue, IntValue};
+use crate::AddressSpace;
 
 use std::convert::TryFrom;
 
@@ -82,9 +85,7 @@ impl<'ctx> IntType<'ctx> {
     /// ```
     // TODOC: Maybe better explain sign extension
     pub fn const_int(self, value: u64, sign_extend: bool) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstInt(self.as_type_ref(), value, sign_extend as i32))
-        }
+        unsafe { IntValue::new(LLVMConstInt(self.as_type_ref(), value, sign_extend as i32)) }
     }
 
     /// Create an `IntValue` from a string and radix. LLVM provides no error handling here,
@@ -117,7 +118,7 @@ impl<'ctx> IntType<'ctx> {
     /// ```
     pub fn const_int_from_string(self, slice: &str, radix: StringRadix) -> Option<IntValue<'ctx>> {
         if !radix.to_regex().is_match(slice) {
-            return None
+            return None;
         }
 
         unsafe {
@@ -143,7 +144,11 @@ impl<'ctx> IntType<'ctx> {
     /// ```
     pub fn const_int_arbitrary_precision(self, words: &[u64]) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstIntOfArbitraryPrecision(self.as_type_ref(), words.len() as u32, words.as_ptr()))
+            IntValue::new(LLVMConstIntOfArbitraryPrecision(
+                self.as_type_ref(),
+                words.len() as u32,
+                words.as_ptr(),
+            ))
         }
     }
 
@@ -159,9 +164,7 @@ impl<'ctx> IntType<'ctx> {
     /// let i32_ptr_value = i32_type.const_all_ones();
     /// ```
     pub fn const_all_ones(self) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstAllOnes(self.as_type_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstAllOnes(self.as_type_ref())) }
     }
 
     /// Creates a constant zero value of this `IntType`.
@@ -179,9 +182,7 @@ impl<'ctx> IntType<'ctx> {
     /// assert_eq!(i8_zero.print_to_string().to_string(), "i8 0");
     /// ```
     pub fn const_zero(self) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(self.int_type.const_zero())
-        }
+        unsafe { IntValue::new(self.int_type.const_zero()) }
     }
 
     /// Creates a `FunctionType` with this `IntType` for its return type.
@@ -195,7 +196,11 @@ impl<'ctx> IntType<'ctx> {
     /// let i8_type = context.i8_type();
     /// let fn_type = i8_type.fn_type(&[], false);
     /// ```
-    pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+    pub fn fn_type(
+        self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
         self.int_type.fn_type(param_types, is_var_args)
     }
 
@@ -311,9 +316,7 @@ impl<'ctx> IntType<'ctx> {
     /// assert_eq!(bool_type.get_bit_width(), 1);
     /// ```
     pub fn get_bit_width(self) -> u32 {
-        unsafe {
-            LLVMGetIntTypeWidth(self.as_type_ref())
-        }
+        unsafe { LLVMGetIntTypeWidth(self.as_type_ref()) }
     }
 
     // See Type::print_to_stderr note on 5.0+ status
@@ -337,15 +340,17 @@ impl<'ctx> IntType<'ctx> {
     /// assert!(i8_undef.is_undef());
     /// ```
     pub fn get_undef(self) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(self.int_type.get_undef())
-        }
+        unsafe { IntValue::new(self.int_type.get_undef()) }
     }
 
     /// Creates a `GenericValue` for use with `ExecutionEngine`s.
     pub fn create_generic_value(self, value: u64, is_signed: bool) -> GenericValue<'ctx> {
         unsafe {
-            GenericValue::new(LLVMCreateGenericValueOfInt(self.as_type_ref(), value, is_signed as i32))
+            GenericValue::new(LLVMCreateGenericValueOfInt(
+                self.as_type_ref(),
+                value,
+                is_signed as i32,
+            ))
         }
     }
 
@@ -364,11 +369,13 @@ impl<'ctx> IntType<'ctx> {
     /// assert!(i8_array.is_const());
     /// ```
     pub fn const_array(self, values: &[IntValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter()
-                                                  .map(|val| val.as_value_ref())
-                                                  .collect();
+        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
-            ArrayValue::new(LLVMConstArray(self.as_type_ref(), values.as_mut_ptr(), values.len() as u32))
+            ArrayValue::new(LLVMConstArray(
+                self.as_type_ref(),
+                values.as_mut_ptr(),
+                values.len() as u32,
+            ))
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -27,14 +27,18 @@ pub use crate::types::fn_type::FunctionType;
 pub use crate::types::int_type::{IntType, StringRadix};
 pub use crate::types::ptr_type::PointerType;
 pub use crate::types::struct_type::StructType;
-pub use crate::types::traits::{AnyType, BasicType, IntMathType, FloatMathType, PointerMathType};
+pub(crate) use crate::types::traits::AsTypeRef;
+pub use crate::types::traits::{AnyType, BasicType, FloatMathType, IntMathType, PointerMathType};
 pub use crate::types::vec_type::VectorType;
 pub use crate::types::void_type::VoidType;
-pub(crate) use crate::types::traits::AsTypeRef;
 
 #[llvm_versions(3.7..=4.0)]
 use llvm_sys::core::LLVMDumpType;
-use llvm_sys::core::{LLVMAlignOf, LLVMGetTypeContext, LLVMFunctionType, LLVMArrayType, LLVMGetUndef, LLVMPointerType, LLVMPrintTypeToString, LLVMTypeIsSized, LLVMSizeOf, LLVMVectorType, LLVMGetElementType, LLVMConstNull};
+use llvm_sys::core::{
+    LLVMAlignOf, LLVMArrayType, LLVMConstNull, LLVMFunctionType, LLVMGetElementType,
+    LLVMGetTypeContext, LLVMGetUndef, LLVMPointerType, LLVMPrintTypeToString, LLVMSizeOf,
+    LLVMTypeIsSized, LLVMVectorType,
+};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 #[cfg(feature = "experimental")]
 use static_alloc::Bump;
@@ -42,10 +46,10 @@ use static_alloc::Bump;
 use std::fmt;
 use std::marker::PhantomData;
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::values::IntValue;
+use crate::AddressSpace;
 
 // Worth noting that types seem to be singletons. At the very least, primitives are.
 // Though this is likely only true per thread since LLVM claims to not be very thread-safe.
@@ -77,33 +81,31 @@ impl<'ctx> Type<'ctx> {
     }
 
     fn const_zero(self) -> LLVMValueRef {
-        unsafe {
-            LLVMConstNull(self.ty)
-        }
+        unsafe { LLVMConstNull(self.ty) }
     }
 
     fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {
-        unsafe {
-            PointerType::new(LLVMPointerType(self.ty, address_space as u32))
-        }
+        unsafe { PointerType::new(LLVMPointerType(self.ty, address_space as u32)) }
     }
 
     fn vec_type(self, size: u32) -> VectorType<'ctx> {
         assert!(size != 0, "Vectors of size zero are not allowed.");
         // -- https://llvm.org/docs/LangRef.html#vector-type
 
-        unsafe {
-            VectorType::new(LLVMVectorType(self.ty, size))
-        }
+        unsafe { VectorType::new(LLVMVectorType(self.ty, size)) }
     }
 
     #[cfg(not(feature = "experimental"))]
     fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
-        let mut param_types: Vec<LLVMTypeRef> = param_types.iter()
-                                                           .map(|val| val.as_type_ref())
-                                                           .collect();
+        let mut param_types: Vec<LLVMTypeRef> =
+            param_types.iter().map(|val| val.as_type_ref()).collect();
         unsafe {
-            FunctionType::new(LLVMFunctionType(self.ty, param_types.as_mut_ptr(), param_types.len() as u32, is_var_args as i32))
+            FunctionType::new(LLVMFunctionType(
+                self.ty,
+                param_types.as_mut_ptr(),
+                param_types.len() as u32,
+                is_var_args as i32,
+            ))
         }
     }
 
@@ -113,7 +115,9 @@ impl<'ctx> Type<'ctx> {
         let mut pool_start = None;
 
         for (i, param_type) in param_types.iter().enumerate() {
-            let addr = pool.leak(param_type.as_type_ref()).expect("Found more than 16 params");
+            let addr = pool
+                .leak(param_type.as_type_ref())
+                .expect("Found more than 16 params");
 
             if i == 0 {
                 pool_start = Some(addr as *mut _);
@@ -121,41 +125,36 @@ impl<'ctx> Type<'ctx> {
         }
 
         unsafe {
-            FunctionType::new(LLVMFunctionType(self.ty, pool_start.unwrap_or(std::ptr::null_mut()), param_types.len() as u32, is_var_args as i32))
+            FunctionType::new(LLVMFunctionType(
+                self.ty,
+                pool_start.unwrap_or(std::ptr::null_mut()),
+                param_types.len() as u32,
+                is_var_args as i32,
+            ))
         }
     }
 
     fn array_type(self, size: u32) -> ArrayType<'ctx> {
-        unsafe {
-            ArrayType::new(LLVMArrayType(self.ty, size))
-        }
+        unsafe { ArrayType::new(LLVMArrayType(self.ty, size)) }
     }
 
     fn get_undef(self) -> LLVMValueRef {
-        unsafe {
-            LLVMGetUndef(self.ty)
-        }
+        unsafe { LLVMGetUndef(self.ty) }
     }
 
     fn get_alignment(self) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMAlignOf(self.ty))
-        }
+        unsafe { IntValue::new(LLVMAlignOf(self.ty)) }
     }
 
     fn get_context(self) -> ContextRef<'ctx> {
-        unsafe {
-            ContextRef::new(LLVMGetTypeContext(self.ty))
-        }
+        unsafe { ContextRef::new(LLVMGetTypeContext(self.ty)) }
     }
 
     // REVIEW: This should be known at compile time, maybe as a const fn?
     // On an enum or trait, this would not be known at compile time (unless
     // enum has only sized types for example)
     fn is_sized(self) -> bool {
-        unsafe {
-            LLVMTypeIsSized(self.ty) == 1
-        }
+        unsafe { LLVMTypeIsSized(self.ty) == 1 }
     }
 
     fn size_of(self) -> Option<IntValue<'ctx>> {
@@ -163,23 +162,16 @@ impl<'ctx> Type<'ctx> {
             return None;
         }
 
-        unsafe {
-            Some(IntValue::new(LLVMSizeOf(self.ty)))
-        }
+        unsafe { Some(IntValue::new(LLVMSizeOf(self.ty))) }
     }
 
     fn print_to_string(self) -> LLVMString {
-        unsafe {
-            LLVMString::new(LLVMPrintTypeToString(self.ty))
-        }
+        unsafe { LLVMString::new(LLVMPrintTypeToString(self.ty)) }
     }
 
     pub fn get_element_type(self) -> AnyTypeEnum<'ctx> {
-        unsafe {
-            AnyTypeEnum::new(LLVMGetElementType(self.ty))
-        }
+        unsafe { AnyTypeEnum::new(LLVMGetElementType(self.ty)) }
     }
-
 }
 
 impl fmt::Debug for Type<'_> {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -1,11 +1,11 @@
-use llvm_sys::core::{LLVMGetPointerAddressSpace, LLVMConstArray};
+use llvm_sys::core::{LLVMConstArray, LLVMGetPointerAddressSpace};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{AnyTypeEnum, BasicTypeEnum, ArrayType, FunctionType, Type, VectorType};
-use crate::values::{AsValueRef, ArrayValue, PointerValue, IntValue};
+use crate::types::{AnyTypeEnum, ArrayType, BasicTypeEnum, FunctionType, Type, VectorType};
+use crate::values::{ArrayValue, AsValueRef, IntValue, PointerValue};
+use crate::AddressSpace;
 
 use std::convert::TryFrom;
 
@@ -109,7 +109,11 @@ impl<'ctx> PointerType<'ctx> {
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
     /// let fn_type = f32_ptr_type.fn_type(&[], false);
     /// ```
-    pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+    pub fn fn_type(
+        self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
         self.ptr_type.fn_type(param_types, is_var_args)
     }
 
@@ -148,9 +152,7 @@ impl<'ctx> PointerType<'ctx> {
     /// assert_eq!(f32_ptr_type.get_address_space(), AddressSpace::Generic);
     /// ```
     pub fn get_address_space(self) -> AddressSpace {
-        let addr_space = unsafe {
-            LLVMGetPointerAddressSpace(self.as_type_ref())
-        };
+        let addr_space = unsafe { LLVMGetPointerAddressSpace(self.as_type_ref()) };
 
         AddressSpace::try_from(addr_space).expect("Unexpectedly found invalid AddressSpace value")
     }
@@ -179,9 +181,7 @@ impl<'ctx> PointerType<'ctx> {
     /// assert!(f32_ptr_null.is_null());
     /// ```
     pub fn const_null(self) -> PointerValue<'ctx> {
-        unsafe {
-            PointerValue::new(self.ptr_type.const_zero())
-        }
+        unsafe { PointerValue::new(self.ptr_type.const_zero()) }
     }
 
     // REVIEW: Unlike the other const_zero functions, this one becomes null instead of a 0 value. Maybe remove?
@@ -201,9 +201,7 @@ impl<'ctx> PointerType<'ctx> {
     /// let f32_ptr_zero = f32_ptr_type.const_zero();
     /// ```
     pub fn const_zero(self) -> PointerValue<'ctx> {
-        unsafe {
-            PointerValue::new(self.ptr_type.const_zero())
-        }
+        unsafe { PointerValue::new(self.ptr_type.const_zero()) }
     }
 
     /// Creates an undefined instance of a `PointerType`.
@@ -221,9 +219,7 @@ impl<'ctx> PointerType<'ctx> {
     /// assert!(f32_ptr_undef.is_undef());
     /// ```
     pub fn get_undef(self) -> PointerValue<'ctx> {
-        unsafe {
-            PointerValue::new(self.ptr_type.get_undef())
-        }
+        unsafe { PointerValue::new(self.ptr_type.get_undef()) }
     }
 
     /// Creates a `VectorType` with this `PointerType` for its element type.
@@ -281,11 +277,13 @@ impl<'ctx> PointerType<'ctx> {
     /// assert!(f32_ptr_array.is_const());
     /// ```
     pub fn const_array(self, values: &[PointerValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter()
-                                                  .map(|val| val.as_value_ref())
-                                                  .collect();
+        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
-            ArrayValue::new(LLVMConstArray(self.as_type_ref(), values.as_mut_ptr(), values.len() as u32))
+            ArrayValue::new(LLVMConstArray(
+                self.as_type_ref(),
+                values.as_mut_ptr(),
+                values.len() as u32,
+            ))
         }
     }
 }

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -2,11 +2,16 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use std::fmt::Debug;
 
-use crate::AddressSpace;
-use crate::types::{IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VectorType, VoidType, Type};
-use crate::types::enums::{AnyTypeEnum, BasicTypeEnum};
-use crate::values::{IntMathValue, FloatMathValue, PointerMathValue, IntValue, FloatValue, PointerValue, VectorValue};
 use crate::support::LLVMString;
+use crate::types::enums::{AnyTypeEnum, BasicTypeEnum};
+use crate::types::{
+    ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, Type, VectorType,
+    VoidType,
+};
+use crate::values::{
+    FloatMathValue, FloatValue, IntMathValue, IntValue, PointerMathValue, PointerValue, VectorValue,
+};
+use crate::AddressSpace;
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -27,16 +32,12 @@ macro_rules! trait_type_set {
 pub trait AnyType<'ctx>: AsTypeRef + Debug {
     /// Returns an `AnyTypeEnum` that represents the current type.
     fn as_any_type_enum(&self) -> AnyTypeEnum<'ctx> {
-        unsafe {
-            AnyTypeEnum::new(self.as_type_ref())
-        }
+        unsafe { AnyTypeEnum::new(self.as_type_ref()) }
     }
 
     /// Prints the definition of a Type to a `LLVMString`.
     fn print_to_string(&self) -> LLVMString {
-        unsafe {
-            Type::new(self.as_type_ref()).print_to_string()
-        }
+        unsafe { Type::new(self.as_type_ref()).print_to_string() }
     }
 }
 
@@ -44,9 +45,7 @@ pub trait AnyType<'ctx>: AsTypeRef + Debug {
 pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// Returns a `BasicTypeEnum` that represents the current type.
     fn as_basic_type_enum(&self) -> BasicTypeEnum<'ctx> {
-        unsafe {
-            BasicTypeEnum::new(self.as_type_ref())
-        }
+        unsafe { BasicTypeEnum::new(self.as_type_ref()) }
     }
 
     /// Create a `FunctionType` with this `BasicType` as its return type.
@@ -62,10 +61,12 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// let int_basic_type = int.as_basic_type_enum();
     /// assert_eq!(int_basic_type.fn_type(&[], false), int.fn_type(&[], false));
     /// ```
-    fn fn_type(&self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
-        unsafe {
-            Type::new(self.as_type_ref()).fn_type(param_types, is_var_args)
-        }
+    fn fn_type(
+        &self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
+        unsafe { Type::new(self.as_type_ref()).fn_type(param_types, is_var_args) }
     }
 
     /// Determines whether or not this `BasicType` is sized or not.
@@ -84,9 +85,7 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// assert!(f32_vec_type.is_sized());
     /// ```
     fn is_sized(&self) -> bool {
-        unsafe {
-            Type::new(self.as_type_ref()).is_sized()
-        }
+        unsafe { Type::new(self.as_type_ref()).is_sized() }
     }
 
     /// Gets the size of this `BasicType`. Value may vary depending on the target architecture.
@@ -103,9 +102,7 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// let f32_type_size = f32_basic_type.size_of();
     /// ```
     fn size_of(&self) -> Option<IntValue<'ctx>> {
-        unsafe {
-            Type::new(self.as_type_ref()).size_of()
-        }
+        unsafe { Type::new(self.as_type_ref()).size_of() }
     }
 
     /// Create an `ArrayType` with this `BasicType` as its elements.
@@ -122,9 +119,7 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// ```
     // FIXME: This likely doesn't belong on the trait, since not all basic types can be turned into arrays?
     fn array_type(&self, size: u32) -> ArrayType<'ctx> {
-        unsafe {
-            Type::new(self.as_type_ref()).array_type(size)
-        }
+        unsafe { Type::new(self.as_type_ref()).array_type(size) }
     }
 
     /// Create a `PointerType` that points to this `BasicType`.
@@ -142,9 +137,7 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// assert_eq!(int_basic_type.ptr_type(addr_space), int.ptr_type(addr_space));
     /// ```
     fn ptr_type(&self, address_space: AddressSpace) -> PointerType<'ctx> {
-        unsafe {
-            Type::new(self.as_type_ref()).ptr_type(address_space)
-        }
+        unsafe { Type::new(self.as_type_ref()).ptr_type(address_space) }
     }
 }
 

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -1,10 +1,10 @@
-use llvm_sys::core::{LLVMConstVector, LLVMGetVectorSize, LLVMConstArray};
+use llvm_sys::core::{LLVMConstArray, LLVMConstVector, LLVMGetVectorSize};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
-use crate::AddressSpace;
 use crate::context::ContextRef;
-use crate::types::{ArrayType, BasicTypeEnum, Type, traits::AsTypeRef, FunctionType, PointerType};
-use crate::values::{AsValueRef, ArrayValue, BasicValue, VectorValue, IntValue};
+use crate::types::{traits::AsTypeRef, ArrayType, BasicTypeEnum, FunctionType, PointerType, Type};
+use crate::values::{ArrayValue, AsValueRef, BasicValue, IntValue, VectorValue};
+use crate::AddressSpace;
 
 /// A `VectorType` is the type of a multiple value SIMD constant or variable.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -71,9 +71,7 @@ impl<'ctx> VectorType<'ctx> {
     /// assert_eq!(f32_vector_type.get_element_type().into_float_type(), f32_type);
     /// ```
     pub fn get_size(self) -> u32 {
-        unsafe {
-            LLVMGetVectorSize(self.as_type_ref())
-        }
+        unsafe { LLVMGetVectorSize(self.as_type_ref()) }
     }
 
     // REVIEW:
@@ -100,12 +98,8 @@ impl<'ctx> VectorType<'ctx> {
     /// assert!(f32_vec_val.is_constant_vector());
     /// ```
     pub fn const_vector<V: BasicValue<'ctx>>(values: &[V]) -> VectorValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter()
-                                                  .map(|val| val.as_value_ref())
-                                                  .collect();
-        unsafe {
-            VectorValue::new(LLVMConstVector(values.as_mut_ptr(), values.len() as u32))
-        }
+        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
+        unsafe { VectorValue::new(LLVMConstVector(values.as_mut_ptr(), values.len() as u32)) }
     }
 
     /// Creates a constant zero value of this `VectorType`.
@@ -121,9 +115,7 @@ impl<'ctx> VectorType<'ctx> {
     /// let f32_vec_zero = f32_vec_type.const_zero();
     /// ```
     pub fn const_zero(self) -> VectorValue<'ctx> {
-        unsafe {
-            VectorValue::new(self.vec_type.const_zero())
-        }
+        unsafe { VectorValue::new(self.vec_type.const_zero()) }
     }
 
     // See Type::print_to_stderr note on 5.0+ status
@@ -148,9 +140,7 @@ impl<'ctx> VectorType<'ctx> {
     /// assert!(f32_vec_undef.is_undef());
     /// ```
     pub fn get_undef(self) -> VectorValue<'ctx> {
-        unsafe {
-            VectorValue::new(self.vec_type.get_undef())
-        }
+        unsafe { VectorValue::new(self.vec_type.get_undef()) }
     }
 
     // SubType: VectorType<BT> -> BT?
@@ -170,7 +160,6 @@ impl<'ctx> VectorType<'ctx> {
     /// ```
     pub fn get_element_type(self) -> BasicTypeEnum<'ctx> {
         self.vec_type.get_element_type().to_basic_type_enum()
-
     }
 
     /// Creates a `PointerType` with this `VectorType` for its element type.
@@ -204,7 +193,11 @@ impl<'ctx> VectorType<'ctx> {
     /// let f32_vec_type = f32_type.vec_type(3);
     /// let fn_type = f32_vec_type.fn_type(&[], false);
     /// ```
-    pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+    pub fn fn_type(
+        self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
         self.vec_type.fn_type(param_types, is_var_args)
     }
 
@@ -245,12 +238,14 @@ impl<'ctx> VectorType<'ctx> {
     /// assert!(f32_array.is_const());
     /// ```
     pub fn const_array(self, values: &[VectorValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter()
-                                                  .map(|val| val.as_value_ref())
-                                                  .collect();
+        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
 
         unsafe {
-            ArrayValue::new(LLVMConstArray(self.as_type_ref(), values.as_mut_ptr(), values.len() as u32))
+            ArrayValue::new(LLVMConstArray(
+                self.as_type_ref(),
+                values.as_mut_ptr(),
+                values.len() as u32,
+            ))
         }
     }
 

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -2,7 +2,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{Type, BasicTypeEnum, FunctionType};
+use crate::types::{BasicTypeEnum, FunctionType, Type};
 
 /// A `VoidType` is a special type with no possible direct instances. It's only
 /// useful as a function return type.
@@ -66,7 +66,11 @@ impl<'ctx> VoidType<'ctx> {
     /// let void_type = context.void_type();
     /// let fn_type = void_type.fn_type(&[], false);
     /// ```
-    pub fn fn_type(self, param_types: &[BasicTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+    pub fn fn_type(
+        self,
+        param_types: &[BasicTypeEnum<'ctx>],
+        is_var_args: bool,
+    ) -> FunctionType<'ctx> {
         self.void_type.fn_type(param_types, is_var_args)
     }
 

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use crate::types::ArrayType;
 use crate::values::traits::{AnyValue, AsValueRef};
-use crate::values::{Value, InstructionValue};
+use crate::values::{InstructionValue, Value};
 
 /// An `ArrayValue` is a block of contiguous constants or variables.
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
@@ -31,9 +31,7 @@ impl<'ctx> ArrayValue<'ctx> {
 
     /// Gets the type of this `ArrayValue`.
     pub fn get_type(self) -> ArrayType<'ctx> {
-        unsafe {
-            ArrayType::new(self.array_value.get_type())
-        }
+        unsafe { ArrayType::new(self.array_value.get_type()) }
     }
 
     /// Determines whether or not this value is null.
@@ -94,12 +92,9 @@ impl fmt::Debug for ArrayValue<'_> {
         let name = self.get_name();
         let is_const = self.is_const();
         let is_null = self.is_null();
-        let is_const_array = unsafe {
-            !LLVMIsAConstantArray(self.as_value_ref()).is_null()
-        };
-        let is_const_data_array = unsafe {
-            !LLVMIsAConstantDataArray(self.as_value_ref()).is_null()
-        };
+        let is_const_array = unsafe { !LLVMIsAConstantArray(self.as_value_ref()).is_null() };
+        let is_const_data_array =
+            unsafe { !LLVMIsAConstantDataArray(self.as_value_ref()).is_null() };
 
         f.debug_struct("ArrayValue")
             .field("name", &name)
@@ -109,7 +104,7 @@ impl fmt::Debug for ArrayValue<'_> {
             .field("is_const_data_array", &is_const_data_array)
             .field("is_null", &is_null)
             .field("llvm_value", &llvm_value)
-            .field("llvm_type",  &llvm_type)
+            .field("llvm_type", &llvm_type)
             .finish()
     }
 }

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -1,5 +1,10 @@
-use either::{Either, Either::{Left, Right}};
-use llvm_sys::core::{LLVMGetNextUse, LLVMGetUser, LLVMGetUsedValue, LLVMIsABasicBlock, LLVMValueAsBasicBlock};
+use either::{
+    Either,
+    Either::{Left, Right},
+};
+use llvm_sys::core::{
+    LLVMGetNextUse, LLVMGetUsedValue, LLVMGetUser, LLVMIsABasicBlock, LLVMValueAsBasicBlock,
+};
 use llvm_sys::prelude::LLVMUseRef;
 
 use std::marker::PhantomData;
@@ -72,17 +77,13 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// 1) In the store instruction
     /// 2) In the pointer bitcast
     pub fn get_next_use(self) -> Option<Self> {
-        let use_ = unsafe {
-            LLVMGetNextUse(self.0)
-        };
+        let use_ = unsafe { LLVMGetNextUse(self.0) };
 
         if use_.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(Self::new(use_))
-        }
+        unsafe { Some(Self::new(use_)) }
     }
 
     /// Gets the user (an `AnyValueEnum`) of this use.
@@ -118,9 +119,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// assert_eq!(store_operand_use1.get_user(), store_instruction);
     /// ```
     pub fn get_user(self) -> AnyValueEnum<'ctx> {
-        unsafe {
-            AnyValueEnum::new(LLVMGetUser(self.0))
-        }
+        unsafe { AnyValueEnum::new(LLVMGetUser(self.0)) }
     }
 
     /// Gets the used value (a `BasicValueEnum` or `BasicBlock`) of this use.
@@ -161,24 +160,16 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// assert_eq!(bitcast_use_value, free_operand0);
     /// ```
     pub fn get_used_value(self) -> Either<BasicValueEnum<'ctx>, BasicBlock<'ctx>> {
-        let used_value = unsafe {
-            LLVMGetUsedValue(self.0)
-        };
+        let used_value = unsafe { LLVMGetUsedValue(self.0) };
 
-        let is_basic_block = unsafe {
-            !LLVMIsABasicBlock(used_value).is_null()
-        };
+        let is_basic_block = unsafe { !LLVMIsABasicBlock(used_value).is_null() };
 
         if is_basic_block {
-            let bb = unsafe {
-                BasicBlock::new(LLVMValueAsBasicBlock(used_value))
-            };
+            let bb = unsafe { BasicBlock::new(LLVMValueAsBasicBlock(used_value)) };
 
             Right(bb.expect("BasicBlock should always be valid"))
         } else {
-            unsafe {
-                Left(BasicValueEnum::new(used_value))
-            }
+            unsafe { Left(BasicValueEnum::new(used_value)) }
         }
     }
 }

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -1,15 +1,18 @@
 use either::Either;
-use llvm_sys::LLVMTypeKind;
-use llvm_sys::core::{LLVMIsTailCall, LLVMSetTailCall, LLVMGetTypeKind, LLVMTypeOf, LLVMSetInstructionCallConv, LLVMGetInstructionCallConv, LLVMSetInstrParamAlignment};
+use llvm_sys::core::{
+    LLVMGetInstructionCallConv, LLVMGetTypeKind, LLVMIsTailCall, LLVMSetInstrParamAlignment,
+    LLVMSetInstructionCallConv, LLVMSetTailCall, LLVMTypeOf,
+};
 use llvm_sys::prelude::LLVMValueRef;
+use llvm_sys::LLVMTypeKind;
 
 #[llvm_versions(3.9..=latest)]
-use crate::attributes::{Attribute};
+use crate::attributes::Attribute;
 use crate::attributes::AttributeLoc;
 use crate::support::LLVMString;
-use crate::values::{AsValueRef, BasicValueEnum, InstructionValue, Value};
 #[llvm_versions(3.9..=latest)]
 use crate::values::FunctionValue;
+use crate::values::{AsValueRef, BasicValueEnum, InstructionValue, Value};
 
 /// A value resulting from a function call. It may have function attributes applied to it.
 ///
@@ -44,9 +47,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// call_site_value.set_tail_call(true);
     /// ```
     pub fn set_tail_call(self, tail_call: bool) {
-        unsafe {
-            LLVMSetTailCall(self.as_value_ref(), tail_call as i32)
-        }
+        unsafe { LLVMSetTailCall(self.as_value_ref(), tail_call as i32) }
     }
 
     /// Determines whether or not this call is a tail call.
@@ -73,9 +74,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// assert!(call_site_value.is_tail_call());
     /// ```
     pub fn is_tail_call(self) -> bool {
-        unsafe {
-            LLVMIsTailCall(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMIsTailCall(self.as_value_ref()) == 1 }
     }
 
     /// Try to convert this `CallSiteValue` to a `BasicValueEnum` if not a void return type.
@@ -102,7 +101,9 @@ impl<'ctx> CallSiteValue<'ctx> {
     pub fn try_as_basic_value(self) -> Either<BasicValueEnum<'ctx>, InstructionValue<'ctx>> {
         unsafe {
             match LLVMGetTypeKind(LLVMTypeOf(self.as_value_ref())) {
-                LLVMTypeKind::LLVMVoidTypeKind => Either::Right(InstructionValue::new(self.as_value_ref())),
+                LLVMTypeKind::LLVMVoidTypeKind => {
+                    Either::Right(InstructionValue::new(self.as_value_ref()))
+                }
                 _ => Either::Left(BasicValueEnum::new(self.as_value_ref())),
             }
         }
@@ -170,7 +171,8 @@ impl<'ctx> CallSiteValue<'ctx> {
         use llvm_sys::core::LLVMGetCalledValue;
 
         unsafe {
-            FunctionValue::new(LLVMGetCalledValue(self.as_value_ref())).expect("This should never be null?")
+            FunctionValue::new(LLVMGetCalledValue(self.as_value_ref()))
+                .expect("This should never be null?")
         }
     }
 
@@ -205,9 +207,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     pub fn count_attributes(self, loc: AttributeLoc) -> u32 {
         use llvm_sys::core::LLVMGetCallSiteAttributeCount;
 
-        unsafe {
-            LLVMGetCallSiteAttributeCount(self.as_value_ref(), loc.get_index())
-        }
+        unsafe { LLVMGetCallSiteAttributeCount(self.as_value_ref(), loc.get_index()) }
     }
 
     /// Gets an enum `Attribute` on this `CallSiteValue` at an index and kind id.
@@ -242,17 +242,14 @@ impl<'ctx> CallSiteValue<'ctx> {
     pub fn get_enum_attribute(self, loc: AttributeLoc, kind_id: u32) -> Option<Attribute> {
         use llvm_sys::core::LLVMGetCallSiteEnumAttribute;
 
-        let ptr = unsafe {
-            LLVMGetCallSiteEnumAttribute(self.as_value_ref(), loc.get_index(), kind_id)
-        };
+        let ptr =
+            unsafe { LLVMGetCallSiteEnumAttribute(self.as_value_ref(), loc.get_index(), kind_id) };
 
         if ptr.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(Attribute::new(ptr))
-        }
+        unsafe { Some(Attribute::new(ptr)) }
     }
 
     /// Gets a string `Attribute` on this `CallSiteValue` at an index and key.
@@ -288,16 +285,19 @@ impl<'ctx> CallSiteValue<'ctx> {
         use llvm_sys::core::LLVMGetCallSiteStringAttribute;
 
         let ptr = unsafe {
-            LLVMGetCallSiteStringAttribute(self.as_value_ref(), loc.get_index(), key.as_ptr() as *const ::libc::c_char, key.len() as u32)
+            LLVMGetCallSiteStringAttribute(
+                self.as_value_ref(),
+                loc.get_index(),
+                key.as_ptr() as *const ::libc::c_char,
+                key.len() as u32,
+            )
         };
 
         if ptr.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(Attribute::new(ptr))
-        }
+        unsafe { Some(Attribute::new(ptr)) }
     }
 
     /// Removes an enum `Attribute` on this `CallSiteValue` at an index and kind id.
@@ -332,9 +332,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     pub fn remove_enum_attribute(self, loc: AttributeLoc, kind_id: u32) {
         use llvm_sys::core::LLVMRemoveCallSiteEnumAttribute;
 
-        unsafe {
-            LLVMRemoveCallSiteEnumAttribute(self.as_value_ref(), loc.get_index(), kind_id)
-        }
+        unsafe { LLVMRemoveCallSiteEnumAttribute(self.as_value_ref(), loc.get_index(), kind_id) }
     }
 
     /// Removes a string `Attribute` on this `CallSiteValue` at an index and key.
@@ -370,7 +368,12 @@ impl<'ctx> CallSiteValue<'ctx> {
         use llvm_sys::core::LLVMRemoveCallSiteStringAttribute;
 
         unsafe {
-            LLVMRemoveCallSiteStringAttribute(self.as_value_ref(), loc.get_index(), key.as_ptr() as *const ::libc::c_char, key.len() as u32)
+            LLVMRemoveCallSiteStringAttribute(
+                self.as_value_ref(),
+                loc.get_index(),
+                key.as_ptr() as *const ::libc::c_char,
+                key.len() as u32,
+            )
         }
     }
 
@@ -402,9 +405,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     pub fn count_arguments(self) -> u32 {
         use llvm_sys::core::LLVMGetNumArgOperands;
 
-        unsafe {
-            LLVMGetNumArgOperands(self.as_value_ref())
-        }
+        unsafe { LLVMGetNumArgOperands(self.as_value_ref()) }
     }
 
     /// Gets the calling convention for this `CallSiteValue`.
@@ -429,9 +430,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// assert_eq!(call_site_value.get_call_convention(), 0);
     /// ```
     pub fn get_call_convention(self) -> u32 {
-        unsafe {
-            LLVMGetInstructionCallConv(self.as_value_ref())
-        }
+        unsafe { LLVMGetInstructionCallConv(self.as_value_ref()) }
     }
 
     /// Sets the calling convention for this `CallSiteValue`.
@@ -458,9 +457,7 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// assert_eq!(call_site_value.get_call_convention(), 2);
     /// ```
     pub fn set_call_convention(self, conv: u32) {
-        unsafe {
-            LLVMSetInstructionCallConv(self.as_value_ref(), conv)
-        }
+        unsafe { LLVMSetInstructionCallConv(self.as_value_ref(), conv) }
     }
 
     /// Shortcut for setting the alignment `Attribute` for this `CallSiteValue`.
@@ -490,11 +487,13 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// call_site_value.set_alignment_attribute(AttributeLoc::Param(0), 2);
     /// ```
     pub fn set_alignment_attribute(self, loc: AttributeLoc, alignment: u32) {
-        assert_eq!(alignment.count_ones(), 1, "Alignment must be a power of two.");
+        assert_eq!(
+            alignment.count_ones(),
+            1,
+            "Alignment must be a power of two."
+        );
 
-        unsafe {
-            LLVMSetInstrParamAlignment(self.as_value_ref(), loc.get_index(), alignment)
-        }
+        unsafe { LLVMSetInstrParamAlignment(self.as_value_ref(), loc.get_index(), alignment) }
     }
 
     /// Prints the definition of a `CallSiteValue` to a `LLVMString`.

--- a/src/values/callable_value.rs
+++ b/src/values/callable_value.rs
@@ -1,11 +1,11 @@
-use std::convert::TryFrom;
 use either::Either;
+use std::convert::TryFrom;
 
 use crate::values::AsValueRef;
-use crate::values::{FunctionValue, PointerValue, AnyValue};
+use crate::values::{AnyValue, FunctionValue, PointerValue};
 
+use llvm_sys::core::{LLVMGetElementType, LLVMGetReturnType, LLVMGetTypeKind, LLVMTypeOf};
 use llvm_sys::prelude::LLVMValueRef;
-use llvm_sys::core::{LLVMGetTypeKind, LLVMGetElementType, LLVMTypeOf, LLVMGetReturnType};
 use llvm_sys::LLVMTypeKind;
 
 /// A value that can be called with the [`build_call`] instruction.
@@ -92,7 +92,9 @@ impl<'ctx> AnyValue<'ctx> for CallableValue<'ctx> {}
 impl<'ctx> CallableValue<'ctx> {
     pub(crate) fn returns_void(&self) -> bool {
         let return_type = unsafe {
-            LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(self.as_value_ref()))))
+            LLVMGetTypeKind(LLVMGetReturnType(LLVMGetElementType(LLVMTypeOf(
+                self.as_value_ref(),
+            ))))
         };
 
         matches!(return_type, LLVMTypeKind::LLVMVoidTypeKind)

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -1,10 +1,13 @@
-use llvm_sys::core::{LLVMIsAInstruction, LLVMTypeOf, LLVMGetTypeKind};
-use llvm_sys::LLVMTypeKind;
+use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf};
 use llvm_sys::prelude::LLVMValueRef;
+use llvm_sys::LLVMTypeKind;
 
 use crate::types::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::traits::AsValueRef;
-use crate::values::{IntValue, FunctionValue, PointerValue, VectorValue, ArrayValue, StructValue, FloatValue, PhiValue, InstructionValue, MetadataValue};
+use crate::values::{
+    ArrayValue, FloatValue, FunctionValue, InstructionValue, IntValue, MetadataValue, PhiValue,
+    PointerValue, StructValue, VectorValue,
+};
 
 use std::convert::TryFrom;
 
@@ -68,33 +71,39 @@ enum_value_set! {BasicMetadataValueEnum: ArrayValue, IntValue, FloatValue, Point
 impl<'ctx> AnyValueEnum<'ctx> {
     pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
         match LLVMGetTypeKind(LLVMTypeOf(value)) {
-            LLVMTypeKind::LLVMFloatTypeKind |
-            LLVMTypeKind::LLVMFP128TypeKind |
-            LLVMTypeKind::LLVMDoubleTypeKind |
-            LLVMTypeKind::LLVMHalfTypeKind |
-            LLVMTypeKind::LLVMX86_FP80TypeKind |
-            LLVMTypeKind::LLVMPPC_FP128TypeKind => AnyValueEnum::FloatValue(FloatValue::new(value)),
+            LLVMTypeKind::LLVMFloatTypeKind
+            | LLVMTypeKind::LLVMFP128TypeKind
+            | LLVMTypeKind::LLVMDoubleTypeKind
+            | LLVMTypeKind::LLVMHalfTypeKind
+            | LLVMTypeKind::LLVMX86_FP80TypeKind
+            | LLVMTypeKind::LLVMPPC_FP128TypeKind => {
+                AnyValueEnum::FloatValue(FloatValue::new(value))
+            }
             LLVMTypeKind::LLVMIntegerTypeKind => AnyValueEnum::IntValue(IntValue::new(value)),
             LLVMTypeKind::LLVMStructTypeKind => AnyValueEnum::StructValue(StructValue::new(value)),
-            LLVMTypeKind::LLVMPointerTypeKind => AnyValueEnum::PointerValue(PointerValue::new(value)),
+            LLVMTypeKind::LLVMPointerTypeKind => {
+                AnyValueEnum::PointerValue(PointerValue::new(value))
+            }
             LLVMTypeKind::LLVMArrayTypeKind => AnyValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyValueEnum::VectorValue(VectorValue::new(value)),
-            LLVMTypeKind::LLVMFunctionTypeKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),
+            LLVMTypeKind::LLVMFunctionTypeKind => {
+                AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap())
+            }
             LLVMTypeKind::LLVMVoidTypeKind => {
                 if LLVMIsAInstruction(value).is_null() {
                     panic!("Void value isn't an instruction.");
                 }
                 AnyValueEnum::InstructionValue(InstructionValue::new(value))
-            },
-            LLVMTypeKind::LLVMMetadataTypeKind => panic!("Metadata values are not supported as AnyValue's."),
-            _ => panic!("The given type is not supported.")
+            }
+            LLVMTypeKind::LLVMMetadataTypeKind => {
+                panic!("Metadata values are not supported as AnyValue's.")
+            }
+            _ => panic!("The given type is not supported."),
         }
     }
 
     pub fn get_type(&self) -> AnyTypeEnum<'ctx> {
-        unsafe {
-            AnyTypeEnum::new(LLVMTypeOf(self.as_value_ref()))
-        }
+        unsafe { AnyTypeEnum::new(LLVMTypeOf(self.as_value_ref())) }
     }
 
     pub fn is_array_value(self) -> bool {
@@ -209,25 +218,31 @@ impl<'ctx> AnyValueEnum<'ctx> {
 impl<'ctx> BasicValueEnum<'ctx> {
     pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
         match LLVMGetTypeKind(LLVMTypeOf(value)) {
-            LLVMTypeKind::LLVMFloatTypeKind |
-            LLVMTypeKind::LLVMFP128TypeKind |
-            LLVMTypeKind::LLVMDoubleTypeKind |
-            LLVMTypeKind::LLVMHalfTypeKind |
-            LLVMTypeKind::LLVMX86_FP80TypeKind |
-            LLVMTypeKind::LLVMPPC_FP128TypeKind => BasicValueEnum::FloatValue(FloatValue::new(value)),
+            LLVMTypeKind::LLVMFloatTypeKind
+            | LLVMTypeKind::LLVMFP128TypeKind
+            | LLVMTypeKind::LLVMDoubleTypeKind
+            | LLVMTypeKind::LLVMHalfTypeKind
+            | LLVMTypeKind::LLVMX86_FP80TypeKind
+            | LLVMTypeKind::LLVMPPC_FP128TypeKind => {
+                BasicValueEnum::FloatValue(FloatValue::new(value))
+            }
             LLVMTypeKind::LLVMIntegerTypeKind => BasicValueEnum::IntValue(IntValue::new(value)),
-            LLVMTypeKind::LLVMStructTypeKind => BasicValueEnum::StructValue(StructValue::new(value)),
-            LLVMTypeKind::LLVMPointerTypeKind => BasicValueEnum::PointerValue(PointerValue::new(value)),
+            LLVMTypeKind::LLVMStructTypeKind => {
+                BasicValueEnum::StructValue(StructValue::new(value))
+            }
+            LLVMTypeKind::LLVMPointerTypeKind => {
+                BasicValueEnum::PointerValue(PointerValue::new(value))
+            }
             LLVMTypeKind::LLVMArrayTypeKind => BasicValueEnum::ArrayValue(ArrayValue::new(value)),
-            LLVMTypeKind::LLVMVectorTypeKind => BasicValueEnum::VectorValue(VectorValue::new(value)),
+            LLVMTypeKind::LLVMVectorTypeKind => {
+                BasicValueEnum::VectorValue(VectorValue::new(value))
+            }
             _ => unreachable!("The given type is not a basic type."),
         }
     }
 
     pub fn get_type(&self) -> BasicTypeEnum<'ctx> {
-        unsafe {
-            BasicTypeEnum::new(LLVMTypeOf(self.as_value_ref()))
-        }
+        unsafe { BasicTypeEnum::new(LLVMTypeOf(self.as_value_ref())) }
     }
 
     pub fn is_array_value(self) -> bool {
@@ -306,8 +321,12 @@ impl<'ctx> BasicValueEnum<'ctx> {
 impl<'ctx> AggregateValueEnum<'ctx> {
     pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
         match LLVMGetTypeKind(LLVMTypeOf(value)) {
-            LLVMTypeKind::LLVMArrayTypeKind => AggregateValueEnum::ArrayValue(ArrayValue::new(value)),
-            LLVMTypeKind::LLVMStructTypeKind => AggregateValueEnum::StructValue(StructValue::new(value)),
+            LLVMTypeKind::LLVMArrayTypeKind => {
+                AggregateValueEnum::ArrayValue(ArrayValue::new(value))
+            }
+            LLVMTypeKind::LLVMStructTypeKind => {
+                AggregateValueEnum::StructValue(StructValue::new(value))
+            }
             _ => unreachable!("The given type is not an aggregate type."),
         }
     }
@@ -340,18 +359,32 @@ impl<'ctx> AggregateValueEnum<'ctx> {
 impl<'ctx> BasicMetadataValueEnum<'ctx> {
     pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
         match LLVMGetTypeKind(LLVMTypeOf(value)) {
-            LLVMTypeKind::LLVMFloatTypeKind |
-            LLVMTypeKind::LLVMFP128TypeKind |
-            LLVMTypeKind::LLVMDoubleTypeKind |
-            LLVMTypeKind::LLVMHalfTypeKind |
-            LLVMTypeKind::LLVMX86_FP80TypeKind |
-            LLVMTypeKind::LLVMPPC_FP128TypeKind => BasicMetadataValueEnum::FloatValue(FloatValue::new(value)),
-            LLVMTypeKind::LLVMIntegerTypeKind => BasicMetadataValueEnum::IntValue(IntValue::new(value)),
-            LLVMTypeKind::LLVMStructTypeKind => BasicMetadataValueEnum::StructValue(StructValue::new(value)),
-            LLVMTypeKind::LLVMPointerTypeKind => BasicMetadataValueEnum::PointerValue(PointerValue::new(value)),
-            LLVMTypeKind::LLVMArrayTypeKind => BasicMetadataValueEnum::ArrayValue(ArrayValue::new(value)),
-            LLVMTypeKind::LLVMVectorTypeKind => BasicMetadataValueEnum::VectorValue(VectorValue::new(value)),
-            LLVMTypeKind::LLVMMetadataTypeKind => BasicMetadataValueEnum::MetadataValue(MetadataValue::new(value)),
+            LLVMTypeKind::LLVMFloatTypeKind
+            | LLVMTypeKind::LLVMFP128TypeKind
+            | LLVMTypeKind::LLVMDoubleTypeKind
+            | LLVMTypeKind::LLVMHalfTypeKind
+            | LLVMTypeKind::LLVMX86_FP80TypeKind
+            | LLVMTypeKind::LLVMPPC_FP128TypeKind => {
+                BasicMetadataValueEnum::FloatValue(FloatValue::new(value))
+            }
+            LLVMTypeKind::LLVMIntegerTypeKind => {
+                BasicMetadataValueEnum::IntValue(IntValue::new(value))
+            }
+            LLVMTypeKind::LLVMStructTypeKind => {
+                BasicMetadataValueEnum::StructValue(StructValue::new(value))
+            }
+            LLVMTypeKind::LLVMPointerTypeKind => {
+                BasicMetadataValueEnum::PointerValue(PointerValue::new(value))
+            }
+            LLVMTypeKind::LLVMArrayTypeKind => {
+                BasicMetadataValueEnum::ArrayValue(ArrayValue::new(value))
+            }
+            LLVMTypeKind::LLVMVectorTypeKind => {
+                BasicMetadataValueEnum::VectorValue(VectorValue::new(value))
+            }
+            LLVMTypeKind::LLVMMetadataTypeKind => {
+                BasicMetadataValueEnum::MetadataValue(MetadataValue::new(value))
+            }
             _ => unreachable!("Unsupported type"),
         }
     }
@@ -443,9 +476,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
 
 impl<'ctx> From<BasicValueEnum<'ctx>> for AnyValueEnum<'ctx> {
     fn from(value: BasicValueEnum<'ctx>) -> Self {
-        unsafe {
-            AnyValueEnum::new(value.as_value_ref())
-        }
+        unsafe { AnyValueEnum::new(value.as_value_ref()) }
     }
 }
 

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -1,12 +1,16 @@
-use llvm_sys::core::{LLVMConstFNeg, LLVMConstFAdd, LLVMConstFSub, LLVMConstFMul, LLVMConstFDiv, LLVMConstFRem, LLVMConstFPCast, LLVMConstFPToUI, LLVMConstFPToSI, LLVMConstFPTrunc, LLVMConstFPExt, LLVMConstFCmp, LLVMConstRealGetDouble};
+use llvm_sys::core::{
+    LLVMConstFAdd, LLVMConstFCmp, LLVMConstFDiv, LLVMConstFMul, LLVMConstFNeg, LLVMConstFPCast,
+    LLVMConstFPExt, LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc, LLVMConstFRem,
+    LLVMConstFSub, LLVMConstRealGetDouble,
+};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
 
-use crate::FloatPredicate;
 use crate::types::{AsTypeRef, FloatType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value};
+use crate::FloatPredicate;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FloatValue<'ctx> {
@@ -29,9 +33,7 @@ impl<'ctx> FloatValue<'ctx> {
     }
 
     pub fn get_type(self) -> FloatType<'ctx> {
-        unsafe {
-            FloatType::new(self.float_value.get_type())
-        }
+        unsafe { FloatType::new(self.float_value.get_type()) }
     }
 
     pub fn is_null(self) -> bool {
@@ -51,75 +53,72 @@ impl<'ctx> FloatValue<'ctx> {
     }
 
     pub fn const_neg(self) -> Self {
-        unsafe {
-            FloatValue::new(LLVMConstFNeg(self.as_value_ref()))
-        }
+        unsafe { FloatValue::new(LLVMConstFNeg(self.as_value_ref())) }
     }
 
     pub fn const_add(self, rhs: FloatValue<'ctx>) -> Self {
-        unsafe {
-            FloatValue::new(LLVMConstFAdd(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { FloatValue::new(LLVMConstFAdd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_sub(self, rhs: FloatValue<'ctx>) -> Self {
-        unsafe {
-            FloatValue::new(LLVMConstFSub(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { FloatValue::new(LLVMConstFSub(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_mul(self, rhs: FloatValue<'ctx>) -> Self {
-        unsafe {
-            FloatValue::new(LLVMConstFMul(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { FloatValue::new(LLVMConstFMul(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_div(self, rhs: FloatValue<'ctx>) -> Self {
-        unsafe {
-            FloatValue::new(LLVMConstFDiv(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { FloatValue::new(LLVMConstFDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_remainder(self, rhs: FloatValue<'ctx>) -> Self {
-        unsafe {
-            FloatValue::new(LLVMConstFRem(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { FloatValue::new(LLVMConstFRem(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_cast(self, float_type: FloatType<'ctx>) -> Self {
         unsafe {
-            FloatValue::new(LLVMConstFPCast(self.as_value_ref(), float_type.as_type_ref()))
+            FloatValue::new(LLVMConstFPCast(
+                self.as_value_ref(),
+                float_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_to_unsigned_int(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstFPToUI(self.as_value_ref(), int_type.as_type_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstFPToUI(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     pub fn const_to_signed_int(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstFPToSI(self.as_value_ref(), int_type.as_type_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstFPToSI(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     pub fn const_truncate(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe {
-            FloatValue::new(LLVMConstFPTrunc(self.as_value_ref(), float_type.as_type_ref()))
+            FloatValue::new(LLVMConstFPTrunc(
+                self.as_value_ref(),
+                float_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_extend(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe {
-            FloatValue::new(LLVMConstFPExt(self.as_value_ref(), float_type.as_type_ref()))
+            FloatValue::new(LLVMConstFPExt(
+                self.as_value_ref(),
+                float_type.as_type_ref(),
+            ))
         }
     }
 
     // SubType: rhs same as lhs; return IntValue<bool>
     pub fn const_compare(self, op: FloatPredicate, rhs: FloatValue<'ctx>) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstFCmp(op.into(), self.as_value_ref(), rhs.as_value_ref()))
+            IntValue::new(LLVMConstFCmp(
+                op.into(),
+                self.as_value_ref(),
+                rhs.as_value_ref(),
+            ))
         }
     }
 
@@ -161,9 +160,7 @@ impl<'ctx> FloatValue<'ctx> {
         }
 
         let mut lossy = 0;
-        let constant = unsafe {
-            LLVMConstRealGetDouble(self.as_value_ref(), &mut lossy)
-        };
+        let constant = unsafe { LLVMConstRealGetDouble(self.as_value_ref(), &mut lossy) };
 
         Some((constant, lossy == 1))
     }

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -1,17 +1,30 @@
-use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyFunction, LLVMViewFunctionCFG, LLVMViewFunctionCFGOnly};
-use llvm_sys::core::{LLVMIsAFunction, LLVMIsConstant, LLVMGetLinkage, LLVMGetPreviousFunction, LLVMGetNextFunction, LLVMGetParam, LLVMCountParams, LLVMGetLastParam, LLVMCountBasicBlocks, LLVMGetFirstParam, LLVMGetNextParam, LLVMGetBasicBlocks, LLVMDeleteFunction, LLVMGetLastBasicBlock, LLVMGetFirstBasicBlock, LLVMGetIntrinsicID, LLVMGetFunctionCallConv, LLVMSetFunctionCallConv, LLVMGetGC, LLVMSetGC, LLVMSetLinkage, LLVMSetParamAlignment, LLVMGetParams};
+use llvm_sys::analysis::{
+    LLVMVerifierFailureAction, LLVMVerifyFunction, LLVMViewFunctionCFG, LLVMViewFunctionCFGOnly,
+};
+#[llvm_versions(3.9..=latest)]
+use llvm_sys::core::{
+    LLVMAddAttributeAtIndex, LLVMGetAttributeCountAtIndex, LLVMGetEnumAttributeAtIndex,
+    LLVMGetStringAttributeAtIndex, LLVMRemoveEnumAttributeAtIndex,
+    LLVMRemoveStringAttributeAtIndex,
+};
+use llvm_sys::core::{
+    LLVMCountBasicBlocks, LLVMCountParams, LLVMDeleteFunction, LLVMGetBasicBlocks,
+    LLVMGetFirstBasicBlock, LLVMGetFirstParam, LLVMGetFunctionCallConv, LLVMGetGC,
+    LLVMGetIntrinsicID, LLVMGetLastBasicBlock, LLVMGetLastParam, LLVMGetLinkage,
+    LLVMGetNextFunction, LLVMGetNextParam, LLVMGetParam, LLVMGetParams, LLVMGetPreviousFunction,
+    LLVMIsAFunction, LLVMIsConstant, LLVMSetFunctionCallConv, LLVMSetGC, LLVMSetLinkage,
+    LLVMSetParamAlignment,
+};
 #[llvm_versions(3.7..=latest)]
 use llvm_sys::core::{LLVMGetPersonalityFn, LLVMSetPersonalityFn};
-#[llvm_versions(3.9..=latest)]
-use llvm_sys::core::{LLVMAddAttributeAtIndex, LLVMGetAttributeCountAtIndex, LLVMGetEnumAttributeAtIndex, LLVMGetStringAttributeAtIndex, LLVMRemoveEnumAttributeAtIndex, LLVMRemoveStringAttributeAtIndex};
-use llvm_sys::prelude::{LLVMValueRef, LLVMBasicBlockRef};
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::debuginfo::{LLVMGetSubprogram, LLVMSetSubprogram};
+use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
 
 use std::ffi::CStr;
+use std::fmt;
 use std::marker::PhantomData;
 use std::mem::forget;
-use std::fmt;
 
 #[llvm_versions(3.9..=latest)]
 use crate::attributes::{Attribute, AttributeLoc};
@@ -37,19 +50,17 @@ impl<'ctx> FunctionValue<'ctx> {
 
         assert!(!LLVMIsAFunction(value).is_null());
 
-        Some(FunctionValue { fn_value: Value::new(value) })
+        Some(FunctionValue {
+            fn_value: Value::new(value),
+        })
     }
 
     pub fn get_linkage(self) -> Linkage {
-        unsafe {
-            LLVMGetLinkage(self.as_value_ref()).into()
-        }
+        unsafe { LLVMGetLinkage(self.as_value_ref()).into() }
     }
 
     pub fn set_linkage(self, linkage: Linkage) {
-        unsafe {
-            LLVMSetLinkage(self.as_value_ref(), linkage.into())
-        }
+        unsafe { LLVMSetLinkage(self.as_value_ref(), linkage.into()) }
     }
 
     pub fn is_null(self) -> bool {
@@ -72,58 +83,42 @@ impl<'ctx> FunctionValue<'ctx> {
             LLVMVerifierFailureAction::LLVMReturnStatusAction
         };
 
-        let code = unsafe {
-            LLVMVerifyFunction(self.fn_value.value, action)
-        };
+        let code = unsafe { LLVMVerifyFunction(self.fn_value.value, action) };
 
         code != 1
     }
 
     // REVIEW: If there's a demand, could easily create a module.get_functions() -> Iterator
     pub fn get_next_function(self) -> Option<Self> {
-        unsafe {
-            FunctionValue::new(LLVMGetNextFunction(self.as_value_ref()))
-        }
+        unsafe { FunctionValue::new(LLVMGetNextFunction(self.as_value_ref())) }
     }
 
     pub fn get_previous_function(self) -> Option<Self> {
-        unsafe {
-            FunctionValue::new(LLVMGetPreviousFunction(self.as_value_ref()))
-        }
+        unsafe { FunctionValue::new(LLVMGetPreviousFunction(self.as_value_ref())) }
     }
 
     pub fn get_first_param(self) -> Option<BasicValueEnum<'ctx>> {
-        let param = unsafe {
-            LLVMGetFirstParam(self.as_value_ref())
-        };
+        let param = unsafe { LLVMGetFirstParam(self.as_value_ref()) };
 
         if param.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(BasicValueEnum::new(param))
-        }
+        unsafe { Some(BasicValueEnum::new(param)) }
     }
 
     pub fn get_last_param(self) -> Option<BasicValueEnum<'ctx>> {
-        let param = unsafe {
-            LLVMGetLastParam(self.as_value_ref())
-        };
+        let param = unsafe { LLVMGetLastParam(self.as_value_ref()) };
 
         if param.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(BasicValueEnum::new(param))
-        }
+        unsafe { Some(BasicValueEnum::new(param)) }
     }
 
     pub fn get_first_basic_block(self) -> Option<BasicBlock<'ctx>> {
-        unsafe {
-            BasicBlock::new(LLVMGetFirstBasicBlock(self.as_value_ref()))
-        }
+        unsafe { BasicBlock::new(LLVMGetFirstBasicBlock(self.as_value_ref())) }
     }
 
     pub fn get_nth_param(self, nth: u32) -> Option<BasicValueEnum<'ctx>> {
@@ -133,21 +128,15 @@ impl<'ctx> FunctionValue<'ctx> {
             return None;
         }
 
-        unsafe {
-            Some(BasicValueEnum::new(LLVMGetParam(self.as_value_ref(), nth)))
-        }
+        unsafe { Some(BasicValueEnum::new(LLVMGetParam(self.as_value_ref(), nth))) }
     }
 
     pub fn count_params(self) -> u32 {
-        unsafe {
-            LLVMCountParams(self.fn_value.value)
-        }
+        unsafe { LLVMCountParams(self.fn_value.value) }
     }
 
     pub fn count_basic_blocks(self) -> u32 {
-        unsafe {
-            LLVMCountBasicBlocks(self.as_value_ref())
-        }
+        unsafe { LLVMCountBasicBlocks(self.as_value_ref()) }
     }
 
     pub fn get_basic_blocks(self) -> Vec<BasicBlock<'ctx>> {
@@ -163,7 +152,10 @@ impl<'ctx> FunctionValue<'ctx> {
             Vec::from_raw_parts(ptr, count as usize, count as usize)
         };
 
-        raw_vec.iter().map(|val| unsafe { BasicBlock::new(*val).unwrap() }).collect()
+        raw_vec
+            .iter()
+            .map(|val| unsafe { BasicBlock::new(*val).unwrap() })
+            .collect()
     }
 
     pub fn get_param_iter(self) -> ParamValueIter<'ctx> {
@@ -187,13 +179,14 @@ impl<'ctx> FunctionValue<'ctx> {
             Vec::from_raw_parts(ptr, count as usize, count as usize)
         };
 
-        raw_vec.iter().map(|val| unsafe { BasicValueEnum::new(*val) }).collect()
+        raw_vec
+            .iter()
+            .map(|val| unsafe { BasicValueEnum::new(*val) })
+            .collect()
     }
 
     pub fn get_last_basic_block(self) -> Option<BasicBlock<'ctx>> {
-        unsafe {
-            BasicBlock::new(LLVMGetLastBasicBlock(self.fn_value.value))
-        }
+        unsafe { BasicBlock::new(LLVMGetLastBasicBlock(self.fn_value.value)) }
     }
 
     /// Gets the name of a `FunctionValue`.
@@ -203,16 +196,12 @@ impl<'ctx> FunctionValue<'ctx> {
 
     /// View the control flow graph and produce a .dot file
     pub fn view_function_cfg(self) {
-        unsafe {
-            LLVMViewFunctionCFG(self.as_value_ref())
-        }
+        unsafe { LLVMViewFunctionCFG(self.as_value_ref()) }
     }
 
     /// Only view the control flow graph
     pub fn view_function_cfg_only(self) {
-        unsafe {
-            LLVMViewFunctionCFGOnly(self.as_value_ref())
-        }
+        unsafe { LLVMViewFunctionCFGOnly(self.as_value_ref()) }
     }
 
     // TODO: Look for ways to prevent use after delete but maybe not possible
@@ -231,9 +220,7 @@ impl<'ctx> FunctionValue<'ctx> {
     pub fn has_personality_function(self) -> bool {
         use llvm_sys::core::LLVMHasPersonalityFn;
 
-        unsafe {
-            LLVMHasPersonalityFn(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMHasPersonalityFn(self.as_value_ref()) == 1 }
     }
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-8")))]
@@ -248,9 +235,7 @@ impl<'ctx> FunctionValue<'ctx> {
             }
         }
 
-        unsafe {
-            FunctionValue::new(LLVMGetPersonalityFn(self.as_value_ref()))
-        }
+        unsafe { FunctionValue::new(LLVMGetPersonalityFn(self.as_value_ref())) }
     }
 
     // TODOC: This function will segfault in 3.8 due to a LLVM bug when
@@ -266,41 +251,29 @@ impl<'ctx> FunctionValue<'ctx> {
 
     #[llvm_versions(3.7..=latest)]
     pub fn set_personality_function(self, personality_fn: FunctionValue<'ctx>) {
-        unsafe {
-            LLVMSetPersonalityFn(self.as_value_ref(), personality_fn.as_value_ref())
-        }
+        unsafe { LLVMSetPersonalityFn(self.as_value_ref(), personality_fn.as_value_ref()) }
     }
 
     pub fn get_intrinsic_id(self) -> u32 {
-        unsafe {
-            LLVMGetIntrinsicID(self.as_value_ref())
-        }
+        unsafe { LLVMGetIntrinsicID(self.as_value_ref()) }
     }
 
     pub fn get_call_conventions(self) -> u32 {
-        unsafe {
-            LLVMGetFunctionCallConv(self.as_value_ref())
-        }
+        unsafe { LLVMGetFunctionCallConv(self.as_value_ref()) }
     }
 
     pub fn set_call_conventions(self, call_conventions: u32) {
-        unsafe {
-            LLVMSetFunctionCallConv(self.as_value_ref(), call_conventions)
-        }
+        unsafe { LLVMSetFunctionCallConv(self.as_value_ref(), call_conventions) }
     }
 
     pub fn get_gc(&self) -> &CStr {
-        unsafe {
-            CStr::from_ptr(LLVMGetGC(self.as_value_ref()))
-        }
+        unsafe { CStr::from_ptr(LLVMGetGC(self.as_value_ref())) }
     }
 
     pub fn set_gc(self, gc: &str) {
         let c_string = to_c_str(gc);
 
-        unsafe {
-            LLVMSetGC(self.as_value_ref(), c_string.as_ptr())
-        }
+        unsafe { LLVMSetGC(self.as_value_ref(), c_string.as_ptr()) }
     }
 
     pub fn replace_all_uses_with(self, other: FunctionValue<'ctx>) {
@@ -356,9 +329,7 @@ impl<'ctx> FunctionValue<'ctx> {
     /// ```
     #[llvm_versions(3.9..=latest)]
     pub fn count_attributes(self, loc: AttributeLoc) -> u32 {
-        unsafe {
-            LLVMGetAttributeCountAtIndex(self.as_value_ref(), loc.get_index())
-        }
+        unsafe { LLVMGetAttributeCountAtIndex(self.as_value_ref(), loc.get_index()) }
     }
 
     /// Removes a string `Attribute` belonging to the specified location in this `FunctionValue`.
@@ -382,7 +353,12 @@ impl<'ctx> FunctionValue<'ctx> {
     #[llvm_versions(3.9..=latest)]
     pub fn remove_string_attribute(self, loc: AttributeLoc, key: &str) {
         unsafe {
-            LLVMRemoveStringAttributeAtIndex(self.as_value_ref(), loc.get_index(), key.as_ptr() as *const ::libc::c_char, key.len() as u32)
+            LLVMRemoveStringAttributeAtIndex(
+                self.as_value_ref(),
+                loc.get_index(),
+                key.as_ptr() as *const ::libc::c_char,
+                key.len() as u32,
+            )
         }
     }
 
@@ -406,9 +382,7 @@ impl<'ctx> FunctionValue<'ctx> {
     /// ```
     #[llvm_versions(3.9..=latest)]
     pub fn remove_enum_attribute(self, loc: AttributeLoc, kind_id: u32) {
-        unsafe {
-            LLVMRemoveEnumAttributeAtIndex(self.as_value_ref(), loc.get_index(), kind_id)
-        }
+        unsafe { LLVMRemoveEnumAttributeAtIndex(self.as_value_ref(), loc.get_index(), kind_id) }
     }
 
     /// Gets an enum `Attribute` belonging to the specified location in this `FunctionValue`.
@@ -433,17 +407,14 @@ impl<'ctx> FunctionValue<'ctx> {
     // SubTypes: -> Option<Attribute<Enum>>
     #[llvm_versions(3.9..=latest)]
     pub fn get_enum_attribute(self, loc: AttributeLoc, kind_id: u32) -> Option<Attribute> {
-        let ptr = unsafe {
-            LLVMGetEnumAttributeAtIndex(self.as_value_ref(), loc.get_index(), kind_id)
-        };
+        let ptr =
+            unsafe { LLVMGetEnumAttributeAtIndex(self.as_value_ref(), loc.get_index(), kind_id) };
 
         if ptr.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(Attribute::new(ptr))
-        }
+        unsafe { Some(Attribute::new(ptr)) }
     }
 
     /// Gets a string `Attribute` belonging to the specified location in this `FunctionValue`.
@@ -469,23 +440,24 @@ impl<'ctx> FunctionValue<'ctx> {
     #[llvm_versions(3.9..=latest)]
     pub fn get_string_attribute(self, loc: AttributeLoc, key: &str) -> Option<Attribute> {
         let ptr = unsafe {
-            LLVMGetStringAttributeAtIndex(self.as_value_ref(), loc.get_index(), key.as_ptr() as *const ::libc::c_char, key.len() as u32)
+            LLVMGetStringAttributeAtIndex(
+                self.as_value_ref(),
+                loc.get_index(),
+                key.as_ptr() as *const ::libc::c_char,
+                key.len() as u32,
+            )
         };
 
         if ptr.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(Attribute::new(ptr))
-        }
+        unsafe { Some(Attribute::new(ptr)) }
     }
 
     pub fn set_param_alignment(self, param_index: u32, alignment: u32) {
         if let Some(param) = self.get_nth_param(param_index) {
-            unsafe {
-                LLVMSetParamAlignment(param.as_value_ref(), alignment)
-            }
+            unsafe { LLVMSetParamAlignment(param.as_value_ref(), alignment) }
         }
     }
 
@@ -493,9 +465,7 @@ impl<'ctx> FunctionValue<'ctx> {
     /// you to further inspect its global properties or even convert it to
     /// a `PointerValue`.
     pub fn as_global_value(self) -> GlobalValue<'ctx> {
-        unsafe {
-            GlobalValue::new(self.as_value_ref())
-        }
+        unsafe { GlobalValue::new(self.as_value_ref()) }
     }
 
     /// Set the debug info descriptor
@@ -531,9 +501,7 @@ impl fmt::Debug for FunctionValue<'_> {
         let llvm_value = self.print_to_string();
         let llvm_type = self.get_type();
         let name = self.get_name();
-        let is_const = unsafe {
-            LLVMIsConstant(self.fn_value.value) == 1
-        };
+        let is_const = unsafe { LLVMIsConstant(self.fn_value.value) == 1 };
         let is_null = self.is_null();
 
         f.debug_struct("FunctionValue")
@@ -559,9 +527,7 @@ impl<'ctx> Iterator for ParamValueIter<'ctx> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.start {
-            let first_value = unsafe {
-                LLVMGetFirstParam(self.param_iter_value)
-            };
+            let first_value = unsafe { LLVMGetFirstParam(self.param_iter_value) };
 
             if first_value.is_null() {
                 return None;
@@ -574,9 +540,7 @@ impl<'ctx> Iterator for ParamValueIter<'ctx> {
             return unsafe { Some(Self::Item::new(first_value)) };
         }
 
-        let next_value = unsafe {
-            LLVMGetNextParam(self.param_iter_value)
-        };
+        let next_value = unsafe { LLVMGetNextParam(self.param_iter_value) };
 
         if next_value.is_null() {
             return None;
@@ -584,8 +548,6 @@ impl<'ctx> Iterator for ParamValueIter<'ctx> {
 
         self.param_iter_value = next_value;
 
-        unsafe {
-            Some(Self::Item::new(next_value))
-        }
+        unsafe { Some(Self::Item::new(next_value)) }
     }
 }

--- a/src/values/generic_value.rs
+++ b/src/values/generic_value.rs
@@ -1,5 +1,8 @@
 use libc::c_void;
-use llvm_sys::execution_engine::{LLVMCreateGenericValueOfPointer, LLVMDisposeGenericValue, LLVMGenericValueIntWidth, LLVMGenericValueRef, LLVMGenericValueToInt, LLVMGenericValueToFloat, LLVMGenericValueToPointer};
+use llvm_sys::execution_engine::{
+    LLVMCreateGenericValueOfPointer, LLVMDisposeGenericValue, LLVMGenericValueIntWidth,
+    LLVMGenericValueRef, LLVMGenericValueToFloat, LLVMGenericValueToInt, LLVMGenericValueToPointer,
+};
 
 use crate::types::{AsTypeRef, FloatType};
 
@@ -24,9 +27,7 @@ impl<'ctx> GenericValue<'ctx> {
 
     // SubType: GenericValue<IntValue> only
     pub fn int_width(self) -> u32 {
-        unsafe {
-            LLVMGenericValueIntWidth(self.generic_value)
-        }
+        unsafe { LLVMGenericValueIntWidth(self.generic_value) }
     }
 
     // SubType: create_generic_value() -> GenericValue<PointerValue, T>
@@ -39,16 +40,12 @@ impl<'ctx> GenericValue<'ctx> {
 
     // SubType: impl only for GenericValue<IntValue>
     pub fn as_int(self, is_signed: bool) -> u64 {
-        unsafe {
-            LLVMGenericValueToInt(self.generic_value, is_signed as i32)
-        }
+        unsafe { LLVMGenericValueToInt(self.generic_value, is_signed as i32) }
     }
 
     // SubType: impl only for GenericValue<FloatValue>
     pub fn as_float(self, float_type: &FloatType<'ctx>) -> f64 {
-        unsafe {
-            LLVMGenericValueToFloat(float_type.as_type_ref(), self.generic_value)
-        }
+        unsafe { LLVMGenericValueToFloat(float_type.as_type_ref(), self.generic_value) }
     }
 
     // SubType: impl only for GenericValue<PointerValue, T>
@@ -60,8 +57,6 @@ impl<'ctx> GenericValue<'ctx> {
 
 impl Drop for GenericValue<'_> {
     fn drop(&mut self) {
-        unsafe {
-            LLVMDisposeGenericValue(self.generic_value)
-        }
+        unsafe { LLVMDisposeGenericValue(self.generic_value) }
     }
 }

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -1,29 +1,43 @@
-use llvm_sys::LLVMThreadLocalMode;
-#[llvm_versions(3.6..8.0)]
-use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
-#[llvm_versions(8.0..=latest)]
-use llvm_sys::core::{LLVMGetVisibility, LLVMSetVisibility, LLVMGetSection, LLVMSetSection, LLVMIsExternallyInitialized, LLVMSetExternallyInitialized, LLVMDeleteGlobal, LLVMIsGlobalConstant, LLVMSetGlobalConstant, LLVMGetPreviousGlobal, LLVMGetNextGlobal, LLVMIsThreadLocal, LLVMSetThreadLocal, LLVMGetThreadLocalMode, LLVMSetThreadLocalMode, LLVMGetInitializer, LLVMSetInitializer, LLVMIsDeclaration, LLVMGetDLLStorageClass, LLVMSetDLLStorageClass, LLVMGetAlignment, LLVMSetAlignment, LLVMGetLinkage, LLVMSetLinkage};
-#[llvm_versions(3.6..=6.0)]
-use llvm_sys::core::{LLVMHasUnnamedAddr, LLVMSetUnnamedAddr};
-#[llvm_versions(7.0..=latest)]
-use llvm_sys::core::{LLVMGetUnnamedAddress, LLVMSetUnnamedAddress};
-#[llvm_versions(7.0..=latest)]
-use llvm_sys::LLVMUnnamedAddr;
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::LLVMGlobalSetMetadata;
+#[llvm_versions(3.6..8.0)]
+use llvm_sys::core::{
+    LLVMDeleteGlobal, LLVMGetAlignment, LLVMGetDLLStorageClass, LLVMGetInitializer, LLVMGetLinkage,
+    LLVMGetNextGlobal, LLVMGetPreviousGlobal, LLVMGetSection, LLVMGetThreadLocalMode,
+    LLVMGetVisibility, LLVMIsDeclaration, LLVMIsExternallyInitialized, LLVMIsGlobalConstant,
+    LLVMIsThreadLocal, LLVMSetAlignment, LLVMSetDLLStorageClass, LLVMSetExternallyInitialized,
+    LLVMSetGlobalConstant, LLVMSetInitializer, LLVMSetLinkage, LLVMSetSection, LLVMSetThreadLocal,
+    LLVMSetThreadLocalMode, LLVMSetVisibility,
+};
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::core::{
+    LLVMDeleteGlobal, LLVMGetAlignment, LLVMGetDLLStorageClass, LLVMGetInitializer, LLVMGetLinkage,
+    LLVMGetNextGlobal, LLVMGetPreviousGlobal, LLVMGetSection, LLVMGetThreadLocalMode,
+    LLVMGetVisibility, LLVMIsDeclaration, LLVMIsExternallyInitialized, LLVMIsGlobalConstant,
+    LLVMIsThreadLocal, LLVMSetAlignment, LLVMSetDLLStorageClass, LLVMSetExternallyInitialized,
+    LLVMSetGlobalConstant, LLVMSetInitializer, LLVMSetLinkage, LLVMSetSection, LLVMSetThreadLocal,
+    LLVMSetThreadLocalMode, LLVMSetVisibility,
+};
+#[llvm_versions(7.0..=latest)]
+use llvm_sys::core::{LLVMGetUnnamedAddress, LLVMSetUnnamedAddress};
+#[llvm_versions(3.6..=6.0)]
+use llvm_sys::core::{LLVMHasUnnamedAddr, LLVMSetUnnamedAddr};
 use llvm_sys::prelude::LLVMValueRef;
+use llvm_sys::LLVMThreadLocalMode;
+#[llvm_versions(7.0..=latest)]
+use llvm_sys::LLVMUnnamedAddr;
 
 use std::ffi::CStr;
 
-use crate::{GlobalVisibility, ThreadLocalMode, DLLStorageClass};
-use crate::module::Linkage;
-use crate::support::{to_c_str, LLVMString};
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
+use crate::module::Linkage;
+use crate::support::{to_c_str, LLVMString};
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValueEnum, BasicValue, PointerValue, Value};
 #[llvm_versions(8.0..=latest)]
 use crate::values::MetadataValue;
+use crate::values::{BasicValue, BasicValueEnum, PointerValue, Value};
+use crate::{DLLStorageClass, GlobalVisibility, ThreadLocalMode};
 
 // REVIEW: GlobalValues are always PointerValues. With SubTypes, we should
 // compress this into a PointerValue<Global> type
@@ -47,85 +61,61 @@ impl<'ctx> GlobalValue<'ctx> {
     }
 
     pub fn get_previous_global(self) -> Option<GlobalValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetPreviousGlobal(self.as_value_ref())
-        };
+        let value = unsafe { LLVMGetPreviousGlobal(self.as_value_ref()) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(GlobalValue::new(value))
-        }
+        unsafe { Some(GlobalValue::new(value)) }
     }
 
     pub fn get_next_global(self) -> Option<GlobalValue<'ctx>> {
-        let value = unsafe {
-            LLVMGetNextGlobal(self.as_value_ref())
-        };
+        let value = unsafe { LLVMGetNextGlobal(self.as_value_ref()) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(GlobalValue::new(value))
-        }
+        unsafe { Some(GlobalValue::new(value)) }
     }
 
     pub fn get_dll_storage_class(self) -> DLLStorageClass {
-        let dll_storage_class = unsafe {
-            LLVMGetDLLStorageClass(self.as_value_ref())
-        };
+        let dll_storage_class = unsafe { LLVMGetDLLStorageClass(self.as_value_ref()) };
 
         DLLStorageClass::new(dll_storage_class)
     }
 
     pub fn set_dll_storage_class(self, dll_storage_class: DLLStorageClass) {
-        unsafe {
-            LLVMSetDLLStorageClass(self.as_value_ref(), dll_storage_class.into())
-        }
+        unsafe { LLVMSetDLLStorageClass(self.as_value_ref(), dll_storage_class.into()) }
     }
 
     pub fn get_initializer(self) -> Option<BasicValueEnum<'ctx>> {
-        let value = unsafe {
-            LLVMGetInitializer(self.as_value_ref())
-        };
+        let value = unsafe { LLVMGetInitializer(self.as_value_ref()) };
 
         if value.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(BasicValueEnum::new(value))
-        }
+        unsafe { Some(BasicValueEnum::new(value)) }
     }
 
     // SubType: This input type should be tied to the BasicType
     pub fn set_initializer(self, value: &dyn BasicValue<'ctx>) {
-        unsafe {
-            LLVMSetInitializer(self.as_value_ref(), value.as_value_ref())
-        }
+        unsafe { LLVMSetInitializer(self.as_value_ref(), value.as_value_ref()) }
     }
 
     pub fn is_thread_local(self) -> bool {
-        unsafe {
-            LLVMIsThreadLocal(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMIsThreadLocal(self.as_value_ref()) == 1 }
     }
 
     // TODOC: Setting this to true is the same as setting GeneralDynamicTLSModel
     pub fn set_thread_local(self, is_thread_local: bool) {
-        unsafe {
-            LLVMSetThreadLocal(self.as_value_ref(), is_thread_local as i32)
-        }
+        unsafe { LLVMSetThreadLocal(self.as_value_ref(), is_thread_local as i32) }
     }
 
     pub fn get_thread_local_mode(self) -> Option<ThreadLocalMode> {
-        let thread_local_mode = unsafe {
-            LLVMGetThreadLocalMode(self.as_value_ref())
-        };
+        let thread_local_mode = unsafe { LLVMGetThreadLocalMode(self.as_value_ref()) };
 
         ThreadLocalMode::new(thread_local_mode)
     }
@@ -138,9 +128,7 @@ impl<'ctx> GlobalValue<'ctx> {
             None => LLVMThreadLocalMode::LLVMNotThreadLocal,
         };
 
-        unsafe {
-            LLVMSetThreadLocalMode(self.as_value_ref(), thread_local_mode)
-        }
+        unsafe { LLVMSetThreadLocalMode(self.as_value_ref(), thread_local_mode) }
     }
 
     // SubType: This should be moved into the type. GlobalValue<Initialized/Uninitialized>
@@ -165,16 +153,12 @@ impl<'ctx> GlobalValue<'ctx> {
     /// assert!(!fn_value.as_global_value().is_declaration());
     /// ```
     pub fn is_declaration(self) -> bool {
-        unsafe {
-            LLVMIsDeclaration(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMIsDeclaration(self.as_value_ref()) == 1 }
     }
 
     #[llvm_versions(3.6..7.0)]
     pub fn has_unnamed_addr(self) -> bool {
-        unsafe {
-            LLVMHasUnnamedAddr(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMHasUnnamedAddr(self.as_value_ref()) == 1 }
     }
 
     #[llvm_versions(7.0..=latest)]
@@ -184,12 +168,9 @@ impl<'ctx> GlobalValue<'ctx> {
         }
     }
 
-
     #[llvm_versions(3.6..7.0)]
     pub fn set_unnamed_addr(self, has_unnamed_addr: bool) {
-        unsafe {
-            LLVMSetUnnamedAddr(self.as_value_ref(), has_unnamed_addr as i32)
-        }
+        unsafe { LLVMSetUnnamedAddr(self.as_value_ref(), has_unnamed_addr as i32) }
     }
 
     #[llvm_versions(7.0..=latest)]
@@ -204,55 +185,39 @@ impl<'ctx> GlobalValue<'ctx> {
     }
 
     pub fn is_constant(self) -> bool {
-        unsafe {
-            LLVMIsGlobalConstant(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMIsGlobalConstant(self.as_value_ref()) == 1 }
     }
 
     pub fn set_constant(self, is_constant: bool) {
-        unsafe {
-            LLVMSetGlobalConstant(self.as_value_ref(), is_constant as i32)
-        }
+        unsafe { LLVMSetGlobalConstant(self.as_value_ref(), is_constant as i32) }
     }
 
     pub fn is_externally_initialized(self) -> bool {
-        unsafe {
-            LLVMIsExternallyInitialized(self.as_value_ref()) == 1
-        }
+        unsafe { LLVMIsExternallyInitialized(self.as_value_ref()) == 1 }
     }
 
     pub fn set_externally_initialized(self, externally_initialized: bool) {
-        unsafe {
-            LLVMSetExternallyInitialized(self.as_value_ref(), externally_initialized as i32)
-        }
+        unsafe { LLVMSetExternallyInitialized(self.as_value_ref(), externally_initialized as i32) }
     }
 
     pub fn set_visibility(self, visibility: GlobalVisibility) {
-        unsafe {
-            LLVMSetVisibility(self.as_value_ref(), visibility.into())
-        }
+        unsafe { LLVMSetVisibility(self.as_value_ref(), visibility.into()) }
     }
 
     pub fn get_visibility(self) -> GlobalVisibility {
-        let visibility = unsafe {
-            LLVMGetVisibility(self.as_value_ref())
-        };
+        let visibility = unsafe { LLVMGetVisibility(self.as_value_ref()) };
 
         GlobalVisibility::new(visibility)
     }
 
     pub fn get_section(&self) -> &CStr {
-        unsafe {
-            CStr::from_ptr(LLVMGetSection(self.as_value_ref()))
-        }
+        unsafe { CStr::from_ptr(LLVMGetSection(self.as_value_ref())) }
     }
 
     pub fn set_section(self, section: &str) {
         let c_string = to_c_str(section);
 
-        unsafe {
-            LLVMSetSection(self.as_value_ref(), c_string.as_ptr())
-        }
+        unsafe { LLVMSetSection(self.as_value_ref(), c_string.as_ptr()) }
     }
 
     pub unsafe fn delete(self) {
@@ -260,29 +225,21 @@ impl<'ctx> GlobalValue<'ctx> {
     }
 
     pub fn as_pointer_value(self) -> PointerValue<'ctx> {
-        unsafe {
-            PointerValue::new(self.as_value_ref())
-        }
+        unsafe { PointerValue::new(self.as_value_ref()) }
     }
 
     pub fn get_alignment(self) -> u32 {
-        unsafe {
-            LLVMGetAlignment(self.as_value_ref())
-        }
+        unsafe { LLVMGetAlignment(self.as_value_ref()) }
     }
 
     pub fn set_alignment(self, alignment: u32) {
-        unsafe {
-            LLVMSetAlignment(self.as_value_ref(), alignment)
-        }
+        unsafe { LLVMSetAlignment(self.as_value_ref(), alignment) }
     }
 
     /// Sets a metadata of the given type on the GlobalValue
     #[llvm_versions(8.0..=latest)]
     pub fn set_metadata(self, metadata: MetadataValue<'ctx>, kind_id: u32) {
-        unsafe {
-            LLVMGlobalSetMetadata(self.as_value_ref(), kind_id, metadata.as_metadata_ref())
-        }
+        unsafe { LLVMGlobalSetMetadata(self.as_value_ref(), kind_id, metadata.as_metadata_ref()) }
     }
 
     /// Gets a `Comdat` assigned to this `GlobalValue`, if any.
@@ -290,9 +247,7 @@ impl<'ctx> GlobalValue<'ctx> {
     pub fn get_comdat(self) -> Option<Comdat> {
         use llvm_sys::comdat::LLVMGetComdat;
 
-        let comdat_ptr = unsafe {
-            LLVMGetComdat(self.as_value_ref())
-        };
+        let comdat_ptr = unsafe { LLVMGetComdat(self.as_value_ref()) };
 
         if comdat_ptr.is_null() {
             return None;
@@ -306,18 +261,14 @@ impl<'ctx> GlobalValue<'ctx> {
     pub fn set_comdat(self, comdat: Comdat) {
         use llvm_sys::comdat::LLVMSetComdat;
 
-        unsafe {
-            LLVMSetComdat(self.as_value_ref(), comdat.0)
-        }
+        unsafe { LLVMSetComdat(self.as_value_ref(), comdat.0) }
     }
 
     #[llvm_versions(7.0..=latest)]
     pub fn get_unnamed_address(self) -> UnnamedAddress {
         use llvm_sys::core::LLVMGetUnnamedAddress;
 
-        let unnamed_address = unsafe {
-            LLVMGetUnnamedAddress(self.as_value_ref())
-        };
+        let unnamed_address = unsafe { LLVMGetUnnamedAddress(self.as_value_ref()) };
 
         UnnamedAddress::new(unnamed_address)
     }
@@ -326,21 +277,15 @@ impl<'ctx> GlobalValue<'ctx> {
     pub fn set_unnamed_address(self, address: UnnamedAddress) {
         use llvm_sys::core::LLVMSetUnnamedAddress;
 
-        unsafe {
-            LLVMSetUnnamedAddress(self.as_value_ref(), address.into())
-        }
+        unsafe { LLVMSetUnnamedAddress(self.as_value_ref(), address.into()) }
     }
 
     pub fn get_linkage(self) -> Linkage {
-        unsafe {
-            LLVMGetLinkage(self.as_value_ref()).into()
-        }
+        unsafe { LLVMGetLinkage(self.as_value_ref()).into() }
     }
 
     pub fn set_linkage(self, linkage: Linkage) {
-        unsafe {
-            LLVMSetLinkage(self.as_value_ref(), linkage.into())
-        }
+        unsafe { LLVMSetLinkage(self.as_value_ref(), linkage.into()) }
     }
 
     pub fn print_to_string(self) -> LLVMString {

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -1,14 +1,25 @@
-use llvm_sys::core::{LLVMConstNot, LLVMConstNeg, LLVMConstNSWNeg, LLVMConstNUWNeg, LLVMConstAdd, LLVMConstNSWAdd, LLVMConstNUWAdd, LLVMConstSub, LLVMConstNSWSub, LLVMConstNUWSub, LLVMConstMul, LLVMConstNSWMul, LLVMConstNUWMul, LLVMConstUDiv, LLVMConstSDiv, LLVMConstSRem, LLVMConstURem, LLVMConstIntCast, LLVMConstXor, LLVMConstOr, LLVMConstAnd, LLVMConstExactSDiv, LLVMConstShl, LLVMConstLShr, LLVMConstAShr, LLVMConstUIToFP, LLVMConstSIToFP, LLVMConstIntToPtr, LLVMConstTrunc, LLVMConstSExt, LLVMConstZExt, LLVMConstTruncOrBitCast, LLVMConstSExtOrBitCast, LLVMConstZExtOrBitCast, LLVMConstBitCast, LLVMConstICmp, LLVMConstIntGetZExtValue, LLVMConstIntGetSExtValue, LLVMConstSelect, LLVMIsAConstantInt};
 #[llvm_versions(4.0..=latest)]
 use llvm_sys::core::LLVMConstExactUDiv;
+use llvm_sys::core::{
+    LLVMConstAShr, LLVMConstAdd, LLVMConstAnd, LLVMConstBitCast, LLVMConstExactSDiv, LLVMConstICmp,
+    LLVMConstIntCast, LLVMConstIntGetSExtValue, LLVMConstIntGetZExtValue, LLVMConstIntToPtr,
+    LLVMConstLShr, LLVMConstMul, LLVMConstNSWAdd, LLVMConstNSWMul, LLVMConstNSWNeg,
+    LLVMConstNSWSub, LLVMConstNUWAdd, LLVMConstNUWMul, LLVMConstNUWNeg, LLVMConstNUWSub,
+    LLVMConstNeg, LLVMConstNot, LLVMConstOr, LLVMConstSDiv, LLVMConstSExt, LLVMConstSExtOrBitCast,
+    LLVMConstSIToFP, LLVMConstSRem, LLVMConstSelect, LLVMConstShl, LLVMConstSub, LLVMConstTrunc,
+    LLVMConstTruncOrBitCast, LLVMConstUDiv, LLVMConstUIToFP, LLVMConstURem, LLVMConstXor,
+    LLVMConstZExt, LLVMConstZExtOrBitCast, LLVMIsAConstantInt,
+};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
 
-use crate::IntPredicate;
-use crate::types::{AsTypeRef, FloatType, PointerType, IntType};
+use crate::types::{AsTypeRef, FloatType, IntType, PointerType};
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value};
+use crate::values::{
+    BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value,
+};
+use crate::IntPredicate;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct IntValue<'ctx> {
@@ -31,9 +42,7 @@ impl<'ctx> IntValue<'ctx> {
     }
 
     pub fn get_type(self) -> IntType<'ctx> {
-        unsafe {
-            IntType::new(self.int_value.get_type())
-        }
+        unsafe { IntType::new(self.int_value.get_type()) }
     }
 
     pub fn is_null(self) -> bool {
@@ -53,242 +62,219 @@ impl<'ctx> IntValue<'ctx> {
     }
 
     pub fn const_not(self) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNot(self.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNot(self.as_value_ref())) }
     }
 
     // REVIEW: What happens when not using a const value? This and other fns
     pub fn const_neg(self) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNeg(self.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNeg(self.as_value_ref())) }
     }
 
     pub fn const_nsw_neg(self) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNSWNeg(self.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNSWNeg(self.as_value_ref())) }
     }
 
     pub fn const_nuw_neg(self) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNUWNeg(self.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNUWNeg(self.as_value_ref())) }
     }
 
     pub fn const_add(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstAdd(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstAdd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_nsw_add(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNSWAdd(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNSWAdd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_nuw_add(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNUWAdd(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNUWAdd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_sub(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstSub(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstSub(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_nsw_sub(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNSWSub(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNSWSub(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_nuw_sub(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNUWSub(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNUWSub(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_mul(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstMul(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstMul(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_nsw_mul(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNSWMul(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNSWMul(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_nuw_mul(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstNUWMul(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstNUWMul(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_unsigned_div(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstUDiv(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstUDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_signed_div(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstSDiv(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstSDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_exact_signed_div(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstExactSDiv(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstExactSDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     #[llvm_versions(4.0..=latest)]
     pub fn const_exact_unsigned_div(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstExactUDiv(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstExactUDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_unsigned_remainder(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstURem(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstURem(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_signed_remainder(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstSRem(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstSRem(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_and(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstAnd(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstAnd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_or(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstOr(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstOr(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_xor(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstXor(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstXor(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     // TODO: Could infer is_signed from type (one day)?
     pub fn const_cast(self, int_type: IntType<'ctx>, is_signed: bool) -> Self {
         unsafe {
-            IntValue::new(LLVMConstIntCast(self.as_value_ref(), int_type.as_type_ref(), is_signed as i32))
+            IntValue::new(LLVMConstIntCast(
+                self.as_value_ref(),
+                int_type.as_type_ref(),
+                is_signed as i32,
+            ))
         }
     }
 
     // TODO: Give shift methods more descriptive names
     pub fn const_shl(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstShl(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstShl(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_rshr(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstLShr(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstLShr(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     pub fn const_ashr(self, rhs: IntValue<'ctx>) -> Self {
-        unsafe {
-            IntValue::new(LLVMConstAShr(self.as_value_ref(), rhs.as_value_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstAShr(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     // SubType: const_to_float impl only for unsigned types
     pub fn const_unsigned_to_float(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe {
-            FloatValue::new(LLVMConstUIToFP(self.as_value_ref(), float_type.as_type_ref()))
+            FloatValue::new(LLVMConstUIToFP(
+                self.as_value_ref(),
+                float_type.as_type_ref(),
+            ))
         }
     }
 
     // SubType: const_to_float impl only for signed types
     pub fn const_signed_to_float(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe {
-            FloatValue::new(LLVMConstSIToFP(self.as_value_ref(), float_type.as_type_ref()))
+            FloatValue::new(LLVMConstSIToFP(
+                self.as_value_ref(),
+                float_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_to_pointer(self, ptr_type: PointerType<'ctx>) -> PointerValue<'ctx> {
         unsafe {
-            PointerValue::new(LLVMConstIntToPtr(self.as_value_ref(), ptr_type.as_type_ref()))
+            PointerValue::new(LLVMConstIntToPtr(
+                self.as_value_ref(),
+                ptr_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_truncate(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstTrunc(self.as_value_ref(), int_type.as_type_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstTrunc(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     // TODO: More descriptive name
     pub fn const_s_extend(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstSExt(self.as_value_ref(), int_type.as_type_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstSExt(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     // TODO: More descriptive name
     pub fn const_z_ext(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
-        unsafe {
-            IntValue::new(LLVMConstZExt(self.as_value_ref(), int_type.as_type_ref()))
-        }
+        unsafe { IntValue::new(LLVMConstZExt(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     pub fn const_truncate_or_bit_cast(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstTruncOrBitCast(self.as_value_ref(), int_type.as_type_ref()))
+            IntValue::new(LLVMConstTruncOrBitCast(
+                self.as_value_ref(),
+                int_type.as_type_ref(),
+            ))
         }
     }
 
     // TODO: More descriptive name
     pub fn const_s_extend_or_bit_cast(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstSExtOrBitCast(self.as_value_ref(), int_type.as_type_ref()))
+            IntValue::new(LLVMConstSExtOrBitCast(
+                self.as_value_ref(),
+                int_type.as_type_ref(),
+            ))
         }
     }
 
     // TODO: More descriptive name
     pub fn const_z_ext_or_bit_cast(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstZExtOrBitCast(self.as_value_ref(), int_type.as_type_ref()))
+            IntValue::new(LLVMConstZExtOrBitCast(
+                self.as_value_ref(),
+                int_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_bit_cast(self, int_type: IntType) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstBitCast(self.as_value_ref(), int_type.as_type_ref()))
+            IntValue::new(LLVMConstBitCast(
+                self.as_value_ref(),
+                int_type.as_type_ref(),
+            ))
         }
     }
 
     // SubType: rhs same as lhs; return IntValue<bool>
     pub fn const_int_compare(self, op: IntPredicate, rhs: IntValue<'ctx>) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstICmp(op.into(), self.as_value_ref(), rhs.as_value_ref()))
+            IntValue::new(LLVMConstICmp(
+                op.into(),
+                self.as_value_ref(),
+                rhs.as_value_ref(),
+            ))
         }
     }
 
     // SubTypes: self can only be IntValue<bool>
     pub fn const_select<BV: BasicValue<'ctx>>(self, then: BV, else_: BV) -> BasicValueEnum<'ctx> {
         unsafe {
-            BasicValueEnum::new(LLVMConstSelect(self.as_value_ref(), then.as_value_ref(), else_.as_value_ref()))
+            BasicValueEnum::new(LLVMConstSelect(
+                self.as_value_ref(),
+                then.as_value_ref(),
+                else_.as_value_ref(),
+            ))
         }
     }
 
@@ -353,9 +339,7 @@ impl<'ctx> IntValue<'ctx> {
             return None;
         }
 
-        unsafe {
-            Some(LLVMConstIntGetZExtValue(self.as_value_ref()))
-        }
+        unsafe { Some(LLVMConstIntGetZExtValue(self.as_value_ref())) }
     }
 
     /// Obtains a constant `IntValue`'s sign extended value.
@@ -380,9 +364,7 @@ impl<'ctx> IntValue<'ctx> {
             return None;
         }
 
-        unsafe {
-            Some(LLVMConstIntGetSExtValue(self.as_value_ref()))
-        }
+        unsafe { Some(LLVMConstIntGetSExtValue(self.as_value_ref())) }
     }
 
     pub fn replace_all_uses_with(self, other: IntValue<'ctx>) {

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -1,10 +1,13 @@
-use llvm_sys::core::{LLVMIsAMDNode, LLVMIsAMDString, LLVMGetMDString, LLVMGetMDNodeNumOperands, LLVMGetMDNodeOperands};
+use llvm_sys::core::{
+    LLVMGetMDNodeNumOperands, LLVMGetMDNodeOperands, LLVMGetMDString, LLVMIsAMDNode,
+    LLVMIsAMDString,
+};
 use llvm_sys::prelude::LLVMValueRef;
 
 #[llvm_versions(7.0..=latest)]
-use llvm_sys::prelude::LLVMMetadataRef;
-#[llvm_versions(7.0..=latest)]
 use llvm_sys::core::LLVMValueAsMetadata;
+#[llvm_versions(7.0..=latest)]
+use llvm_sys::prelude::LLVMMetadataRef;
 
 use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
@@ -56,23 +59,17 @@ impl<'ctx> MetadataValue<'ctx> {
 
     #[llvm_versions(7.0..=latest)]
     pub(crate) fn as_metadata_ref(self) -> LLVMMetadataRef {
-        unsafe {
-            LLVMValueAsMetadata(self.as_value_ref())
-        }
+        unsafe { LLVMValueAsMetadata(self.as_value_ref()) }
     }
 
     // SubTypes: This can probably go away with subtypes
     pub fn is_node(self) -> bool {
-        unsafe {
-            LLVMIsAMDNode(self.as_value_ref()) == self.as_value_ref()
-        }
+        unsafe { LLVMIsAMDNode(self.as_value_ref()) == self.as_value_ref() }
     }
 
     // SubTypes: This can probably go away with subtypes
     pub fn is_string(self) -> bool {
-        unsafe {
-            LLVMIsAMDString(self.as_value_ref()) == self.as_value_ref()
-        }
+        unsafe { LLVMIsAMDString(self.as_value_ref()) == self.as_value_ref() }
     }
 
     pub fn get_string_value(&self) -> Option<&CStr> {
@@ -81,9 +78,7 @@ impl<'ctx> MetadataValue<'ctx> {
         }
 
         let mut len = 0;
-        let c_str = unsafe {
-            CStr::from_ptr(LLVMGetMDString(self.as_value_ref(), &mut len))
-        };
+        let c_str = unsafe { CStr::from_ptr(LLVMGetMDString(self.as_value_ref(), &mut len)) };
 
         Some(c_str)
     }
@@ -94,9 +89,7 @@ impl<'ctx> MetadataValue<'ctx> {
             return 0;
         }
 
-        unsafe {
-            LLVMGetMDNodeNumOperands(self.as_value_ref())
-        }
+        unsafe { LLVMGetMDNodeNumOperands(self.as_value_ref()) }
     }
 
     // SubTypes: Node only one day
@@ -130,7 +123,8 @@ impl<'ctx> MetadataValue<'ctx> {
     }
 
     pub fn replace_all_uses_with(self, other: &MetadataValue<'ctx>) {
-        self.metadata_value.replace_all_uses_with(other.as_value_ref())
+        self.metadata_value
+            .replace_all_uses_with(other.as_value_ref())
     }
 }
 

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -6,6 +6,7 @@ mod array_value;
 mod basic_value_use;
 #[deny(missing_docs)]
 mod call_site_value;
+mod callable_value;
 mod enums;
 mod float_value;
 mod fn_value;
@@ -19,32 +20,38 @@ mod ptr_value;
 mod struct_value;
 mod traits;
 mod vec_value;
-mod callable_value;
 
 use crate::support::LLVMString;
 pub use crate::values::array_value::ArrayValue;
 pub use crate::values::basic_value_use::BasicValueUse;
 pub use crate::values::call_site_value::CallSiteValue;
-pub use crate::values::enums::{AnyValueEnum, AggregateValueEnum, BasicValueEnum, BasicMetadataValueEnum};
+pub use crate::values::callable_value::CallableValue;
+pub use crate::values::enums::{
+    AggregateValueEnum, AnyValueEnum, BasicMetadataValueEnum, BasicValueEnum,
+};
 pub use crate::values::float_value::FloatValue;
 pub use crate::values::fn_value::FunctionValue;
 pub use crate::values::generic_value::GenericValue;
 pub use crate::values::global_value::GlobalValue;
 #[llvm_versions(7.0..=latest)]
 pub use crate::values::global_value::UnnamedAddress;
-pub use crate::values::instruction_value::{InstructionValue, InstructionOpcode};
+pub use crate::values::instruction_value::{InstructionOpcode, InstructionValue};
 pub use crate::values::int_value::IntValue;
 pub use crate::values::metadata_value::{MetadataValue, FIRST_CUSTOM_METADATA_KIND_ID};
 pub use crate::values::phi_value::PhiValue;
 pub use crate::values::ptr_value::PointerValue;
 pub use crate::values::struct_value::StructValue;
-pub use crate::values::callable_value::CallableValue;
-pub use crate::values::traits::{AnyValue, AggregateValue, BasicValue, IntMathValue, FloatMathValue, PointerMathValue};
-pub use crate::values::vec_value::VectorValue;
 pub(crate) use crate::values::traits::AsValueRef;
+pub use crate::values::traits::{
+    AggregateValue, AnyValue, BasicValue, FloatMathValue, IntMathValue, PointerMathValue,
+};
+pub use crate::values::vec_value::VectorValue;
 
-use llvm_sys::core::{LLVMIsConstant, LLVMIsNull, LLVMIsUndef, LLVMPrintTypeToString, LLVMPrintValueToString, LLVMTypeOf, LLVMDumpValue, LLVMIsAInstruction, LLVMReplaceAllUsesWith, LLVMGetFirstUse};
-use llvm_sys::prelude::{LLVMValueRef, LLVMTypeRef};
+use llvm_sys::core::{
+    LLVMDumpValue, LLVMGetFirstUse, LLVMIsAInstruction, LLVMIsConstant, LLVMIsNull, LLVMIsUndef,
+    LLVMPrintTypeToString, LLVMPrintValueToString, LLVMReplaceAllUsesWith, LLVMTypeOf,
+};
+use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use std::ffi::CStr;
 use std::fmt;
@@ -58,7 +65,10 @@ struct Value<'ctx> {
 
 impl<'ctx> Value<'ctx> {
     pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
-        debug_assert!(!value.is_null(), "This should never happen since containing struct should check null ptrs");
+        debug_assert!(
+            !value.is_null(),
+            "This should never happen since containing struct should check null ptrs"
+        );
 
         Value {
             value,
@@ -67,9 +77,7 @@ impl<'ctx> Value<'ctx> {
     }
 
     fn is_instruction(self) -> bool {
-        unsafe {
-            !LLVMIsAInstruction(self.value).is_null()
-        }
+        unsafe { !LLVMIsAInstruction(self.value).is_null() }
     }
 
     fn as_instruction(self) -> Option<InstructionValue<'ctx>> {
@@ -77,21 +85,15 @@ impl<'ctx> Value<'ctx> {
             return None;
         }
 
-        unsafe {
-            Some(InstructionValue::new(self.value))
-        }
+        unsafe { Some(InstructionValue::new(self.value)) }
     }
 
     fn is_null(self) -> bool {
-        unsafe {
-            LLVMIsNull(self.value) == 1
-        }
+        unsafe { LLVMIsNull(self.value) == 1 }
     }
 
     fn is_const(self) -> bool {
-        unsafe {
-            LLVMIsConstant(self.value) == 1
-        }
+        unsafe { LLVMIsConstant(self.value) == 1 }
     }
 
     // TODOC: According to https://stackoverflow.com/questions/21593752/llvm-how-to-pass-a-name-to-constantint
@@ -101,11 +103,18 @@ impl<'ctx> Value<'ctx> {
     // add a ParamValue wrapper type that always have it but conditional types (IntValue<Variable>)
     // that also have it. This isn't a huge deal though, since it hasn't proven to be UB so far
     fn set_name(self, name: &str) {
-        #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0"))]
+        #[cfg(any(
+            feature = "llvm3-6",
+            feature = "llvm3-7",
+            feature = "llvm3-8",
+            feature = "llvm3-9",
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0"
+        ))]
         {
-            use llvm_sys::core::LLVMSetValueName;
             use crate::support::to_c_str;
+            use llvm_sys::core::LLVMSetValueName;
 
             let c_string = to_c_str(name);
 
@@ -113,13 +122,24 @@ impl<'ctx> Value<'ctx> {
                 LLVMSetValueName(self.value, c_string.as_ptr());
             }
         }
-        #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                      feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+        #[cfg(not(any(
+            feature = "llvm3-6",
+            feature = "llvm3-7",
+            feature = "llvm3-8",
+            feature = "llvm3-9",
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0"
+        )))]
         {
             use llvm_sys::core::LLVMSetValueName2;
 
             unsafe {
-                LLVMSetValueName2(self.value, name.as_ptr() as *const ::libc::c_char, name.len())
+                LLVMSetValueName2(
+                    self.value,
+                    name.as_ptr() as *const ::libc::c_char,
+                    name.len(),
+                )
             }
         }
     }
@@ -127,15 +147,29 @@ impl<'ctx> Value<'ctx> {
     // get_name should *not* return a LLVMString, because it is not an owned value AFAICT
     // TODO: Should make this take ownership of self. But what is the lifetime of the string? 'ctx?
     fn get_name(&self) -> &CStr {
-        #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0"))]
+        #[cfg(any(
+            feature = "llvm3-6",
+            feature = "llvm3-7",
+            feature = "llvm3-8",
+            feature = "llvm3-9",
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0"
+        ))]
         let ptr = unsafe {
             use llvm_sys::core::LLVMGetValueName;
 
             LLVMGetValueName(self.value)
         };
-        #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                      feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+        #[cfg(not(any(
+            feature = "llvm3-6",
+            feature = "llvm3-7",
+            feature = "llvm3-8",
+            feature = "llvm3-9",
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0"
+        )))]
         let ptr = unsafe {
             use llvm_sys::core::LLVMGetValueName2;
             let mut len = 0;
@@ -143,33 +177,23 @@ impl<'ctx> Value<'ctx> {
             LLVMGetValueName2(self.value, &mut len)
         };
 
-        unsafe {
-            CStr::from_ptr(ptr)
-        }
+        unsafe { CStr::from_ptr(ptr) }
     }
 
     fn is_undef(self) -> bool {
-        unsafe {
-            LLVMIsUndef(self.value) == 1
-        }
+        unsafe { LLVMIsUndef(self.value) == 1 }
     }
 
     fn get_type(self) -> LLVMTypeRef {
-        unsafe {
-            LLVMTypeOf(self.value)
-        }
+        unsafe { LLVMTypeOf(self.value) }
     }
 
     fn print_to_string(self) -> LLVMString {
-        unsafe {
-            LLVMString::new(LLVMPrintValueToString(self.value))
-        }
+        unsafe { LLVMString::new(LLVMPrintValueToString(self.value)) }
     }
 
     fn print_to_stderr(self) {
-        unsafe {
-            LLVMDumpValue(self.value)
-        }
+        unsafe { LLVMDumpValue(self.value) }
     }
 
     // REVIEW: I think this is memory safe, though it may result in an IR error
@@ -177,33 +201,25 @@ impl<'ctx> Value<'ctx> {
     fn replace_all_uses_with(self, other: LLVMValueRef) {
         // LLVM may infinite-loop when they aren't distinct, which is UB in C++.
         if self.value != other {
-            unsafe {
-                LLVMReplaceAllUsesWith(self.value, other)
-            }
+            unsafe { LLVMReplaceAllUsesWith(self.value, other) }
         }
     }
 
     pub fn get_first_use(self) -> Option<BasicValueUse<'ctx>> {
-        let use_ = unsafe {
-            LLVMGetFirstUse(self.value)
-        };
+        let use_ = unsafe { LLVMGetFirstUse(self.value) };
 
         if use_.is_null() {
             return None;
         }
 
-        unsafe {
-            Some(BasicValueUse::new(use_))
-        }
+        unsafe { Some(BasicValueUse::new(use_)) }
     }
 }
 
 impl fmt::Debug for Value<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let llvm_value = self.print_to_string();
-        let llvm_type = unsafe {
-            CStr::from_ptr(LLVMPrintTypeToString(LLVMTypeOf(self.value)))
-        };
+        let llvm_type = unsafe { CStr::from_ptr(LLVMPrintTypeToString(LLVMTypeOf(self.value))) };
         let name = self.get_name();
         let is_const = self.is_const();
         let is_null = self.is_null();

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -1,4 +1,6 @@
-use llvm_sys::core::{LLVMAddIncoming, LLVMCountIncoming, LLVMGetIncomingBlock, LLVMGetIncomingValue};
+use llvm_sys::core::{
+    LLVMAddIncoming, LLVMCountIncoming, LLVMGetIncomingBlock, LLVMGetIncomingValue,
+};
 use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
 
 use std::ffi::CStr;
@@ -26,20 +28,24 @@ impl<'ctx> PhiValue<'ctx> {
 
     pub fn add_incoming(self, incoming: &[(&dyn BasicValue<'ctx>, BasicBlock<'ctx>)]) {
         let (mut values, mut basic_blocks): (Vec<LLVMValueRef>, Vec<LLVMBasicBlockRef>) = {
-            incoming.iter()
-                    .map(|&(v, bb)| (v.as_value_ref(), bb.basic_block))
-                    .unzip()
+            incoming
+                .iter()
+                .map(|&(v, bb)| (v.as_value_ref(), bb.basic_block))
+                .unzip()
         };
 
         unsafe {
-            LLVMAddIncoming(self.as_value_ref(), values.as_mut_ptr(), basic_blocks.as_mut_ptr(), incoming.len() as u32);
+            LLVMAddIncoming(
+                self.as_value_ref(),
+                values.as_mut_ptr(),
+                basic_blocks.as_mut_ptr(),
+                incoming.len() as u32,
+            );
         }
     }
 
     pub fn count_incoming(self) -> u32 {
-        unsafe {
-            LLVMCountIncoming(self.as_value_ref())
-        }
+        unsafe { LLVMCountIncoming(self.as_value_ref()) }
     }
 
     pub fn get_incoming(self, index: u32) -> Option<(BasicValueEnum<'ctx>, BasicBlock<'ctx>)> {
@@ -48,11 +54,11 @@ impl<'ctx> PhiValue<'ctx> {
         }
 
         let basic_block = unsafe {
-            BasicBlock::new(LLVMGetIncomingBlock(self.as_value_ref(), index)).expect("Invalid BasicBlock")
+            BasicBlock::new(LLVMGetIncomingBlock(self.as_value_ref(), index))
+                .expect("Invalid BasicBlock")
         };
-        let value = unsafe {
-            BasicValueEnum::new(LLVMGetIncomingValue(self.as_value_ref(), index))
-        };
+        let value =
+            unsafe { BasicValueEnum::new(LLVMGetIncomingValue(self.as_value_ref(), index)) };
 
         Some((value, basic_block))
     }
@@ -78,7 +84,9 @@ impl<'ctx> PhiValue<'ctx> {
 
     // SubType: -> InstructionValue<Phi>
     pub fn as_instruction(self) -> InstructionValue<'ctx> {
-        self.phi_value.as_instruction().expect("PhiValue should always be a Phi InstructionValue")
+        self.phi_value
+            .as_instruction()
+            .expect("PhiValue should always be a Phi InstructionValue")
     }
 
     pub fn replace_all_uses_with(self, other: &PhiValue<'ctx>) {
@@ -86,9 +94,7 @@ impl<'ctx> PhiValue<'ctx> {
     }
 
     pub fn as_basic_value(self) -> BasicValueEnum<'ctx> {
-        unsafe {
-            BasicValueEnum::new(self.as_value_ref())
-        }
+        unsafe { BasicValueEnum::new(self.as_value_ref()) }
     }
 }
 

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -1,4 +1,7 @@
-use llvm_sys::core::{LLVMConstGEP, LLVMConstInBoundsGEP, LLVMConstPtrToInt, LLVMConstPointerCast, LLVMConstAddrSpaceCast};
+use llvm_sys::core::{
+    LLVMConstAddrSpaceCast, LLVMConstGEP, LLVMConstInBoundsGEP, LLVMConstPointerCast,
+    LLVMConstPtrToInt,
+};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
@@ -27,9 +30,7 @@ impl<'ctx> PointerValue<'ctx> {
     }
 
     pub fn get_type(self) -> PointerType<'ctx> {
-        unsafe {
-            PointerType::new(self.ptr_value.get_type())
-        }
+        unsafe { PointerType::new(self.ptr_value.get_type()) }
     }
 
     pub fn is_null(self) -> bool {
@@ -66,23 +67,36 @@ impl<'ctx> PointerValue<'ctx> {
     // REVIEW: Should this be on array value too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
     pub unsafe fn const_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
-                                                                 .map(|val| val.as_value_ref())
-                                                                 .collect();
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
+            .iter()
+            .map(|val| val.as_value_ref())
+            .collect();
         let value = {
-            LLVMConstGEP(self.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32)
+            LLVMConstGEP(
+                self.as_value_ref(),
+                index_values.as_mut_ptr(),
+                index_values.len() as u32,
+            )
         };
 
         PointerValue::new(value)
     }
 
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
-    pub unsafe fn const_in_bounds_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
-        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter()
-                                                                 .map(|val| val.as_value_ref())
-                                                                 .collect();
+    pub unsafe fn const_in_bounds_gep(
+        self,
+        ordered_indexes: &[IntValue<'ctx>],
+    ) -> PointerValue<'ctx> {
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes
+            .iter()
+            .map(|val| val.as_value_ref())
+            .collect();
         let value = {
-            LLVMConstInBoundsGEP(self.as_value_ref(), index_values.as_mut_ptr(), index_values.len() as u32)
+            LLVMConstInBoundsGEP(
+                self.as_value_ref(),
+                index_values.as_mut_ptr(),
+                index_values.len() as u32,
+            )
         };
 
         PointerValue::new(value)
@@ -90,19 +104,28 @@ impl<'ctx> PointerValue<'ctx> {
 
     pub fn const_to_int(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe {
-            IntValue::new(LLVMConstPtrToInt(self.as_value_ref(), int_type.as_type_ref()))
+            IntValue::new(LLVMConstPtrToInt(
+                self.as_value_ref(),
+                int_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_cast(self, ptr_type: PointerType<'ctx>) -> PointerValue<'ctx> {
         unsafe {
-            PointerValue::new(LLVMConstPointerCast(self.as_value_ref(), ptr_type.as_type_ref()))
+            PointerValue::new(LLVMConstPointerCast(
+                self.as_value_ref(),
+                ptr_type.as_type_ref(),
+            ))
         }
     }
 
     pub fn const_address_space_cast(self, ptr_type: PointerType<'ctx>) -> PointerValue<'ctx> {
         unsafe {
-            PointerValue::new(LLVMConstAddrSpaceCast(self.as_value_ref(), ptr_type.as_type_ref()))
+            PointerValue::new(LLVMConstAddrSpaceCast(
+                self.as_value_ref(),
+                ptr_type.as_type_ref(),
+            ))
         }
     }
 

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -27,9 +27,7 @@ impl<'ctx> StructValue<'ctx> {
     }
 
     pub fn get_type(self) -> StructType<'ctx> {
-        unsafe {
-            StructType::new(self.struct_value.get_type())
-        }
+        unsafe { StructType::new(self.struct_value.get_type()) }
     }
 
     pub fn is_null(self) -> bool {
@@ -49,7 +47,8 @@ impl<'ctx> StructValue<'ctx> {
     }
 
     pub fn replace_all_uses_with(self, other: StructValue<'ctx>) {
-        self.struct_value.replace_all_uses_with(other.as_value_ref())
+        self.struct_value
+            .replace_all_uses_with(other.as_value_ref())
     }
 }
 

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -1,11 +1,17 @@
-use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::core::{LLVMConstExtractValue, LLVMConstInsertValue};
+use llvm_sys::prelude::LLVMValueRef;
 
 use std::fmt::Debug;
 
-use crate::values::{ArrayValue, AggregateValueEnum, BasicValueUse, CallSiteValue, GlobalValue, StructValue, BasicValueEnum, AnyValueEnum, IntValue, FloatValue, PointerValue, PhiValue, VectorValue, FunctionValue, InstructionValue, Value};
-use crate::types::{IntMathType, FloatMathType, PointerMathType, IntType, FloatType, PointerType, VectorType};
 use crate::support::LLVMString;
+use crate::types::{
+    FloatMathType, FloatType, IntMathType, IntType, PointerMathType, PointerType, VectorType,
+};
+use crate::values::{
+    AggregateValueEnum, AnyValueEnum, ArrayValue, BasicValueEnum, BasicValueUse, CallSiteValue,
+    FloatValue, FunctionValue, GlobalValue, InstructionValue, IntValue, PhiValue, PointerValue,
+    StructValue, Value, VectorValue,
+};
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
@@ -44,9 +50,7 @@ macro_rules! math_trait_value_set {
 pub trait AggregateValue<'ctx>: BasicValue<'ctx> {
     /// Returns an enum containing a typed version of the `AggregateValue`.
     fn as_aggregate_value_enum(&self) -> AggregateValueEnum<'ctx> {
-        unsafe {
-            AggregateValueEnum::new(self.as_value_ref())
-        }
+        unsafe { AggregateValueEnum::new(self.as_value_ref()) }
     }
 
     // REVIEW: How does LLVM treat out of bound index? Maybe we should return an Option?
@@ -54,14 +58,27 @@ pub trait AggregateValue<'ctx>: BasicValue<'ctx> {
     // REVIEW: Should this be AggregatePointerValue?
     fn const_extract_value(&self, indexes: &mut [u32]) -> BasicValueEnum<'ctx> {
         unsafe {
-            BasicValueEnum::new(LLVMConstExtractValue(self.as_value_ref(), indexes.as_mut_ptr(), indexes.len() as u32))
+            BasicValueEnum::new(LLVMConstExtractValue(
+                self.as_value_ref(),
+                indexes.as_mut_ptr(),
+                indexes.len() as u32,
+            ))
         }
     }
 
     // SubTypes: value should really be T in self: VectorValue<T> I think
-    fn const_insert_value<BV: BasicValue<'ctx>>(&self, value: BV, indexes: &mut [u32]) -> BasicValueEnum<'ctx> {
+    fn const_insert_value<BV: BasicValue<'ctx>>(
+        &self,
+        value: BV,
+        indexes: &mut [u32],
+    ) -> BasicValueEnum<'ctx> {
         unsafe {
-            BasicValueEnum::new(LLVMConstInsertValue(self.as_value_ref(), value.as_value_ref(), indexes.as_mut_ptr(), indexes.len() as u32))
+            BasicValueEnum::new(LLVMConstInsertValue(
+                self.as_value_ref(),
+                value.as_value_ref(),
+                indexes.as_mut_ptr(),
+                indexes.len() as u32,
+            ))
         }
     }
 }
@@ -70,9 +87,7 @@ pub trait AggregateValue<'ctx>: BasicValue<'ctx> {
 pub trait BasicValue<'ctx>: AnyValue<'ctx> {
     /// Returns an enum containing a typed version of the `BasicValue`.
     fn as_basic_value_enum(&self) -> BasicValueEnum<'ctx> {
-        unsafe {
-            BasicValueEnum::new(self.as_value_ref())
-        }
+        unsafe { BasicValueEnum::new(self.as_value_ref()) }
     }
 
     /// Most `BasicValue`s are the byproduct of an instruction
@@ -84,22 +99,16 @@ pub trait BasicValue<'ctx>: AnyValue<'ctx> {
             return None;
         }
 
-        unsafe {
-            Some(InstructionValue::new(self.as_value_ref()))
-        }
+        unsafe { Some(InstructionValue::new(self.as_value_ref())) }
     }
 
     fn get_first_use(&self) -> Option<BasicValueUse> {
-        unsafe {
-            Value::new(self.as_value_ref()).get_first_use()
-        }
+        unsafe { Value::new(self.as_value_ref()).get_first_use() }
     }
 
     /// Sets the name of a `BasicValue`. If the value is a constant, this is a noop.
     fn set_name(&self, name: &str) {
-        unsafe {
-            Value::new(self.as_value_ref()).set_name(name)
-        }
+        unsafe { Value::new(self.as_value_ref()).set_name(name) }
     }
 
     // REVIEW: Possible encompassing methods to implement:
@@ -128,16 +137,12 @@ pub trait PointerMathValue<'ctx>: BasicValue<'ctx> {
 pub trait AnyValue<'ctx>: AsValueRef + Debug {
     /// Returns an enum containing a typed version of `AnyValue`.
     fn as_any_value_enum(&self) -> AnyValueEnum<'ctx> {
-        unsafe {
-            AnyValueEnum::new(self.as_value_ref())
-        }
+        unsafe { AnyValueEnum::new(self.as_value_ref()) }
     }
 
     /// Prints a value to a `LLVMString`
     fn print_to_string(&self) -> LLVMString {
-        unsafe {
-            Value::new(self.as_value_ref()).print_to_string()
-        }
+        unsafe { Value::new(self.as_value_ref()).print_to_string() }
     }
 }
 

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -36,7 +36,10 @@ fn test_string_attributes() {
     assert!(!string_attribute.is_enum());
     assert!(string_attribute.is_string());
 
-    assert_eq!(string_attribute.get_string_kind_id().to_str(), Ok("my_key_123"));
+    assert_eq!(
+        string_attribute.get_string_kind_id().to_str(),
+        Ok("my_key_123")
+    );
     assert_eq!(string_attribute.get_string_value().to_str(), Ok("my_val"));
 }
 
@@ -69,8 +72,14 @@ fn test_attributes_on_function_values() {
     fn_value.add_attribute(AttributeLoc::Return, enum_attribute);
 
     assert_eq!(fn_value.count_attributes(AttributeLoc::Return), 2);
-    assert_eq!(fn_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute), Some(enum_attribute));
-    assert_eq!(fn_value.get_string_attribute(AttributeLoc::Return, "my_key"), Some(string_attribute));
+    assert_eq!(
+        fn_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute),
+        Some(enum_attribute)
+    );
+    assert_eq!(
+        fn_value.get_string_attribute(AttributeLoc::Return, "my_key"),
+        Some(string_attribute)
+    );
 
     fn_value.remove_string_attribute(AttributeLoc::Return, "my_key");
 
@@ -80,8 +89,12 @@ fn test_attributes_on_function_values() {
 
     assert_eq!(fn_value.count_attributes(AttributeLoc::Function), 0);
     assert_eq!(fn_value.count_attributes(AttributeLoc::Return), 0);
-    assert!(fn_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute).is_none());
-    assert!(fn_value.get_string_attribute(AttributeLoc::Return, "my_key").is_none());
+    assert!(fn_value
+        .get_enum_attribute(AttributeLoc::Return, alignstack_attribute)
+        .is_none());
+    assert!(fn_value
+        .get_string_attribute(AttributeLoc::Return, "my_key")
+        .is_none());
 }
 
 #[test]
@@ -101,7 +114,8 @@ fn test_attributes_on_call_site_values() {
 
     builder.position_at_end(entry_bb);
 
-    let call_site_value = builder.build_call(fn_value, &[i32_type.const_int(1, false).into()], "my_fn");
+    let call_site_value =
+        builder.build_call(fn_value, &[i32_type.const_int(1, false).into()], "my_fn");
 
     builder.build_return(None);
 
@@ -118,8 +132,14 @@ fn test_attributes_on_call_site_values() {
     call_site_value.add_attribute(AttributeLoc::Return, enum_attribute);
 
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 2);
-    assert_eq!(call_site_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute), Some(enum_attribute));
-    assert_eq!(call_site_value.get_string_attribute(AttributeLoc::Return, "my_key"), Some(string_attribute));
+    assert_eq!(
+        call_site_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute),
+        Some(enum_attribute)
+    );
+    assert_eq!(
+        call_site_value.get_string_attribute(AttributeLoc::Return, "my_key"),
+        Some(string_attribute)
+    );
 
     call_site_value.remove_string_attribute(AttributeLoc::Return, "my_key");
 
@@ -128,12 +148,18 @@ fn test_attributes_on_call_site_values() {
     call_site_value.remove_enum_attribute(AttributeLoc::Return, alignstack_attribute);
 
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 0);
-    assert!(call_site_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute).is_none());
-    assert!(call_site_value.get_string_attribute(AttributeLoc::Return, "my_key").is_none());
+    assert!(call_site_value
+        .get_enum_attribute(AttributeLoc::Return, alignstack_attribute)
+        .is_none());
+    assert!(call_site_value
+        .get_string_attribute(AttributeLoc::Return, "my_key")
+        .is_none());
     assert_eq!(call_site_value.get_called_fn_value(), fn_value);
 
     call_site_value.set_alignment_attribute(AttributeLoc::Return, 16);
 
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 1);
-    assert!(call_site_value.get_enum_attribute(AttributeLoc::Return, align_attribute).is_some());
+    assert!(call_site_value
+        .get_enum_attribute(AttributeLoc::Return, align_attribute)
+        .is_some());
 }

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -91,15 +91,23 @@ fn test_get_basic_blocks() {
     let function = module.add_function("testing", fn_type, None);
 
     assert_eq!(function.get_name().to_str(), Ok("testing"));
-    assert_eq!(fn_type.get_return_type().unwrap().into_int_type().get_bit_width(), 1);
+    assert_eq!(
+        fn_type
+            .get_return_type()
+            .unwrap()
+            .into_int_type()
+            .get_bit_width(),
+        1
+    );
 
     assert!(function.get_last_basic_block().is_none());
     assert_eq!(function.get_basic_blocks().len(), 0);
 
     let basic_block = context.append_basic_block(function, "entry");
 
-    let last_basic_block = function.get_last_basic_block()
-                                   .expect("Did not find expected basic block");
+    let last_basic_block = function
+        .get_last_basic_block()
+        .expect("Did not find expected basic block");
 
     assert_eq!(last_basic_block, basic_block);
 
@@ -130,10 +138,22 @@ fn test_get_terminator() {
 
     builder.build_return(None);
 
-    assert_eq!(basic_block.get_terminator().unwrap().get_opcode(), InstructionOpcode::Return);
-    assert_eq!(basic_block.get_first_instruction().unwrap().get_opcode(), InstructionOpcode::Return);
-    assert_eq!(basic_block.get_last_instruction().unwrap().get_opcode(), InstructionOpcode::Return);
-    assert_eq!(basic_block.get_last_instruction(), basic_block.get_terminator());
+    assert_eq!(
+        basic_block.get_terminator().unwrap().get_opcode(),
+        InstructionOpcode::Return
+    );
+    assert_eq!(
+        basic_block.get_first_instruction().unwrap().get_opcode(),
+        InstructionOpcode::Return
+    );
+    assert_eq!(
+        basic_block.get_last_instruction().unwrap().get_opcode(),
+        InstructionOpcode::Return
+    );
+    assert_eq!(
+        basic_block.get_last_instruction(),
+        basic_block.get_terminator()
+    );
 }
 
 #[test]
@@ -176,7 +196,7 @@ fn test_rauw() {
     builder.position_at_end(entry);
     let branch_inst = builder.build_unconditional_branch(bb1);
 
-    bb1.replace_all_uses_with(&bb1);  // no-op
+    bb1.replace_all_uses_with(&bb1); // no-op
     bb1.replace_all_uses_with(&bb2);
 
     assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -1,10 +1,10 @@
-use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, OptimizationLevel};
 use inkwell::context::Context;
 use inkwell::values::BasicValue;
 use inkwell::values::CallableValue;
+use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, OptimizationLevel};
 
-use std::ptr::null;
 use std::convert::TryFrom;
+use std::ptr::null;
 
 #[test]
 fn test_build_call() {
@@ -192,7 +192,13 @@ fn test_build_invoke_catch_all() {
         let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
 
         let null = i8_ptr_type.const_zero();
-        let res = builder.build_landing_pad(exception_type, personality_function, &[null.into()], false, "res");
+        let res = builder.build_landing_pad(
+            exception_type,
+            personality_function,
+            &[null.into()],
+            false,
+            "res",
+        );
 
         let fakepi = f32_type.const_zero();
 
@@ -203,7 +209,7 @@ fn test_build_invoke_catch_all() {
 }
 
 #[test]
-fn landing_pad_filter() { 
+fn landing_pad_filter() {
     use inkwell::module::Linkage;
     use inkwell::values::AnyValue;
 
@@ -267,8 +273,15 @@ fn landing_pad_filter() {
         type_info_int.set_linkage(Linkage::External);
 
         // make the filter landing pad
-        let filter_pattern = i8_ptr_type.const_array(&[type_info_int.as_any_value_enum().into_pointer_value()]);
-        let res = builder.build_landing_pad(exception_type, personality_function, &[filter_pattern.into()], false, "res");
+        let filter_pattern =
+            i8_ptr_type.const_array(&[type_info_int.as_any_value_enum().into_pointer_value()]);
+        let res = builder.build_landing_pad(
+            exception_type,
+            personality_function,
+            &[filter_pattern.into()],
+            false,
+            "res",
+        );
 
         let fakepi = f32_type.const_zero();
 
@@ -366,17 +379,23 @@ fn test_null_checked_ptr_ops() {
 
     builder.build_return(Some(&index1));
 
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     unsafe {
-        let check_null_index1 = execution_engine.get_function::<unsafe extern "C" fn(*const i8) -> i8>("check_null_index1").unwrap();
+        let check_null_index1 = execution_engine
+            .get_function::<unsafe extern "C" fn(*const i8) -> i8>("check_null_index1")
+            .unwrap();
 
         let array = &[100i8, 42i8];
 
         assert_eq!(check_null_index1.call(null()), -1i8);
         assert_eq!(check_null_index1.call(array.as_ptr()), 42i8);
 
-        let check_null_index2 = execution_engine.get_function::<unsafe extern "C" fn(*const i8) -> i8>("check_null_index2").unwrap();
+        let check_null_index2 = execution_engine
+            .get_function::<unsafe extern "C" fn(*const i8) -> i8>("check_null_index2")
+            .unwrap();
 
         assert_eq!(check_null_index2.call(null()), -1i8);
         assert_eq!(check_null_index2.call(array.as_ptr()), 42i8);
@@ -388,7 +407,9 @@ fn test_binary_ops() {
     let context = Context::create();
     let module = context.create_module("unsafe");
     let builder = context.create_builder();
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     // Here we're going to create an and function which looks roughly like:
     // fn and(left: bool, right: bool) -> bool {
@@ -472,7 +493,9 @@ fn test_switch() {
     let context = Context::create();
     let module = context.create_module("unsafe");
     let builder = context.create_builder();
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     // Here we're going to create a function which looks roughly like:
     // fn switch(val: u8) -> u8 {
@@ -515,7 +538,9 @@ fn test_switch() {
     builder.build_return(Some(&double));
 
     unsafe {
-        let switch = execution_engine.get_function::<unsafe extern "C" fn(u8) -> u8>("switch").unwrap();
+        let switch = execution_engine
+            .get_function::<unsafe extern "C" fn(u8) -> u8>("switch")
+            .unwrap();
 
         assert_eq!(switch.call(0), 1);
         assert_eq!(switch.call(1), 2);
@@ -530,7 +555,9 @@ fn test_bit_shifts() {
     let context = Context::create();
     let module = context.create_module("unsafe");
     let builder = context.create_builder();
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     // Here we're going to create a function which looks roughly like:
     // fn left_shift(value: u8, bits: u8) -> u8 {
@@ -583,9 +610,15 @@ fn test_bit_shifts() {
     builder.build_return(Some(&shift));
 
     unsafe {
-        let left_shift = execution_engine.get_function::<unsafe extern "C" fn(u8, u8) -> u8>("left_shift").unwrap();
-        let right_shift  = execution_engine.get_function::<unsafe extern "C" fn(u8, u8) -> u8>("right_shift").unwrap();
-        let right_shift_sign_extend = execution_engine.get_function::<unsafe extern "C" fn(i8, u8) -> i8>("right_shift_sign_extend").unwrap();
+        let left_shift = execution_engine
+            .get_function::<unsafe extern "C" fn(u8, u8) -> u8>("left_shift")
+            .unwrap();
+        let right_shift = execution_engine
+            .get_function::<unsafe extern "C" fn(u8, u8) -> u8>("right_shift")
+            .unwrap();
+        let right_shift_sign_extend = execution_engine
+            .get_function::<unsafe extern "C" fn(i8, u8) -> i8>("right_shift_sign_extend")
+            .unwrap();
 
         assert_eq!(left_shift.call(0, 0), 0);
         assert_eq!(left_shift.call(0, 4), 0);
@@ -725,7 +758,8 @@ fn test_vector_convert_ops() {
     builder.position_at_end(entry);
     let in_vec = fn_value.get_first_param().unwrap().into_vector_value();
     let casted_vec = builder.build_float_to_signed_int(in_vec, int32_vec_type, "casted_vec");
-    let _uncasted_vec = builder.build_signed_int_to_float(casted_vec, float32_vec_type, "uncasted_vec");
+    let _uncasted_vec =
+        builder.build_signed_int_to_float(casted_vec, float32_vec_type, "uncasted_vec");
     builder.build_return(Some(&casted_vec));
     assert!(fn_value.verify(true));
 }
@@ -739,7 +773,14 @@ fn test_vector_binary_ops() {
     let bool_vec_type = context.bool_type().vec_type(2);
 
     // Here we're building a function that takes in three <2 x i32>s and returns them added together as a <2 x i32>
-    let fn_type = int32_vec_type.fn_type(&[int32_vec_type.into(), int32_vec_type.into(), int32_vec_type.into()], false);
+    let fn_type = int32_vec_type.fn_type(
+        &[
+            int32_vec_type.into(),
+            int32_vec_type.into(),
+            int32_vec_type.into(),
+        ],
+        false,
+    );
     let fn_value = module.add_function("test_int_vec_add", fn_type, None);
     let entry = context.append_basic_block(fn_value, "entry");
     let builder = context.create_builder();
@@ -755,7 +796,14 @@ fn test_vector_binary_ops() {
 
     // Here we're building a function that takes in three <2 x f32>s and returns x * y / z as an
     // <2 x f32>
-    let fn_type = float32_vec_type.fn_type(&[float32_vec_type.into(), float32_vec_type.into(), float32_vec_type.into()], false);
+    let fn_type = float32_vec_type.fn_type(
+        &[
+            float32_vec_type.into(),
+            float32_vec_type.into(),
+            float32_vec_type.into(),
+        ],
+        false,
+    );
     let fn_value = module.add_function("test_float_vec_mul", fn_type, None);
     let entry = context.append_basic_block(fn_value, "entry");
     let builder = context.create_builder();
@@ -771,7 +819,14 @@ fn test_vector_binary_ops() {
 
     // Here we're building a function that takes two <2 x f32>s and a <2 x bool> and returns (x < y) * z
     // as a <2 x bool>
-    let fn_type = bool_vec_type.fn_type(&[float32_vec_type.into(), float32_vec_type.into(), bool_vec_type.into()], false);
+    let fn_type = bool_vec_type.fn_type(
+        &[
+            float32_vec_type.into(),
+            float32_vec_type.into(),
+            bool_vec_type.into(),
+        ],
+        false,
+    );
     let fn_value = module.add_function("test_float_vec_compare", fn_type, None);
     let entry = context.append_basic_block(fn_value, "entry");
     let builder = context.create_builder();
@@ -780,7 +835,8 @@ fn test_vector_binary_ops() {
     let p1_vec = fn_value.get_first_param().unwrap().into_vector_value();
     let p2_vec = fn_value.get_nth_param(1).unwrap().into_vector_value();
     let p3_vec = fn_value.get_nth_param(2).unwrap().into_vector_value();
-    let compared_vec = builder.build_float_compare(inkwell::FloatPredicate::OLT, p1_vec, p2_vec, "compared_vec");
+    let compared_vec =
+        builder.build_float_compare(inkwell::FloatPredicate::OLT, p1_vec, p2_vec, "compared_vec");
     let multiplied_vec = builder.build_int_mul(compared_vec, p3_vec, "multiplied_vec");
     builder.build_return(Some(&multiplied_vec));
     assert!(fn_value.verify(true));
@@ -791,7 +847,10 @@ fn test_vector_pointer_ops() {
     let context = Context::create();
     let module = context.create_module("test");
     let int32_vec_type = context.i32_type().vec_type(4);
-    let i8_ptr_vec_type = context.i8_type().ptr_type(AddressSpace::Generic).vec_type(4);
+    let i8_ptr_vec_type = context
+        .i8_type()
+        .ptr_type(AddressSpace::Generic)
+        .vec_type(4);
     let bool_vec_type = context.bool_type().vec_type(4);
 
     // Here we're building a function that takes a <4 x i32>, converts it to a <4 x i8*> and returns a
@@ -826,35 +885,81 @@ fn test_insert_value() {
     builder.position_at_end(entry);
 
     let array_alloca = builder.build_alloca(array_type, "array_alloca");
-    let array = builder.build_load(array_alloca, "array_load").into_array_value();
+    let array = builder
+        .build_load(array_alloca, "array_load")
+        .into_array_value();
     let const_int1 = i32_type.const_int(2, false);
     let const_int2 = i32_type.const_int(5, false);
     let const_int3 = i32_type.const_int(6, false);
     let const_float = f32_type.const_float(3.14);
 
-    assert!(builder.build_insert_value(array, const_int1, 0, "insert").unwrap().is_array_value());
-    assert!(builder.build_insert_value(array, const_int2, 1, "insert").unwrap().is_array_value());
-    assert!(builder.build_insert_value(array, const_int3, 2, "insert").unwrap().is_array_value());
-    assert!(builder.build_insert_value(array, const_int3, 3, "insert").is_none());
-    assert!(builder.build_insert_value(array, const_int3, 4, "insert").is_none());
+    assert!(builder
+        .build_insert_value(array, const_int1, 0, "insert")
+        .unwrap()
+        .is_array_value());
+    assert!(builder
+        .build_insert_value(array, const_int2, 1, "insert")
+        .unwrap()
+        .is_array_value());
+    assert!(builder
+        .build_insert_value(array, const_int3, 2, "insert")
+        .unwrap()
+        .is_array_value());
+    assert!(builder
+        .build_insert_value(array, const_int3, 3, "insert")
+        .is_none());
+    assert!(builder
+        .build_insert_value(array, const_int3, 4, "insert")
+        .is_none());
 
-    assert!(builder.build_extract_value(array, 0, "extract").unwrap().is_int_value());
-    assert!(builder.build_extract_value(array, 1, "extract").unwrap().is_int_value());
-    assert!(builder.build_extract_value(array, 2, "extract").unwrap().is_int_value());
+    assert!(builder
+        .build_extract_value(array, 0, "extract")
+        .unwrap()
+        .is_int_value());
+    assert!(builder
+        .build_extract_value(array, 1, "extract")
+        .unwrap()
+        .is_int_value());
+    assert!(builder
+        .build_extract_value(array, 2, "extract")
+        .unwrap()
+        .is_int_value());
     assert!(builder.build_extract_value(array, 3, "extract").is_none());
 
     let struct_alloca = builder.build_alloca(struct_type, "struct_alloca");
-    let struct_value = builder.build_load(struct_alloca, "struct_load").into_struct_value();
+    let struct_value = builder
+        .build_load(struct_alloca, "struct_load")
+        .into_struct_value();
 
-    assert!(builder.build_insert_value(struct_value, const_int2, 0, "insert").unwrap().is_struct_value());
-    assert!(builder.build_insert_value(struct_value, const_float, 1, "insert").unwrap().is_struct_value());
-    assert!(builder.build_insert_value(struct_value, const_float, 2, "insert").is_none());
-    assert!(builder.build_insert_value(struct_value, const_float, 3, "insert").is_none());
+    assert!(builder
+        .build_insert_value(struct_value, const_int2, 0, "insert")
+        .unwrap()
+        .is_struct_value());
+    assert!(builder
+        .build_insert_value(struct_value, const_float, 1, "insert")
+        .unwrap()
+        .is_struct_value());
+    assert!(builder
+        .build_insert_value(struct_value, const_float, 2, "insert")
+        .is_none());
+    assert!(builder
+        .build_insert_value(struct_value, const_float, 3, "insert")
+        .is_none());
 
-    assert!(builder.build_extract_value(struct_value, 0, "extract").unwrap().is_int_value());
-    assert!(builder.build_extract_value(struct_value, 1, "extract").unwrap().is_float_value());
-    assert!(builder.build_extract_value(struct_value, 2, "extract").is_none());
-    assert!(builder.build_extract_value(struct_value, 3, "extract").is_none());
+    assert!(builder
+        .build_extract_value(struct_value, 0, "extract")
+        .unwrap()
+        .is_int_value());
+    assert!(builder
+        .build_extract_value(struct_value, 1, "extract")
+        .unwrap()
+        .is_float_value());
+    assert!(builder
+        .build_extract_value(struct_value, 2, "extract")
+        .is_none());
+    assert!(builder
+        .build_extract_value(struct_value, 3, "extract")
+        .is_none());
 
     builder.build_return(None);
 
@@ -877,7 +982,11 @@ fn test_alignment_bytes() {
         let result = run_memcpy_on(&context, &module, alignment);
 
         if is_alignment_ok(alignment) {
-            assert!(result.is_ok() && module.verify().is_ok(), "alignment of {} was a power of 2 under 2^64, but did not verify for memcpy.", alignment);
+            assert!(
+                result.is_ok() && module.verify().is_ok(),
+                "alignment of {} was a power of 2 under 2^64, but did not verify for memcpy.",
+                alignment
+            );
         } else {
             assert!(result.is_err(), "alignment of {} was a power of 2 under 2^64, yet verification passed for memcpy when it should not have.", alignment);
         }
@@ -885,7 +994,11 @@ fn test_alignment_bytes() {
         let result = run_memmove_on(&context, &module, alignment);
 
         if is_alignment_ok(alignment) {
-            assert!(result.is_ok() && module.verify().is_ok(), "alignment of {} was a power of 2 under 2^64, but did not verify for memmove.", alignment);
+            assert!(
+                result.is_ok() && module.verify().is_ok(),
+                "alignment of {} was a power of 2 under 2^64, but did not verify for memmove.",
+                alignment
+            );
         } else {
             assert!(result.is_err(), "alignment of {} was a power of 2 under 2^64, yet verification passed for memmove when it should not have.", alignment);
         }
@@ -899,7 +1012,11 @@ fn test_alignment_bytes() {
 }
 
 #[llvm_versions(8.0..=latest)]
-fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &inkwell::module::Module<'ctx>, alignment: u32) -> Result<(), &'static str> {
+fn run_memcpy_on<'ctx>(
+    context: &'ctx Context,
+    module: &inkwell::module::Module<'ctx>,
+    alignment: u32,
+) -> Result<(), &'static str> {
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;
@@ -911,7 +1028,9 @@ fn run_memcpy_on<'ctx>(context: &'ctx Context, module: &inkwell::module::Module<
     builder.position_at_end(entry);
 
     let len_value = i64_type.const_int(array_len as u64, false);
-    let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
+    let array_ptr = builder
+        .build_array_malloc(i32_type, len_value, "array_ptr")
+        .unwrap();
 
     // Initialize the array with the values [1, 2, 3, 4]
     for index in 0..4 {
@@ -952,10 +1071,14 @@ fn test_memcpy() {
         panic!("Errors defining module: {:?}", errors);
     }
 
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     unsafe {
-        let func = execution_engine.get_function::<unsafe extern "C" fn() -> *const i32>("test_fn").unwrap();
+        let func = execution_engine
+            .get_function::<unsafe extern "C" fn() -> *const i32>("test_fn")
+            .unwrap();
         let actual = std::slice::from_raw_parts(func.call(), 4);
 
         assert_eq!(&[1, 2, 1, 2], actual);
@@ -963,7 +1086,11 @@ fn test_memcpy() {
 }
 
 #[llvm_versions(8.0..=latest)]
-fn run_memmove_on<'ctx>(context: &'ctx Context, module: &inkwell::module::Module<'ctx>, alignment: u32) -> Result<(), &'static str> {
+fn run_memmove_on<'ctx>(
+    context: &'ctx Context,
+    module: &inkwell::module::Module<'ctx>,
+    alignment: u32,
+) -> Result<(), &'static str> {
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;
@@ -975,7 +1102,9 @@ fn run_memmove_on<'ctx>(context: &'ctx Context, module: &inkwell::module::Module
     builder.position_at_end(entry);
 
     let len_value = i64_type.const_int(array_len as u64, false);
-    let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
+    let array_ptr = builder
+        .build_array_malloc(i32_type, len_value, "array_ptr")
+        .unwrap();
 
     // Initialize the array with the values [1, 2, 3, 4]
     for index in 0..4 {
@@ -1016,10 +1145,14 @@ fn test_memmove() {
         panic!("Errors defining module: {:?}", errors);
     }
 
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     unsafe {
-        let func = execution_engine.get_function::<unsafe extern "C" fn() -> *const i32>("test_fn").unwrap();
+        let func = execution_engine
+            .get_function::<unsafe extern "C" fn() -> *const i32>("test_fn")
+            .unwrap();
         let actual = std::slice::from_raw_parts(func.call(), 4);
 
         assert_eq!(&[1, 2, 1, 2], actual);
@@ -1065,7 +1198,10 @@ fn test_bitcast() {
 
     builder.build_return(None);
 
-    assert!(module.verify().is_ok(), module.print_to_string().to_string());
+    assert!(
+        module.verify().is_ok(),
+        module.print_to_string().to_string()
+    );
 
     let first_iv = cast.as_instruction_value().unwrap();
 
@@ -1094,22 +1230,42 @@ fn test_atomicrmw() {
 
     let ptr_value = i32_type.ptr_type(AddressSpace::Generic).get_undef();
     let zero_value = i32_type.const_zero();
-    let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
+    let result = builder.build_atomicrmw(
+        AtomicRMWBinOp::Add,
+        ptr_value,
+        zero_value,
+        AtomicOrdering::Unordered,
+    );
     assert!(result.is_ok());
 
     let ptr_value = i64_type.ptr_type(AddressSpace::Generic).get_undef();
     let zero_value = i32_type.const_zero();
-    let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
+    let result = builder.build_atomicrmw(
+        AtomicRMWBinOp::Add,
+        ptr_value,
+        zero_value,
+        AtomicOrdering::Unordered,
+    );
     assert!(result.is_err());
 
     let ptr_value = i31_type.ptr_type(AddressSpace::Generic).get_undef();
     let zero_value = i31_type.const_zero();
-    let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
+    let result = builder.build_atomicrmw(
+        AtomicRMWBinOp::Add,
+        ptr_value,
+        zero_value,
+        AtomicOrdering::Unordered,
+    );
     assert!(result.is_err());
 
     let ptr_value = i4_type.ptr_type(AddressSpace::Generic).get_undef();
     let zero_value = i4_type.const_zero();
-    let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
+    let result = builder.build_atomicrmw(
+        AtomicRMWBinOp::Add,
+        ptr_value,
+        zero_value,
+        AtomicOrdering::Unordered,
+    );
     assert!(result.is_err());
 }
 
@@ -1134,67 +1290,133 @@ fn test_cmpxchg() {
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_ok());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Unordered, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Unordered,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Unordered);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Unordered,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Release);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Release,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::AcquireRelease);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::AcquireRelease,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::SequentiallyConsistent);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::SequentiallyConsistent,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i64_type.const_zero();
     let neg_one_value = i32_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
     let neg_one_value = i64_type.const_all_ones();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_err());
 
     let ptr_value = i32_ptr_ptr_type.get_undef();
     let zero_value = i32_ptr_type.const_zero();
     let neg_one_value = i32_ptr_type.const_zero();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_ok());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_ptr_type.const_zero();
     let neg_one_value = i32_ptr_type.const_zero();
-    let result = builder.build_cmpxchg(ptr_value, zero_value, neg_one_value, AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+    let result = builder.build_cmpxchg(
+        ptr_value,
+        zero_value,
+        neg_one_value,
+        AtomicOrdering::Monotonic,
+        AtomicOrdering::Monotonic,
+    );
     assert!(result.is_err());
 }
 
@@ -1220,7 +1442,13 @@ fn test_safe_struct_gep() {
 
     assert!(builder.build_struct_gep(i32_ptr, 0, "struct_gep").is_err());
     assert!(builder.build_struct_gep(i32_ptr, 10, "struct_gep").is_err());
-    assert!(builder.build_struct_gep(struct_ptr, 0, "struct_gep").is_ok());
-    assert!(builder.build_struct_gep(struct_ptr, 1, "struct_gep").is_ok());
-    assert!(builder.build_struct_gep(struct_ptr, 2, "struct_gep").is_err());
+    assert!(builder
+        .build_struct_gep(struct_ptr, 0, "struct_gep")
+        .is_ok());
+    assert!(builder
+        .build_struct_gep(struct_ptr, 1, "struct_gep")
+        .is_ok());
+    assert!(builder
+        .build_struct_gep(struct_ptr, 2, "struct_gep")
+        .is_err());
 }

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -1,5 +1,5 @@
-use inkwell::AddressSpace;
 use inkwell::context::Context;
+use inkwell::AddressSpace;
 
 #[test]
 fn test_no_context_double_free() {

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -348,7 +348,11 @@ fn test_global_expressions() {
     );
 
     let di_type = dibuilder.create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO);
-    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::Global), "gv");
+    let gv = module.add_global(
+        context.i64_type(),
+        Some(inkwell::AddressSpace::Global),
+        "gv",
+    );
 
     let const_v = dibuilder.create_constant_expression(10);
 
@@ -371,5 +375,11 @@ fn test_global_expressions() {
 
     // TODO: Metadata set on the global values cannot be retrieved using the C api,
     // therefore, it's currently not possible to test that the data was set without generating the IR
-    assert!(gv.print_to_string().to_string().contains("!dbg"), format!("expected !dbg but generated gv was {}",gv.print_to_string()));
+    assert!(
+        gv.print_to_string().to_string().contains("!dbg"),
+        format!(
+            "expected !dbg but generated gv was {}",
+            gv.print_to_string()
+        )
+    );
 }

--- a/tests/all/test_execution_engine.rs
+++ b/tests/all/test_execution_engine.rs
@@ -1,8 +1,8 @@
-use inkwell::{AddressSpace, OptimizationLevel, IntPredicate};
 use inkwell::context::Context;
 use inkwell::execution_engine::FunctionLookupError;
-use inkwell::values::BasicValue;
 use inkwell::targets::{InitializationConfig, Target};
+use inkwell::values::BasicValue;
+use inkwell::{AddressSpace, IntPredicate, OptimizationLevel};
 
 type Thunk = unsafe extern "C" fn();
 
@@ -19,13 +19,20 @@ fn test_get_function_address() {
     // assert_eq!(module.create_jit_execution_engine(OptimizationLevel::None), Err("Unable to find target for this triple (no targets are registered)".into()));
     let module = context.create_module("errors_abound");
 
-    Target::initialize_native(&InitializationConfig::default()).expect("Failed to initialize native target");
+    Target::initialize_native(&InitializationConfig::default())
+        .expect("Failed to initialize native target");
 
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     unsafe {
-        assert_eq!(execution_engine.get_function::<Thunk>("errors").unwrap_err(),
-            FunctionLookupError::FunctionNotFound);
+        assert_eq!(
+            execution_engine
+                .get_function::<Thunk>("errors")
+                .unwrap_err(),
+            FunctionLookupError::FunctionNotFound
+        );
     }
 
     let module = context.create_module("errors_abound");
@@ -35,11 +42,17 @@ fn test_get_function_address() {
     builder.position_at_end(basic_block);
     builder.build_return(None);
 
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     unsafe {
-        assert_eq!(execution_engine.get_function::<Thunk>("errors").unwrap_err(),
-            FunctionLookupError::FunctionNotFound);
+        assert_eq!(
+            execution_engine
+                .get_function::<Thunk>("errors")
+                .unwrap_err(),
+            FunctionLookupError::FunctionNotFound
+        );
 
         assert!(execution_engine.get_function::<Thunk>("func").is_ok());
     }
@@ -87,21 +100,22 @@ fn test_jit_execution_engine() {
     builder.position_at_end(check_arg3);
     builder.build_unconditional_branch(success);
 
-    Target::initialize_native(&InitializationConfig::default()).expect("Failed to initialize native target");
+    Target::initialize_native(&InitializationConfig::default())
+        .expect("Failed to initialize native target");
 
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).expect("Could not create Execution Engine");
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .expect("Could not create Execution Engine");
 
-    let main = execution_engine.get_function_value("main").expect("Could not find main in ExecutionEngine");
+    let main = execution_engine
+        .get_function_value("main")
+        .expect("Could not find main in ExecutionEngine");
 
-    let ret = unsafe {
-        execution_engine.run_function_as_main(main, &["input", "bar"])
-    };
+    let ret = unsafe { execution_engine.run_function_as_main(main, &["input", "bar"]) };
 
     assert_eq!(ret, 1, "unexpected main return code: {}", ret);
 
-    let ret = unsafe {
-        execution_engine.run_function_as_main(main, &["input", "bar", "baz"])
-    };
+    let ret = unsafe { execution_engine.run_function_as_main(main, &["input", "bar", "baz"]) };
 
     assert_eq!(ret, 42, "unexpected main return code: {}", ret);
 }
@@ -131,12 +145,13 @@ fn test_interpreter_execution_engine() {
     assert!(module.create_interpreter_execution_engine().is_ok());
 }
 
-
 #[test]
 fn test_add_remove_module() {
     let context = Context::create();
     let module = context.create_module("test");
-    let ee = module.create_jit_execution_engine(OptimizationLevel::default()).unwrap();
+    let ee = module
+        .create_jit_execution_engine(OptimizationLevel::default())
+        .unwrap();
 
     assert!(ee.add_module(&module).is_err());
 
@@ -156,7 +171,6 @@ fn test_add_remove_module() {
 //     Target::initialize_r600(&InitializationConfig::default());
 //     #[cfg(not(feature = "llvm3-6"))]
 //     Target::initialize_amd_gpu(&InitializationConfig::default());
-
 
 //     let context = Context::create();
 //     let module = context.create_module("test");

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -49,7 +49,14 @@ fn test_operands() {
     assert!(free_operand0.is_pointer_value()); // (implictly casted) i8* arg1
     assert!(free_operand1.is_pointer_value()); // Free function ptr
     assert_eq!(free_operand0_instruction.get_opcode(), BitCast);
-    assert_eq!(free_operand0_instruction.get_operand(0).unwrap().left().unwrap(), arg1);
+    assert_eq!(
+        free_operand0_instruction
+            .get_operand(0)
+            .unwrap()
+            .left()
+            .unwrap(),
+        arg1
+    );
     assert!(free_operand0_instruction.get_operand(1).is_none());
     assert!(free_operand0_instruction.get_operand(2).is_none());
     assert!(free_instruction.get_operand(2).is_none());
@@ -107,8 +114,14 @@ fn test_operands() {
     assert!(store_operand_use1.get_next_use().is_none());
     assert_eq!(store_operand_use1, arg1_second_use);
 
-    assert_eq!(store_operand_use0.get_user().into_instruction_value(), store_instruction);
-    assert_eq!(store_operand_use1.get_user().into_instruction_value(), store_instruction);
+    assert_eq!(
+        store_operand_use0.get_user().into_instruction_value(),
+        store_instruction
+    );
+    assert_eq!(
+        store_operand_use1.get_user().into_instruction_value(),
+        store_instruction
+    );
     assert_eq!(store_operand_use0.get_used_value().left().unwrap(), f32_val);
     assert_eq!(store_operand_use1.get_used_value().left().unwrap(), arg1);
 
@@ -152,7 +165,10 @@ fn test_basic_block_operand() {
 
     let bb_operand_use = branch_instruction.get_operand_use(0).unwrap();
 
-    assert_eq!(bb_operand_use.get_used_value().right().unwrap(), basic_block2);
+    assert_eq!(
+        bb_operand_use.get_used_value().right().unwrap(),
+        basic_block2
+    );
 
     builder.position_at_end(basic_block2);
     builder.build_return(None);
@@ -182,12 +198,19 @@ fn test_get_next_use() {
     // f32_val constant appears twice, so there are two uses (first, next)
     let first_use = f32_val.get_first_use().unwrap();
 
-    assert_eq!(first_use.get_user(), add_pi1.as_instruction_value().unwrap());
-    assert_eq!(first_use.get_next_use().map(|x| x.get_user().into_float_value()), Some(add_pi0));
+    assert_eq!(
+        first_use.get_user(),
+        add_pi1.as_instruction_value().unwrap()
+    );
+    assert_eq!(
+        first_use
+            .get_next_use()
+            .map(|x| x.get_user().into_float_value()),
+        Some(add_pi0)
+    );
     assert!(arg1.get_first_use().is_some());
     assert!(module.verify().is_ok());
 }
-
 
 #[test]
 fn test_instructions() {
@@ -228,19 +251,28 @@ fn test_instructions() {
     assert_eq!(ptr.as_instruction().unwrap().get_opcode(), IntToPtr);
     assert_eq!(icmp.as_instruction().unwrap().get_opcode(), ICmp);
     assert_eq!(ptr.as_instruction().unwrap().get_icmp_predicate(), None);
-    assert_eq!(icmp.as_instruction().unwrap().get_icmp_predicate().unwrap(), IntPredicate::EQ);
+    assert_eq!(
+        icmp.as_instruction().unwrap().get_icmp_predicate().unwrap(),
+        IntPredicate::EQ
+    );
     assert_eq!(f32_sum.as_instruction().unwrap().get_opcode(), FAdd);
     assert_eq!(fcmp.as_instruction().unwrap().get_opcode(), FCmp);
     assert_eq!(f32_sum.as_instruction().unwrap().get_fcmp_predicate(), None);
     assert_eq!(icmp.as_instruction().unwrap().get_fcmp_predicate(), None);
-    assert_eq!(fcmp.as_instruction().unwrap().get_fcmp_predicate().unwrap(), FloatPredicate::OEQ);
+    assert_eq!(
+        fcmp.as_instruction().unwrap().get_fcmp_predicate().unwrap(),
+        FloatPredicate::OEQ
+    );
     assert_eq!(free_instruction.get_opcode(), Call);
     assert_eq!(return_instruction.get_opcode(), Return);
 
     // test instruction cloning
     let instruction_clone = return_instruction.clone();
 
-    assert_eq!(instruction_clone.get_opcode(), return_instruction.get_opcode());
+    assert_eq!(
+        instruction_clone.get_opcode(),
+        return_instruction.get_opcode()
+    );
     assert_ne!(instruction_clone, return_instruction);
 
     // test copying
@@ -357,7 +389,10 @@ fn test_mem_instructions() {
     assert!(store_instruction.set_alignment(14).is_err());
     assert_eq!(store_instruction.get_alignment().unwrap(), 0);
 
-    let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    let fadd_instruction = builder
+        .build_float_add(load.into_float_value(), f32_val, "")
+        .as_instruction_value()
+        .unwrap();
     assert!(fadd_instruction.get_volatile().is_err());
     assert!(fadd_instruction.set_volatile(false).is_err());
     assert!(fadd_instruction.get_alignment().is_err());
@@ -418,7 +453,10 @@ fn test_mem_instructions() {
     assert!(store_instruction.set_alignment(14).is_err());
     assert_eq!(store_instruction.get_alignment().unwrap(), 4);
 
-    let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    let fadd_instruction = builder
+        .build_float_add(load.into_float_value(), f32_val, "")
+        .as_instruction_value()
+        .unwrap();
     assert!(fadd_instruction.get_volatile().is_err());
     assert!(fadd_instruction.set_volatile(false).is_err());
     assert!(fadd_instruction.get_alignment().is_err());
@@ -454,21 +492,49 @@ fn test_atomic_ordering_mem_instructions() {
     let load = builder.build_load(arg1, "");
     let load_instruction = load.as_instruction_value().unwrap();
 
-    assert_eq!(store_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::NotAtomic);
-    assert_eq!(load_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::NotAtomic);
-    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Monotonic).is_ok());
-    assert_eq!(store_instruction.get_atomic_ordering().unwrap(), AtomicOrdering::Monotonic);
-    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Release).is_ok());
-    assert!(load_instruction.set_atomic_ordering(AtomicOrdering::Acquire).is_ok());
+    assert_eq!(
+        store_instruction.get_atomic_ordering().unwrap(),
+        AtomicOrdering::NotAtomic
+    );
+    assert_eq!(
+        load_instruction.get_atomic_ordering().unwrap(),
+        AtomicOrdering::NotAtomic
+    );
+    assert!(store_instruction
+        .set_atomic_ordering(AtomicOrdering::Monotonic)
+        .is_ok());
+    assert_eq!(
+        store_instruction.get_atomic_ordering().unwrap(),
+        AtomicOrdering::Monotonic
+    );
+    assert!(store_instruction
+        .set_atomic_ordering(AtomicOrdering::Release)
+        .is_ok());
+    assert!(load_instruction
+        .set_atomic_ordering(AtomicOrdering::Acquire)
+        .is_ok());
 
-    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::Acquire).is_err());
-    assert!(store_instruction.set_atomic_ordering(AtomicOrdering::AcquireRelease).is_err());
-    assert!(load_instruction.set_atomic_ordering(AtomicOrdering::AcquireRelease).is_err());
-    assert!(load_instruction.set_atomic_ordering(AtomicOrdering::Release).is_err());
+    assert!(store_instruction
+        .set_atomic_ordering(AtomicOrdering::Acquire)
+        .is_err());
+    assert!(store_instruction
+        .set_atomic_ordering(AtomicOrdering::AcquireRelease)
+        .is_err());
+    assert!(load_instruction
+        .set_atomic_ordering(AtomicOrdering::AcquireRelease)
+        .is_err());
+    assert!(load_instruction
+        .set_atomic_ordering(AtomicOrdering::Release)
+        .is_err());
 
-    let fadd_instruction = builder.build_float_add(load.into_float_value(), f32_val, "").as_instruction_value().unwrap();
+    let fadd_instruction = builder
+        .build_float_add(load.into_float_value(), f32_val, "")
+        .as_instruction_value()
+        .unwrap();
     assert!(fadd_instruction.get_atomic_ordering().is_err());
-    assert!(fadd_instruction.set_atomic_ordering(AtomicOrdering::NotAtomic).is_err());
+    assert!(fadd_instruction
+        .set_atomic_ordering(AtomicOrdering::NotAtomic)
+        .is_err());
 }
 
 #[test]

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -1,14 +1,14 @@
 extern crate inkwell;
 
-use self::inkwell::OptimizationLevel;
 use self::inkwell::context::Context;
 use self::inkwell::memory_buffer::MemoryBuffer;
 use self::inkwell::module::Module;
 use self::inkwell::targets::{Target, TargetTriple};
 use self::inkwell::values::AnyValue;
+use self::inkwell::OptimizationLevel;
 
 use std::env::temp_dir;
-use std::fs::{File, remove_file};
+use std::fs::{remove_file, File};
 use std::io::Read;
 use std::path::Path;
 
@@ -29,7 +29,8 @@ fn test_write_bitcode_to_path() {
     let mut contents = Vec::new();
     let mut file = File::open(&path).expect("Could not open temp file");
 
-    file.read_to_end(&mut contents).expect("Unable to verify written file");
+    file.read_to_end(&mut contents)
+        .expect("Unable to verify written file");
 
     assert!(!contents.is_empty());
 
@@ -117,7 +118,10 @@ fn test_write_and_load_memory_buffer() {
 
     let module2 = context.create_module_from_ir(memory_buffer).unwrap();
 
-    assert_eq!(module2.get_function("my_fn").unwrap().print_to_string(), function.print_to_string());
+    assert_eq!(
+        module2.get_function("my_fn").unwrap().print_to_string(),
+        function.print_to_string()
+    );
 
     let memory_buffer2 = module.write_bitcode_to_memory();
     let object_file = memory_buffer2.create_object_file();
@@ -177,24 +181,24 @@ fn test_get_struct_type_global_context() {
 // TODO: test compile fail
 // #[test]
 // fn test_module_no_double_free() {
-    // let _module = {
-    //     let context = Context::create();
+// let _module = {
+//     let context = Context::create();
 
-    //     context.create_module("my_mod")
-    // };
+//     context.create_module("my_mod")
+// };
 // }
 
 // #[test]
 // fn test_owned_module_dropped_ee_and_context() {
-    // let _module = {
-    //     let context = Context::create();
-    //     let module = context.create_module("my_mod");
+// let _module = {
+//     let context = Context::create();
+//     let module = context.create_module("my_mod");
 
-    //     module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
-    //     module
-    // };
+//     module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+//     module
+// };
 
-    // Context and EE will live on in the module until here
+// Context and EE will live on in the module until here
 // }
 
 #[test]
@@ -305,7 +309,10 @@ fn test_print_to_file() {
 
     let bad_path = Path::new("/tmp/some/silly/path/that/sure/doesn't/exist");
 
-    assert_eq!(module.print_to_file(bad_path).unwrap_err().to_str(), Ok("No such file or directory"));
+    assert_eq!(
+        module.print_to_file(bad_path).unwrap_err().to_str(),
+        Ok("No such file or directory")
+    );
 
     let mut temp_path = temp_dir();
 
@@ -325,8 +332,15 @@ fn test_get_set_target() {
     assert_eq!(module.get_name().to_str(), Ok("mod"));
     assert_eq!(module.get_triple(), TargetTriple::create(""));
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     assert_eq!(module.get_source_file_name().to_str(), Ok("mod"));
 
     #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8")))]
@@ -337,8 +351,15 @@ fn test_get_set_target() {
     assert_eq!(module.get_name().to_str(), Ok("mod2"));
     assert_eq!(module.get_triple(), triple);
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     {
         module.set_source_file_name("foo.rs");
 
@@ -381,7 +402,9 @@ fn test_linking_modules() {
     // fn_val2 is no longer the same instance of f2
     assert_ne!(module.get_function("f2"), Some(fn_val2));
 
-    let _execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).expect("Could not create Execution Engine");
+    let _execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .expect("Could not create Execution Engine");
     let module4 = context.create_module("mod4");
 
     // EE owned module links in unowned (empty) module
@@ -399,7 +422,10 @@ fn test_linking_modules() {
     #[cfg(feature = "llvm3-6")] // Likely a LLVM bug that no error message is produced in 3-6
     assert_eq!(module.link_in_module(module5).unwrap_err().to_str(), Ok(""));
     #[cfg(not(feature = "llvm3-6"))]
-    assert_eq!(module.link_in_module(module5).unwrap_err().to_str(), Ok("Linking globals named \'f2\': symbol multiply defined!"));
+    assert_eq!(
+        module.link_in_module(module5).unwrap_err().to_str(),
+        Ok("Linking globals named \'f2\': symbol multiply defined!")
+    );
 
     let module6 = context.create_module("mod5");
     let fn_val4 = module6.add_function("f4", fn_type, None);
@@ -408,7 +434,9 @@ fn test_linking_modules() {
     builder.position_at_end(basic_block4);
     builder.build_return(None);
 
-    let execution_engine2 = module6.create_jit_execution_engine(OptimizationLevel::None).expect("Could not create Execution Engine");
+    let execution_engine2 = module6
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .expect("Could not create Execution Engine");
 
     // EE owned module cannot link another EE owned module
     assert!(module.link_in_module(module6).is_err());
@@ -417,8 +445,15 @@ fn test_linking_modules() {
 
 #[test]
 fn test_metadata_flags() {
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     {
         let context = Context::create();
         let module = context.create_module("my_module");
@@ -467,19 +502,27 @@ fn test_double_ee_from_same_module() {
     builder.position_at_end(basic_block);
     builder.build_return(None);
 
-    module.create_execution_engine().expect("Could not create Execution Engine");
+    module
+        .create_execution_engine()
+        .expect("Could not create Execution Engine");
 
     assert!(module.create_execution_engine().is_err());
 
     let module2 = module.clone();
 
-    module2.create_jit_execution_engine(OptimizationLevel::None).expect("Could not create Execution Engine");
+    module2
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .expect("Could not create Execution Engine");
 
-    assert!(module.create_jit_execution_engine(OptimizationLevel::None).is_err());
+    assert!(module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .is_err());
 
     let module3 = module.clone();
 
-    module3.create_interpreter_execution_engine().expect("Could not create Execution Engine");
+    module3
+        .create_interpreter_execution_engine()
+        .expect("Could not create Execution Engine");
 
     assert!(module.create_interpreter_execution_engine().is_err());
 }

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -1,8 +1,8 @@
 extern crate inkwell;
 
-use self::inkwell::OptimizationLevel::Aggressive;
 use self::inkwell::context::Context;
-use self::inkwell::passes::{PassManagerBuilder, PassManager, PassRegistry};
+use self::inkwell::passes::{PassManager, PassManagerBuilder, PassRegistry};
+use self::inkwell::OptimizationLevel::Aggressive;
 
 #[test]
 fn test_init_all_passes_for_module() {
@@ -25,7 +25,13 @@ fn test_init_all_passes_for_module() {
     pass_manager.add_internalize_pass(true);
     pass_manager.add_strip_dead_prototypes_pass();
     pass_manager.add_strip_symbol_pass();
-    #[cfg(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9", feature = "llvm4-0"))]
+    #[cfg(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0"
+    ))]
     pass_manager.add_bb_vectorize_pass();
     pass_manager.add_loop_vectorize_pass();
     pass_manager.add_slp_vectorize_pass();
@@ -72,21 +78,41 @@ fn test_init_all_passes_for_module() {
     pass_manager.add_scoped_no_alias_aa_pass();
     pass_manager.add_basic_alias_analysis_pass();
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9"
+    )))]
     {
         pass_manager.add_early_cse_mem_ssa_pass();
         pass_manager.add_new_gvn_pass();
     }
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     {
         pass_manager.add_aggressive_inst_combiner_pass();
         pass_manager.add_loop_unroll_and_jam_pass();
     }
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0"
+    )))]
     {
         pass_manager.add_coroutine_early_pass();
         pass_manager.add_coroutine_split_pass();
@@ -143,9 +169,27 @@ fn test_pass_manager_builder() {
     let module2 = module.clone();
 
     // TODOC: In 3.6, 3.8, & 3.9 it returns false. Seems like a LLVM bug?
-    #[cfg(not(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-7",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0"
+    )))]
     assert!(!module_pass_manager.run_on(&module));
-    #[cfg(any(feature = "llvm3-7", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0"))]
+    #[cfg(any(
+        feature = "llvm3-7",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0"
+    ))]
     assert!(module_pass_manager.run_on(&module));
 
     let lto_pass_manager = PassManager::create(());
@@ -171,7 +215,14 @@ fn test_pass_registry() {
     pass_registry.initialize_ipa();
     pass_registry.initialize_codegen();
     pass_registry.initialize_target();
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     pass_registry.initialize_aggressive_inst_combiner();
 }

--- a/tests/all/test_tari_example.rs
+++ b/tests/all/test_tari_example.rs
@@ -1,18 +1,21 @@
 extern crate inkwell;
 
-use self::inkwell::OptimizationLevel;
 use self::inkwell::context::Context;
-use self::inkwell::targets::{InitializationConfig, Target};
 use self::inkwell::execution_engine::JitFunction;
+use self::inkwell::targets::{InitializationConfig, Target};
+use self::inkwell::OptimizationLevel;
 
 #[test]
 fn test_tari_example() {
-    Target::initialize_native(&InitializationConfig::default()).expect("Failed to initialize native target");
+    Target::initialize_native(&InitializationConfig::default())
+        .expect("Failed to initialize native target");
 
     let context = Context::create();
     let module = context.create_module("sum");
     let builder = context.create_builder();
-    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+    let execution_engine = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .unwrap();
 
     let i64_type = context.i64_type();
     let fn_type = i64_type.fn_type(&[i64_type.into(), i64_type.into(), i64_type.into()], false);

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -1,7 +1,7 @@
-use inkwell::AddressSpace;
 use inkwell::context::Context;
-use inkwell::values::AnyValue;
 use inkwell::types::BasicType;
+use inkwell::values::AnyValue;
+use inkwell::AddressSpace;
 
 #[test]
 fn test_struct_type() {
@@ -18,7 +18,10 @@ fn test_struct_type() {
     assert!(av_struct.get_name().is_none());
     assert_eq!(*av_struct.get_context(), context);
     assert_eq!(av_struct.count_fields(), 2);
-    assert_eq!(av_struct.get_field_types(), &[int_vector.into(), float_array.into()]);
+    assert_eq!(
+        av_struct.get_field_types(),
+        &[int_vector.into(), float_array.into()]
+    );
 
     #[cfg(not(feature = "llvm3-6"))]
     {
@@ -59,7 +62,10 @@ fn test_struct_type() {
     assert!(!opaque_struct.is_packed());
     assert!(opaque_struct.is_opaque());
     assert!(!opaque_struct.is_sized());
-    assert_eq!(opaque_struct.get_name().map(|s| s.to_str()), Some(Ok("opaque_struct")));
+    assert_eq!(
+        opaque_struct.get_name().map(|s| s.to_str()),
+        Some(Ok("opaque_struct"))
+    );
     assert_eq!(*opaque_struct.get_context(), context);
     assert_eq!(opaque_struct.count_fields(), 0);
     assert!(opaque_struct.get_field_types().is_empty());
@@ -79,10 +85,16 @@ fn test_struct_type() {
     assert!(no_longer_opaque_struct.is_packed());
     assert!(!no_longer_opaque_struct.is_opaque());
     assert!(no_longer_opaque_struct.is_sized());
-    assert_eq!(no_longer_opaque_struct.get_name().map(|s| s.to_str()), Some(Ok("opaque_struct")));
+    assert_eq!(
+        no_longer_opaque_struct.get_name().map(|s| s.to_str()),
+        Some(Ok("opaque_struct"))
+    );
     assert_eq!(*no_longer_opaque_struct.get_context(), context);
     assert_eq!(no_longer_opaque_struct.count_fields(), 2);
-    assert_eq!(no_longer_opaque_struct.get_field_types(), &[int_vector.into(), float_array.into()]);
+    assert_eq!(
+        no_longer_opaque_struct.get_field_types(),
+        &[int_vector.into(), float_array.into()]
+    );
 
     #[cfg(not(feature = "llvm3-6"))]
     {
@@ -92,8 +104,13 @@ fn test_struct_type() {
         assert!(field_1.is_vector_type());
         assert!(field_2.is_array_type());
         assert!(no_longer_opaque_struct.get_field_type_at_index(2).is_none());
-        assert!(no_longer_opaque_struct.get_field_type_at_index(200).is_none());
-        assert_eq!(no_longer_opaque_struct.get_field_types(), vec![field_1, field_2]);
+        assert!(no_longer_opaque_struct
+            .get_field_type_at_index(200)
+            .is_none());
+        assert_eq!(
+            no_longer_opaque_struct.get_field_types(),
+            vec![field_1, field_2]
+        );
     }
 }
 
@@ -122,9 +139,7 @@ fn test_function_type() {
 
 #[test]
 fn test_sized_types() {
-    unsafe {
-        Context::get_global(sized_types)
-    }
+    unsafe { Context::get_global(sized_types) }
 }
 
 fn sized_types(global_ctx: &Context) {
@@ -224,7 +239,9 @@ fn sized_types(global_ctx: &Context) {
     let opaque_struct_type = global_ctx.opaque_struct_type("opaque");
 
     assert!(!opaque_struct_type.is_sized());
-    assert!(opaque_struct_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(opaque_struct_type
+        .ptr_type(AddressSpace::Generic)
+        .is_sized());
     assert!(!opaque_struct_type.array_type(0).is_sized());
 }
 
@@ -303,15 +320,39 @@ fn test_const_zero() {
     assert_eq!(i64_zero.print_to_string().to_str(), Ok("i64 0"));
     assert_eq!(i128_zero.print_to_string().to_str(), Ok("i128 0"));
     assert_eq!(f16_zero.print_to_string().to_str(), Ok("half 0xH0000"));
-    assert_eq!(f32_zero.print_to_string().to_str(), Ok("float 0.000000e+00"));
-    assert_eq!(f64_zero.print_to_string().to_str(), Ok("double 0.000000e+00"));
-    assert_eq!(f80_zero.print_to_string().to_str(), Ok("x86_fp80 0xK00000000000000000000"));
-    assert_eq!(f128_zero.print_to_string().to_str(), Ok("fp128 0xL00000000000000000000000000000000"));
-    assert_eq!(ppc_f128_zero.print_to_string().to_str(), Ok("ppc_fp128 0xM00000000000000000000000000000000"));
-    assert_eq!(struct_zero.print_to_string().to_str(), Ok("{ i8, fp128 } zeroinitializer"));
+    assert_eq!(
+        f32_zero.print_to_string().to_str(),
+        Ok("float 0.000000e+00")
+    );
+    assert_eq!(
+        f64_zero.print_to_string().to_str(),
+        Ok("double 0.000000e+00")
+    );
+    assert_eq!(
+        f80_zero.print_to_string().to_str(),
+        Ok("x86_fp80 0xK00000000000000000000")
+    );
+    assert_eq!(
+        f128_zero.print_to_string().to_str(),
+        Ok("fp128 0xL00000000000000000000000000000000")
+    );
+    assert_eq!(
+        ppc_f128_zero.print_to_string().to_str(),
+        Ok("ppc_fp128 0xM00000000000000000000000000000000")
+    );
+    assert_eq!(
+        struct_zero.print_to_string().to_str(),
+        Ok("{ i8, fp128 } zeroinitializer")
+    );
     assert_eq!(ptr_zero.print_to_string().to_str(), Ok("double* null"));
-    assert_eq!(vec_zero.print_to_string().to_str(), Ok("<42 x double> zeroinitializer"));
-    assert_eq!(array_zero.print_to_string().to_str(), Ok("[42 x double] zeroinitializer"));
+    assert_eq!(
+        vec_zero.print_to_string().to_str(),
+        Ok("<42 x double> zeroinitializer")
+    );
+    assert_eq!(
+        array_zero.print_to_string().to_str(),
+        Ok("[42 x double] zeroinitializer")
+    );
 }
 
 #[test]
@@ -357,19 +398,29 @@ fn test_basic_type_enum() {
     let int = context.i32_type();
     let types: &[&dyn BasicType] = &[
         // ints and floats
-        &int, &context.i64_type(), &context.f32_type(), &context.f64_type(),
+        &int,
+        &context.i64_type(),
+        &context.f32_type(),
+        &context.f64_type(),
         // derived types
-        &int.array_type(0), &int.ptr_type(addr),
+        &int.array_type(0),
+        &int.ptr_type(addr),
         &context.struct_type(&[int.as_basic_type_enum()], false),
-        &int.vec_type(1)
+        &int.vec_type(1),
     ];
     for basic_type in types {
-        assert_eq!(basic_type.as_basic_type_enum().ptr_type(addr),
-                   basic_type.ptr_type(addr));
-        assert_eq!(basic_type.as_basic_type_enum().array_type(0),
-                   basic_type.array_type(0));
-        assert_eq!(basic_type.as_basic_type_enum().size_of(),
-                   basic_type.size_of());
+        assert_eq!(
+            basic_type.as_basic_type_enum().ptr_type(addr),
+            basic_type.ptr_type(addr)
+        );
+        assert_eq!(
+            basic_type.as_basic_type_enum().array_type(0),
+            basic_type.array_type(0)
+        );
+        assert_eq!(
+            basic_type.as_basic_type_enum().size_of(),
+            basic_type.size_of()
+        );
     }
 }
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1,11 +1,13 @@
-use inkwell::{DLLStorageClass, FloatPredicate, GlobalVisibility, ThreadLocalMode, AddressSpace};
 use inkwell::attributes::AttributeLoc;
+#[llvm_versions(7.0..=latest)]
+use inkwell::comdat::ComdatSelectionKind;
 use inkwell::context::Context;
 use inkwell::module::Linkage::*;
 use inkwell::types::{AnyType, StringRadix, VectorType};
-use inkwell::values::{AnyValue, BasicValue, CallableValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
-#[llvm_versions(7.0..=latest)]
-use inkwell::comdat::ComdatSelectionKind;
+use inkwell::values::{
+    AnyValue, BasicValue, CallableValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID,
+};
+use inkwell::{AddressSpace, DLLStorageClass, FloatPredicate, GlobalVisibility, ThreadLocalMode};
 
 use std::convert::TryFrom;
 
@@ -320,10 +322,32 @@ fn test_verify_fn() {
 
     let function = module.add_function("fn", fn_type, None);
 
-    #[cfg(not(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0"
+    )))]
     assert!(!function.verify(false));
     // REVIEW: Why does 3.9 -> 8.0 return true here? LLVM bug? Bugfix?
-    #[cfg(any(feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0"))]
+    #[cfg(any(
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0"
+    ))]
     assert!(function.verify(false));
 
     let basic_block = context.append_basic_block(function, "entry");
@@ -348,7 +372,10 @@ fn test_metadata() {
     // or a new lookup
 
     assert_eq!(context.get_kind_id("foo"), FIRST_CUSTOM_METADATA_KIND_ID);
-    assert_eq!(context.get_kind_id("bar"), FIRST_CUSTOM_METADATA_KIND_ID + 1);
+    assert_eq!(
+        context.get_kind_id("bar"),
+        FIRST_CUSTOM_METADATA_KIND_ID + 1
+    );
 
     // Predefined
     assert_eq!(context.get_kind_id("dbg"), 0);
@@ -384,18 +411,36 @@ fn test_metadata() {
         assert_eq!(context.get_kind_id("type"), 19);
     }
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9"
+    )))]
     {
         assert_eq!(context.get_kind_id("section_prefix"), 20);
         assert_eq!(context.get_kind_id("absolute_symbol"), 21);
     }
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9", feature = "llvm4-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0"
+    )))]
     {
         assert_eq!(context.get_kind_id("associated"), 22);
     }
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9", feature = "llvm4-0", feature = "llvm5-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0"
+    )))]
     {
         assert_eq!(context.get_kind_id("callees"), 23);
         assert_eq!(context.get_kind_id("irr_loop"), 24);
@@ -410,7 +455,10 @@ fn test_metadata() {
 
     assert_eq!(md_string.get_node_size(), 0);
     assert_eq!(md_string.get_node_values().len(), 0);
-    assert_eq!(md_string.get_string_value().unwrap().to_str(), Ok("lots of metadata here"));
+    assert_eq!(
+        md_string.get_string_value().unwrap().to_str(),
+        Ok("lots of metadata here")
+    );
 
     let bool_type = context.bool_type();
     // let i8_type = context.i8_type();
@@ -461,11 +509,17 @@ fn test_metadata() {
 
     assert_eq!(global_md.len(), 2);
 
-    let (md_0, md_1) = (global_md[0].get_node_values(), global_md[1].get_node_values());
+    let (md_0, md_1) = (
+        global_md[0].get_node_values(),
+        global_md[1].get_node_values(),
+    );
 
     assert_eq!(md_0.len(), 1);
     assert_eq!(md_1.len(), 2);
-    assert_eq!(md_0[0].into_metadata_value().get_string_value(), md_string.get_string_value());
+    assert_eq!(
+        md_0[0].into_metadata_value().get_string_value(),
+        md_string.get_string_value()
+    );
     assert_eq!(md_1[0].into_int_value(), bool_val);
     assert_eq!(md_1[1].into_float_value(), f32_val);
 
@@ -515,7 +569,10 @@ fn test_metadata() {
     let md_node_values = ret_instr.get_metadata(2).unwrap().get_node_values();
 
     assert_eq!(md_node_values.len(), 1);
-    assert_eq!(md_node_values[0].into_metadata_value().get_string_value(), md_string.get_string_value());
+    assert_eq!(
+        md_node_values[0].into_metadata_value().get_string_value(),
+        md_string.get_string_value()
+    );
 
     // New Context Metadata
     let context_metadata_node = context.metadata_node(&[bool_val.into(), f32_val.into()]);
@@ -560,44 +617,91 @@ fn test_floats() {
     let f64_two = f64_type.const_float(2.);
     let neg_two = f64_two.const_neg();
 
-    assert_eq!(neg_two.print_to_string().to_str(), Ok("double -2.000000e+00"));
+    assert_eq!(
+        neg_two.print_to_string().to_str(),
+        Ok("double -2.000000e+00")
+    );
 
     let neg_three = neg_two.const_sub(f64_one);
 
-    assert_eq!(neg_three.print_to_string().to_str(), Ok("double -3.000000e+00"));
+    assert_eq!(
+        neg_three.print_to_string().to_str(),
+        Ok("double -3.000000e+00")
+    );
 
     let pos_six = neg_three.const_mul(neg_two);
 
-    assert_eq!(pos_six.print_to_string().to_str(), Ok("double 6.000000e+00"));
+    assert_eq!(
+        pos_six.print_to_string().to_str(),
+        Ok("double 6.000000e+00")
+    );
 
     let pos_eight = pos_six.const_add(f64_two);
 
-    assert_eq!(pos_eight.print_to_string().to_str(), Ok("double 8.000000e+00"));
+    assert_eq!(
+        pos_eight.print_to_string().to_str(),
+        Ok("double 8.000000e+00")
+    );
 
     let pos_four = pos_eight.const_div(f64_two);
 
-    assert_eq!(pos_four.print_to_string().to_str(), Ok("double 4.000000e+00"));
+    assert_eq!(
+        pos_four.print_to_string().to_str(),
+        Ok("double 4.000000e+00")
+    );
 
     let rem = pos_six.const_remainder(pos_four);
 
     assert_eq!(rem.print_to_string().to_str(), Ok("double 2.000000e+00"));
 
-    assert!(f64_one.const_compare(FloatPredicate::PredicateFalse, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::PredicateTrue, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::OEQ, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::OGT, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::OGE, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::OLT, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::OLE, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::ONE, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::UEQ, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::UGT, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::UGE, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::ULT, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::ULE, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::UNE, f64_two).is_null());
-    assert!(!f64_one.const_compare(FloatPredicate::ORD, f64_two).is_null());
-    assert!(f64_one.const_compare(FloatPredicate::UNO, f64_two).is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::PredicateFalse, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::PredicateTrue, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::OEQ, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::OGT, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::OGE, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::OLT, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::OLE, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::ONE, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::UEQ, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::UGT, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::UGE, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::ULT, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::ULE, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::UNE, f64_two)
+        .is_null());
+    assert!(!f64_one
+        .const_compare(FloatPredicate::ORD, f64_two)
+        .is_null());
+    assert!(f64_one
+        .const_compare(FloatPredicate::UNO, f64_two)
+        .is_null());
 }
 
 #[test]
@@ -629,19 +733,35 @@ fn test_function_value_no_params() {
 fn test_value_from_string() {
     let context = Context::create();
     let i8_type = context.i8_type();
-    let i8_val = i8_type.const_int_from_string("0121", StringRadix::Decimal).unwrap();
+    let i8_val = i8_type
+        .const_int_from_string("0121", StringRadix::Decimal)
+        .unwrap();
 
     assert_eq!(i8_val.print_to_string().to_str(), Ok("i8 121"));
 
-    let i8_val = i8_type.const_int_from_string("0121", StringRadix::try_from(10).unwrap()).unwrap();
+    let i8_val = i8_type
+        .const_int_from_string("0121", StringRadix::try_from(10).unwrap())
+        .unwrap();
 
     assert_eq!(i8_val.print_to_string().to_string(), "i8 121");
 
     assert_eq!(i8_type.const_int_from_string("", StringRadix::Binary), None);
-    assert_eq!(i8_type.const_int_from_string("-", StringRadix::Binary), None);
-    assert_eq!(i8_type.const_int_from_string("--1", StringRadix::Binary), None);
-    assert_eq!(i8_type.const_int_from_string("2", StringRadix::Binary), None);
-    assert_eq!(i8_type.const_int_from_string("2", StringRadix::Binary), None);
+    assert_eq!(
+        i8_type.const_int_from_string("-", StringRadix::Binary),
+        None
+    );
+    assert_eq!(
+        i8_type.const_int_from_string("--1", StringRadix::Binary),
+        None
+    );
+    assert_eq!(
+        i8_type.const_int_from_string("2", StringRadix::Binary),
+        None
+    );
+    assert_eq!(
+        i8_type.const_int_from_string("2", StringRadix::Binary),
+        None
+    );
 
     // Floats
     let f64_type = context.f64_type();
@@ -716,8 +836,15 @@ fn test_globals() {
 
     let global = module.add_global(i8_type, None, "my_global");
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     assert_eq!(global.get_unnamed_address(), UnnamedAddress::None);
     assert!(global.get_previous_global().is_none());
     assert!(global.get_next_global().is_none());
@@ -730,7 +857,17 @@ fn test_globals() {
     assert!(!global.is_externally_initialized());
     assert_eq!(global.get_name().to_str(), Ok("my_global"));
     // REVIEW: Segfaults in 4.0 -> 11.0
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0", feature = "llvm8-0", feature = "llvm9-0", feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0")))]
+    #[cfg(not(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0"
+    )))]
     assert_eq!(global.get_section().to_str(), Ok(""));
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::default());
     assert_eq!(global.get_visibility(), GlobalVisibility::default());
@@ -745,8 +882,15 @@ fn test_globals() {
     assert!(module.get_global("my_global").is_none());
     assert_eq!(module.get_global("glob").unwrap(), global);
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     global.set_unnamed_address(UnnamedAddress::Local);
     global.set_dll_storage_class(DLLStorageClass::Import);
     global.set_initializer(&i8_zero);
@@ -757,13 +901,23 @@ fn test_globals() {
     global.set_section("not sure what goes here");
 
     // REVIEW: Not sure why this is Global when we set it to Local
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     assert_eq!(global.get_unnamed_address(), UnnamedAddress::Global);
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::Import);
     assert_eq!(global.get_initializer().unwrap().into_int_value(), i8_zero);
     assert_eq!(global.get_visibility(), GlobalVisibility::Hidden);
-    assert_eq!(global.get_thread_local_mode().unwrap(), ThreadLocalMode::InitialExecTLSModel);
+    assert_eq!(
+        global.get_thread_local_mode().unwrap(),
+        ThreadLocalMode::InitialExecTLSModel
+    );
     assert!(global.is_thread_local());
     assert!(global.has_unnamed_addr());
     assert!(global.is_constant());
@@ -776,16 +930,30 @@ fn test_globals() {
 
     assert_eq!(global.get_linkage(), Private);
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     global.set_unnamed_address(UnnamedAddress::Global);
     global.set_dll_storage_class(DLLStorageClass::Export);
     global.set_thread_local(false);
     global.set_linkage(External);
     global.set_visibility(GlobalVisibility::Protected);
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     assert_eq!(global.get_unnamed_address(), UnnamedAddress::Global);
     assert!(!global.is_thread_local());
     assert_eq!(global.get_visibility(), GlobalVisibility::Protected);
@@ -794,15 +962,24 @@ fn test_globals() {
 
     assert_eq!(global.get_dll_storage_class(), DLLStorageClass::Export);
     assert!(global.is_thread_local());
-    assert_eq!(global.get_thread_local_mode().unwrap(), ThreadLocalMode::GeneralDynamicTLSModel);
+    assert_eq!(
+        global.get_thread_local_mode().unwrap(),
+        ThreadLocalMode::GeneralDynamicTLSModel
+    );
 
     global.set_thread_local_mode(Some(ThreadLocalMode::LocalExecTLSModel));
 
-    assert_eq!(global.get_thread_local_mode().unwrap(), ThreadLocalMode::LocalExecTLSModel);
+    assert_eq!(
+        global.get_thread_local_mode().unwrap(),
+        ThreadLocalMode::LocalExecTLSModel
+    );
 
     global.set_thread_local_mode(Some(ThreadLocalMode::LocalDynamicTLSModel));
 
-    assert_eq!(global.get_thread_local_mode().unwrap(), ThreadLocalMode::LocalDynamicTLSModel);
+    assert_eq!(
+        global.get_thread_local_mode().unwrap(),
+        ThreadLocalMode::LocalDynamicTLSModel
+    );
 
     global.set_thread_local_mode(None);
 
@@ -828,8 +1005,15 @@ fn test_globals() {
     // REVIEW: This doesn't seem to work. LLVM bug?
     assert!(global2.is_externally_initialized());
 
-    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
-                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(
+        feature = "llvm3-6",
+        feature = "llvm3-7",
+        feature = "llvm3-8",
+        feature = "llvm3-9",
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0"
+    )))]
     {
         assert!(global.get_comdat().is_none());
 
@@ -883,13 +1067,13 @@ fn test_phi_values() {
     assert_eq!(phi.count_incoming(), 0);
     assert_eq!(phi.print_to_string().to_str(), Ok("  %if = phi i1 "));
 
-    phi.add_incoming(&[
-        (&false_val, then_block),
-        (&true_val, else_block),
-    ]);
+    phi.add_incoming(&[(&false_val, then_block), (&true_val, else_block)]);
 
     assert_eq!(phi.count_incoming(), 2);
-    assert_eq!(phi.print_to_string().to_str(), Ok("  %if = phi i1 [ false, %then ], [ true, %else ]"));
+    assert_eq!(
+        phi.print_to_string().to_str(),
+        Ok("  %if = phi i1 [ false, %then ], [ true, %else ]")
+    );
 
     let (then_val, then_bb) = phi.get_incoming(0).unwrap();
     let (else_val, else_bb) = phi.get_incoming(1).unwrap();
@@ -929,17 +1113,26 @@ fn test_allocations() {
 
     let stack_array = builder.build_array_alloca(i32_type, i32_three, "stack_array");
 
-    assert_eq!(stack_array.get_type().print_to_string().to_str(), Ok("i32*"));
+    assert_eq!(
+        stack_array.get_type().print_to_string().to_str(),
+        Ok("i32*")
+    );
 
     let heap_ptr = builder.build_malloc(i32_type, "heap_ptr");
 
     assert!(heap_ptr.is_ok());
-    assert_eq!(heap_ptr.unwrap().get_type().print_to_string().to_str(), Ok("i32*"));
+    assert_eq!(
+        heap_ptr.unwrap().get_type().print_to_string().to_str(),
+        Ok("i32*")
+    );
 
     let heap_array = builder.build_array_malloc(i32_type, i32_three, "heap_array");
 
     assert!(heap_array.is_ok());
-    assert_eq!(heap_array.unwrap().get_type().print_to_string().to_str(), Ok("i32*"));
+    assert_eq!(
+        heap_array.unwrap().get_type().print_to_string().to_str(),
+        Ok("i32*")
+    );
 
     let bad_malloc_res = builder.build_malloc(unsized_type, "");
 
@@ -956,8 +1149,14 @@ fn test_string_values() {
     let string = context.const_string(b"my_string", false);
     let string_null = context.const_string(b"my_string", true);
 
-    assert_eq!(string.print_to_string().to_string(), "[9 x i8] c\"my_string\"");
-    assert_eq!(string_null.print_to_string().to_string(), "[10 x i8] c\"my_string\\00\"");
+    assert_eq!(
+        string.print_to_string().to_string(),
+        "[9 x i8] c\"my_string\""
+    );
+    assert_eq!(
+        string_null.print_to_string().to_string(),
+        "[10 x i8] c\"my_string\\00\""
+    );
     assert!(string.is_const_string());
     assert!(string_null.is_const_string());
 
@@ -970,12 +1169,24 @@ fn test_string_values() {
     assert!(!string.is_constant_data_vector());
     assert!(!string_null.is_constant_data_vector());
 
-    assert_eq!(string.print_to_string().to_string(), "[9 x i8] c\"my_string\"");
-    assert_eq!(string_null.print_to_string().to_string(), "[10 x i8] c\"my_string\\00\"");
+    assert_eq!(
+        string.print_to_string().to_string(),
+        "[9 x i8] c\"my_string\""
+    );
+    assert_eq!(
+        string_null.print_to_string().to_string(),
+        "[10 x i8] c\"my_string\\00\""
+    );
     assert!(string.is_const_string());
     assert!(string_null.is_const_string());
-    assert_eq!(string.get_type().get_element_type().into_int_type(), i8_type);
-    assert_eq!(string_null.get_type().get_element_type().into_int_type(), i8_type);
+    assert_eq!(
+        string.get_type().get_element_type().into_int_type(),
+        i8_type
+    );
+    assert_eq!(
+        string_null.get_type().get_element_type().into_int_type(),
+        i8_type
+    );
     assert_eq!(string.get_string_constant().to_str(), Ok("my_string"));
     assert_eq!(string_null.get_string_constant().to_str(), Ok("my_string"));
 
@@ -1042,17 +1253,32 @@ fn test_consts() {
     assert!(array_val.is_const());
     assert!(arbitrary_precision_int.is_const());
 
-    assert_eq!(arbitrary_precision_int.print_to_string().to_str(), Ok("i64 1"));
+    assert_eq!(
+        arbitrary_precision_int.print_to_string().to_str(),
+        Ok("i64 1")
+    );
 
     assert!(!vec_val.is_const_string());
     assert!(!vec_val.is_constant_vector());
     assert!(vec_val.is_constant_data_vector());
 
     assert_eq!(bool_val.get_zero_extended_constant(), Some(1));
-    assert_eq!(i8_val.get_zero_extended_constant(), Some(u8::max_value() as u64));
-    assert_eq!(i16_val.get_zero_extended_constant(), Some(u16::max_value() as u64));
-    assert_eq!(i32_val.get_zero_extended_constant(), Some(u32::max_value() as u64));
-    assert_eq!(i64_val.get_zero_extended_constant(), Some(u64::max_value() as u64));
+    assert_eq!(
+        i8_val.get_zero_extended_constant(),
+        Some(u8::max_value() as u64)
+    );
+    assert_eq!(
+        i16_val.get_zero_extended_constant(),
+        Some(u16::max_value() as u64)
+    );
+    assert_eq!(
+        i32_val.get_zero_extended_constant(),
+        Some(u32::max_value() as u64)
+    );
+    assert_eq!(
+        i64_val.get_zero_extended_constant(),
+        Some(u64::max_value() as u64)
+    );
     assert_eq!(i128_val.get_zero_extended_constant(), None);
 
     assert_eq!(bool_val.get_sign_extended_constant(), Some(-1));
@@ -1104,11 +1330,17 @@ fn test_function_value_to_global_to_pointer() {
     builder.build_return(None);
 
     assert!(!fn_global_value.is_declaration());
-    assert_eq!(fn_global_value.get_dll_storage_class(), DLLStorageClass::Default);
+    assert_eq!(
+        fn_global_value.get_dll_storage_class(),
+        DLLStorageClass::Default
+    );
 
     fn_global_value.set_dll_storage_class(DLLStorageClass::Export);
 
-    assert_eq!(fn_global_value.get_dll_storage_class(), DLLStorageClass::Export);
+    assert_eq!(
+        fn_global_value.get_dll_storage_class(),
+        DLLStorageClass::Export
+    );
     assert!(fn_global_value.get_thread_local_mode().is_none());
     assert_eq!(fn_global_value.get_visibility(), GlobalVisibility::Default);
 
@@ -1199,7 +1431,8 @@ fn test_constant_expression() {
     let fn_type = void_type.fn_type(&[], false);
 
     let function = module.add_function("", fn_type, None);
-    let expr = builder.build_ptr_to_int(function.as_global_value().as_pointer_value(), i32_type, "");
+    let expr =
+        builder.build_ptr_to_int(function.as_global_value().as_pointer_value(), i32_type, "");
 
     assert!(expr.is_const());
     assert!(!expr.is_constant_int());


### PR DESCRIPTION
# Description

This patch is the result of running `rustfmt **/*.rs` from the root of
this project. The goal is the following: When a user (like me) edits a
file, the file is automatically formatted on save; which results in
larger diffs than needed. Let's fix the coding styles once and for all
thanks to `rustfmt` :-)!
