### PR TITLE
Add function to get the address of a basic block

### DIFF
--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -201,3 +201,15 @@ fn test_get_first_use() {
     assert_eq!(bb1.get_first_use().unwrap().get_user(), branch_inst);
     assert!(bb1.get_first_use().unwrap().get_next_use().is_none());
 }
+
+#[test]
+fn test_get_address() {
+    let context = Context::create();
+    let module = context.create_module("my_mod");
+    let void_type = context.void_type();
+    let fn_type = void_type.fn_type(&[], false);
+    let fn_val = module.add_function("my_fn", fn_type, None);
+    let bb = context.append_basic_block(fn_val, "entry");
+    
+    assert!(bb.get_address().is_some());
+}


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

I have added a function to get the address of a basic block if it exists as a PointerValue. This function is a wrapper for `LLVMBlockAddress`. 
See [here](https://llvm.org/docs/LangRef.html#addresses-of-basic-blocks) for more information on `blockaddress`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

A test was added in `tests/test_basic_block.rs`, and this has also been put to use in a toy language of mine which proved it to be working.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
