### PR TITLE
Add type attribute api.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ llvm-sys-80 = { package = "llvm-sys", version = "80.3", optional = true }
 llvm-sys-90 = { package = "llvm-sys", version = "90.2", optional = true }
 llvm-sys-100 = { package = "llvm-sys", version = "100.2", optional = true }
 llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
-llvm-sys-120 = { package = "llvm-sys", version = "120.0", optional = true }
+llvm-sys-120 = { package = "llvm-sys", version = "120.2", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.11"
 regex = "1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,6 +7,8 @@ use llvm_sys::core::{LLVMCreateEnumAttribute, LLVMCreateStringAttribute};
 use llvm_sys::core::{LLVMConstInlineAsm};
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::core::{LLVMGetInlineAsm};
+#[llvm_versions(12.0..=latest)]
+use llvm_sys::core::{LLVMCreateTypeAttribute};
 #[llvm_versions(7.0..=latest)]
 use crate::InlineAsmDialect;
 use llvm_sys::prelude::{LLVMContextRef, LLVMTypeRef, LLVMValueRef, LLVMDiagnosticInfoRef};
@@ -25,7 +27,7 @@ use crate::memory_buffer::MemoryBuffer;
 use crate::module::Module;
 use crate::support::{to_c_str, LLVMString};
 use crate::targets::TargetData;
-use crate::types::{BasicTypeEnum, FloatType, IntType, StructType, VoidType, AsTypeRef, FunctionType};
+use crate::types::{AnyTypeEnum, BasicTypeEnum, FloatType, IntType, StructType, VoidType, AsTypeRef, FunctionType};
 use crate::values::{AsValueRef, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, StructValue, MetadataValue, VectorValue, PointerValue};
 
 use std::marker::PhantomData;
@@ -901,6 +903,37 @@ impl Context {
                 key.len() as u32,
                 val.as_ptr() as *const _,
                 val.len() as u32,
+            ))
+        }
+    }
+
+    /// Create an enum `Attribute` with an `AnyTypeEnum` attached to it.
+    ///
+    /// # Example
+    /// ```rust
+    /// use inkwell::context::Context;
+    /// use inkwell::attributes::Attribute;
+    /// use inkwell::types::AnyType;
+    ///
+    /// let context = Context::create();
+    /// let kind_id = Attribute::get_named_enum_kind_id("sret");
+    /// let any_type = context.i32_type().as_any_type_enum();
+    /// let type_attribute = context.create_type_attribute(
+    ///     kind_id,
+    ///     any_type,
+    /// );
+    ///
+    /// assert!(type_attribute.is_type());
+    /// assert_eq!(type_attribute.get_type_value(), any_type);
+    /// assert_ne!(type_attribute.get_type_value(), context.i64_type().as_any_type_enum());
+    /// ```
+    #[llvm_versions(12.0..=latest)]
+    pub fn create_type_attribute(&self, kind_id: u32, type_ref: AnyTypeEnum) -> Attribute {
+        unsafe {
+            Attribute::new(LLVMCreateTypeAttribute(
+                self.context,
+                kind_id,
+                type_ref.as_type_ref(),
             ))
         }
     }


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

I have extended the api for `Context` and for `Attribute` to add support for type attributes.
This includes wrapping 3 new ffi calls: 
- [LLVMCreateTypeAttribute](https://docs.rs/llvm-sys/120.2.0/llvm_sys/core/fn.LLVMCreateTypeAttribute.html)
- [LLVMGetTypeAttributeValue](https://docs.rs/llvm-sys/120.2.0/llvm_sys/core/fn.LLVMGetTypeAttributeValue.html)
- [LLVMIsTypeAttribute](https://docs.rs/llvm-sys/120.2.0/llvm_sys/core/fn.LLVMIsTypeAttribute.html)

The added api was based in the old api for attributes.

## Related Issue

#260 

## How This Has Been Tested

I have added tests in `inkwell/tests/all/test_attributes.rs` as well as doc tests in each of the methods added. Only tested with llvm version `12.0.1` through `cargo test --features "target-all,llvm12-0"`.

Also I had been tested during development of my front-end at [ekitai](https://github.com/tarberd/ekitai).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
