### PR TITLE
Accept AnyValue in PhiValue::replace_all_uses_with

### DIFF
--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -6,7 +6,9 @@ use std::ffi::CStr;
 
 use crate::basic_block::BasicBlock;
 use crate::values::traits::AsValueRef;
-use crate::values::{BasicValue, BasicValueEnum, InstructionOpcode, InstructionValue, Value};
+use crate::values::{
+    AnyValue, BasicValue, BasicValueEnum, InstructionOpcode, InstructionValue, Value,
+};
 
 // REVIEW: Metadata for phi values?
 /// A Phi Instruction returns a value based on which basic block branched into
@@ -82,7 +84,7 @@ impl<'ctx> PhiValue<'ctx> {
         self.phi_value.as_instruction().expect("PhiValue should always be a Phi InstructionValue")
     }
 
-    pub fn replace_all_uses_with(self, other: &PhiValue<'ctx>) {
+    pub fn replace_all_uses_with<T: AnyValue<'ctx>>(self, other: T) {
         self.phi_value.replace_all_uses_with(other.as_value_ref())
     }
 

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -26,6 +26,7 @@ mod test_module;
 mod test_object_file;
 mod test_passes;
 mod test_phi_conversion;
+mod test_phi_replacement;
 mod test_targets;
 mod test_tari_example;
 mod test_types;

--- a/tests/all/test_phi_replacement.rs
+++ b/tests/all/test_phi_replacement.rs
@@ -1,0 +1,32 @@
+use inkwell::context::Context;
+
+#[test]
+fn test_phi_replacement() {
+    let context = Context::create();
+    let module = context.create_module("phi");
+    let builder = context.create_builder();
+
+    let bool_type = context.bool_type();
+    let fn_type = bool_type.fn_type(&[], false);
+    let function = module.add_function("do_stuff", fn_type, None);
+    let entry_block = context.append_basic_block(function, "entry");
+    let return_block = context.append_basic_block(function, "return");
+    builder.position_at_end(entry_block);
+
+    let phi = builder.build_phi(bool_type, "phi_node");
+
+    builder.position_at_end(return_block);
+    builder.build_return(Some(&phi.as_basic_value()));
+
+    builder.position_at_end(entry_block);
+    let return_value = builder.build_and(
+        bool_type.const_int(0, false),
+        bool_type.const_int(1, false),
+        "and",
+    );
+    phi.replace_all_uses_with(return_value);
+    phi.as_instruction().erase_from_basic_block();
+    builder.build_unconditional_branch(return_block);
+
+    module.verify().unwrap();
+}


### PR DESCRIPTION
## Description

Allow replacing a `PhiValue` with any value kind, not just another `PhiValue`. This is necessary to be able to use a `PhiValue` as placeholder until the value is actually defined when translating from another SSA form ir like Cranelift ir.

## Related Issue

Fixes https://github.com/TheDan64/inkwell/issues/272

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

I don't think this breaks anything as `PhiValue` implements `AnyValue`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
