### PR TITLE
remove regex dependency (outside of tests)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,10 @@ llvm-sys-120 = { package = "llvm-sys", version = "120.2", optional = true }
 llvm-sys-130 = { package = "llvm-sys", version = "130.0", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.11"
-regex = "1"
 static-alloc = { version = "0.2", optional = true }
+
+[dev-dependencies]
+regex = "1"
 
 [badges]
 travis-ci = { repository = "TheDan64/inkwell" }

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -1,7 +1,6 @@
 use llvm_sys::core::{LLVMConstInt, LLVMConstAllOnes, LLVMGetIntTypeWidth, LLVMConstIntOfStringAndSize, LLVMConstIntOfArbitraryPrecision, LLVMConstArray};
 use llvm_sys::execution_engine::LLVMCreateGenericValueOfInt;
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
-use regex::Regex;
 
 use crate::AddressSpace;
 use crate::context::ContextRef;
@@ -43,14 +42,24 @@ impl TryFrom<u8> for StringRadix {
 }
 
 impl StringRadix {
-    /// Create a Regex that matches valid strings for the given radix.
-    pub fn to_regex(&self) -> Regex {
+    /// Is the string valid for the given radix?
+    pub fn matches_str(&self, slice: &str) -> bool {
+        // drop 1 optional + or -
+        let slice = slice.strip_prefix(|c| c == '+' || c == '-'));
+
+        // there must be at least 1 actual digit
+        if slice.is_empty() {
+            return false;
+        }
+
+        // and all digits must be in the radix' character set
+        let mut it = slice.chars();
         match self {
-            StringRadix::Binary => Regex::new(r"^[-+]?[01]+$").unwrap(),
-            StringRadix::Octal => Regex::new(r"^[-+]?[0-7]+$").unwrap(),
-            StringRadix::Decimal => Regex::new(r"^[-+]?[0-9]+$").unwrap(),
-            StringRadix::Hexadecimal => Regex::new(r"^[-+]?[0-9abcdefABCDEF]+$").unwrap(),
-            StringRadix::Alphanumeric => Regex::new(r"^[-+]?[0-9[:alpha:]]+$").unwrap(),
+            StringRadix::Binary => it.all(|c| matches!(c, '0'..='1')),
+            StringRadix::Octal => it.all(|c| matches!(c, '0'..='7')),
+            StringRadix::Decimal => it.all(|c| matches!(c, '0'..='9')),
+            StringRadix::Hexadecimal => it.all(|c| matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F')),
+            StringRadix::Alphanumeric => it.all(|c| matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z')),
         }
     }
 }
@@ -117,7 +126,7 @@ impl<'ctx> IntType<'ctx> {
     /// assert!(i8_val.is_none());
     /// ```
     pub fn const_int_from_string(self, slice: &str, radix: StringRadix) -> Option<IntValue<'ctx>> {
-        if !radix.to_regex().is_match(slice) {
+        if !radix.matches_str(slice) {
             return None
         }
 

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -45,7 +45,7 @@ impl StringRadix {
     /// Is the string valid for the given radix?
     pub fn matches_str(&self, slice: &str) -> bool {
         // drop 1 optional + or -
-        let slice = slice.strip_prefix(|c| c == '+' || c == '-'));
+        let slice = slice.strip_prefix(|c| c == '+' || c == '-').unwrap_or(slice);
 
         // there must be at least 1 actual digit
         if slice.is_empty() {


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Replaces the use of regex matching in `int_type.rs` with features from the stdlib. The main benefit is that the `regex` crate can be moved to [ `dev-dependencies`](https://doc.rust-lang.org/rust-by-example/testing/dev_dependencies.html)  and is therefore not compiled when using inkwell as a dependency.

I also generally don't like regex too much and think the rust code is nicer, but that's a matter of taste.

Regex is still used in `tests/all/test_targets.rs`, with this beauty:
```rust
    let datalayout_specification_re = Regex::new("[Ee]|S\\d+|P\\d+|A\\d+|p(\\d+)?:\\d+:\\d+(:\\d+)?|i\\d+:\\d+(:\\d+)?|v\\d+:\\d+(:\\d+)?|f\\d+:\\d+(:\\d+)?|a:\\d+(:\\d)?|F[in]\\d+|m:[emoxw]|n\\d+(:\\d)*|ni:\\d+(:\\d)*").unwrap();
```
I'm not going to touch that one.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

tests pass. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
