### PR TITLE
Add passthru for 'MergeFunctionsPass'

### DIFF
--- a/src/passes.rs
+++ b/src/passes.rs
@@ -2,6 +2,8 @@ use llvm_sys::core::{LLVMDisposePassManager, LLVMInitializeFunctionPassManager, 
 use llvm_sys::initialization::{LLVMInitializeCore, LLVMInitializeTransformUtils, LLVMInitializeScalarOpts, LLVMInitializeObjCARCOpts, LLVMInitializeVectorization, LLVMInitializeInstCombine, LLVMInitializeIPO, LLVMInitializeInstrumentation, LLVMInitializeAnalysis, LLVMInitializeIPA, LLVMInitializeCodeGen, LLVMInitializeTarget};
 use llvm_sys::prelude::{LLVMPassManagerRef, LLVMPassRegistryRef};
 use llvm_sys::transforms::ipo::{LLVMAddArgumentPromotionPass, LLVMAddConstantMergePass, LLVMAddDeadArgEliminationPass, LLVMAddFunctionAttrsPass, LLVMAddFunctionInliningPass, LLVMAddAlwaysInlinerPass, LLVMAddGlobalDCEPass, LLVMAddGlobalOptimizerPass, LLVMAddIPSCCPPass, LLVMAddInternalizePass, LLVMAddStripDeadPrototypesPass, LLVMAddPruneEHPass, LLVMAddStripSymbolsPass};
+#[llvm_versions(10.0..=latest)]
+use llvm_sys::transforms::ipo::LLVMAddMergeFunctionsPass;
 use llvm_sys::transforms::pass_manager_builder::{LLVMPassManagerBuilderRef, LLVMPassManagerBuilderCreate, LLVMPassManagerBuilderDispose, LLVMPassManagerBuilderSetOptLevel, LLVMPassManagerBuilderSetSizeLevel, LLVMPassManagerBuilderSetDisableUnitAtATime, LLVMPassManagerBuilderSetDisableUnrollLoops, LLVMPassManagerBuilderSetDisableSimplifyLibCalls, LLVMPassManagerBuilderUseInlinerWithThreshold, LLVMPassManagerBuilderPopulateFunctionPassManager, LLVMPassManagerBuilderPopulateModulePassManager, LLVMPassManagerBuilderPopulateLTOPassManager};
 use llvm_sys::transforms::scalar::{LLVMAddAggressiveDCEPass, LLVMAddMemCpyOptPass, LLVMAddAlignmentFromAssumptionsPass, LLVMAddCFGSimplificationPass, LLVMAddDeadStoreEliminationPass, LLVMAddScalarizerPass, LLVMAddMergedLoadStoreMotionPass, LLVMAddGVNPass, LLVMAddIndVarSimplifyPass, LLVMAddInstructionCombiningPass, LLVMAddJumpThreadingPass, LLVMAddLICMPass, LLVMAddLoopDeletionPass, LLVMAddLoopIdiomPass, LLVMAddLoopRotatePass, LLVMAddLoopRerollPass, LLVMAddLoopUnrollPass, LLVMAddLoopUnswitchPass, LLVMAddPartiallyInlineLibCallsPass, LLVMAddSCCPPass, LLVMAddScalarReplAggregatesPass, LLVMAddScalarReplAggregatesPassSSA, LLVMAddScalarReplAggregatesPassWithThreshold, LLVMAddSimplifyLibCallsPass, LLVMAddTailCallEliminationPass, LLVMAddDemoteMemoryToRegisterPass, LLVMAddVerifierPass, LLVMAddCorrelatedValuePropagationPass, LLVMAddEarlyCSEPass, LLVMAddLowerExpectIntrinsicPass, LLVMAddTypeBasedAliasAnalysisPass, LLVMAddScopedNoAliasAAPass, LLVMAddBasicAliasAnalysisPass, LLVMAddReassociatePass};
 #[llvm_versions(3.7..=latest)]
@@ -301,6 +303,14 @@ impl<T: PassManagerSubType> PassManager<T> {
     pub fn add_constant_merge_pass(&self) {
         unsafe {
             LLVMAddConstantMergePass(self.pass_manager)
+        }
+    }
+
+    /// Discovers identical functions and collapses them.
+    #[llvm_versions(10.0..=latest)]
+    pub fn add_merge_functions_pass(&self) {
+        unsafe {
+            LLVMAddMergeFunctionsPass(self.pass_manager)
         }
     }
 

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -12,6 +12,8 @@ fn test_init_all_passes_for_module() {
 
     pass_manager.add_argument_promotion_pass();
     pass_manager.add_constant_merge_pass();
+    #[cfg(any(feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0"))]
+    pass_manager.add_merge_functions_pass();
     pass_manager.add_dead_arg_elimination_pass();
     pass_manager.add_function_attrs_pass();
     pass_manager.add_function_inlining_pass();

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -12,7 +12,9 @@ fn test_init_all_passes_for_module() {
 
     pass_manager.add_argument_promotion_pass();
     pass_manager.add_constant_merge_pass();
-    #[cfg(any(feature = "llvm10-0", feature = "llvm11-0", feature = "llvm12-0"))]
+    #[cfg(not(any(feature = "llvm3-6", feature = "llvm3-7", feature = "llvm3-8", feature = "llvm3-9",
+                  feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm7-0",
+                  feature = "llvm8-0", feature = "llvm9-0")))]
     pass_manager.add_merge_functions_pass();
     pass_manager.add_dead_arg_elimination_pass();
     pass_manager.add_function_attrs_pass();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
Exposes the `mergefunc` optimization pass to _Inkwell_ through `LLVMAddMergeFunctionsPass` function in _llvm-sys_

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
#267 

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Built and tested under `llvm8-0` and `llvm11-0` (versions I readily have available).  Correct feature flag based off of presence of function in upstream `llvm-sys` (https://docs.rs/llvm-sys/100.2.2/src/llvm_sys/transforms/ipo.rs.html).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
