### PR TITLE
Fix wasm build

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -610,7 +610,7 @@ impl<'ctx> Module<'ctx> {
                 LLVMWriteBitcodeToFD(self.module.get(), file.as_raw_fd(), should_close as i32, unbuffered as i32) == 0
             }
         }
-        #[cfg(windows)]
+        #[cfg(not(unix))]
         return false;
     }
 


### PR DESCRIPTION
    `cargo build --target wasm32-wasi --features llvm11-0` fails with:
    
       --> /home/sean/git/inkwell/src/module.rs:601:95
        |
    601 |     pub fn write_bitcode_to_file(&self, file: &File, should_close: bool, unbuffered: bool) -> bool {
        |            ---------------------                                                              ^^^^ expected `bool`, found `()`
        |            |
        |            implicitly returns `()` as its body has no tail or `return` expression
    
    Note that as_raw_fd() cannot be used on wasi yet, since this depends on
    wasm_ext which is unstable:
    
    https://github.com/rust-lang/rust/issues/71213

Signed-off-by: Sean Young <sean@mess.org>
