### PR TITLE
Derive Copy & Clone for enums (#264)

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -38,7 +38,7 @@ use std::mem::MaybeUninit;
 use std::path::Path;
 use std::ptr;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum CodeModel {
     Default,
     JITDefault,
@@ -48,7 +48,7 @@ pub enum CodeModel {
     Large,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum RelocMode {
     Default,
     Static,
@@ -56,7 +56,7 @@ pub enum RelocMode {
     DynamicNoPic,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum FileType {
     Assembly,
     Object,
@@ -1289,7 +1289,7 @@ impl Drop for TargetMachine {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum ByteOrdering {
     BigEndian,
     LittleEndian,


### PR DESCRIPTION

## Description

Derive `Copy` & `Clone` for simple, value enums. 

## Related Issue

#264 

## How This Has Been Tested

Not necessary.

## Option\<Breaking Changes\>

Changes the public interface for a few enums. Shouldn't break anything.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
