### PR TITLE
Add support for memset

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -852,7 +852,7 @@ impl<'ctx> Builder<'ctx> {
         }
     }
 
-    /// Build a [memset](http://llvm.org/docs/LangRef.html#llvm-memset-intrinsic) instruction.
+    /// Build a [memset](http://llvm.org/docs/LangRef.html#llvm-memset-intrinsics) instruction.
     ///
     /// Alignment arguments are specified in bytes, and should always be
     /// both a power of 2 and under 2^64.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -1009,7 +1009,7 @@ fn test_memmove() {
     let context = Context::create();
     let module = context.create_module("av");
 
-    assert!(run_memcpy_on(&context, &module, 8).is_ok());
+    assert!(run_memmove_on(&context, &module, 8).is_ok());
 
     // Verify the module
     if let Err(errors) = module.verify() {
@@ -1025,6 +1025,65 @@ fn test_memmove() {
         assert_eq!(&[1, 2, 1, 2], actual);
     }
 }
+
+#[llvm_versions(8.0..=latest)]
+fn run_memset_on<'ctx>(context: &'ctx Context, module: &inkwell::module::Module<'ctx>, alignment: u32) -> Result<(), &'static str> {
+    let i8_type = context.i8_type();
+    let i32_type = context.i32_type();
+    let i64_type = context.i64_type();
+    let array_len = 4;
+    let fn_type = i32_type.ptr_type(AddressSpace::Generic).fn_type(&[], false);
+    let fn_value = module.add_function("test_fn", fn_type, None);
+    let builder = context.create_builder();
+    let entry = context.append_basic_block(fn_value, "entry");
+
+    builder.position_at_end(entry);
+
+    let len_value = i64_type.const_int(array_len as u64, false);
+    let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
+
+    let elems_to_copy = 2;
+    let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
+    let size_val = i64_type.const_int(bytes_to_copy as u64, false);
+    // Memset the first half of the array as 0
+    let val = i8_type.const_zero();
+    builder.build_memset(array_ptr, alignment, val, size_val)?;
+    // Memset the second half of the array as -1
+    let val = i8_type.const_all_ones(); 
+    let index = i32_type.const_int(2, false);
+    let part_2 = unsafe { builder.build_in_bounds_gep(array_ptr, &[index], "index") };
+    builder.build_memset(part_2, alignment, val, size_val)?;
+    builder.build_return(Some(&array_ptr));
+
+    Ok(())
+}
+
+#[llvm_versions(8.0..=latest)]
+#[test]
+fn test_memset() {
+    // 1. Allocate an array with a few elements.
+    // 2. Memmove from the first half of the array to the second half.
+    // 3. Run the code in an execution engine and verify the array's contents.
+    let context = Context::create();
+    let module = context.create_module("av");
+
+    assert!(run_memset_on(&context, &module, 8).is_ok());
+
+    // Verify the module
+    if let Err(errors) = module.verify() {
+        panic!("Errors defining module: {:?}", errors);
+    }
+
+    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
+
+    unsafe {
+        let func = execution_engine.get_function::<unsafe extern "C" fn() -> *const i32>("test_fn").unwrap();
+        let actual = std::slice::from_raw_parts(func.call(), 4);
+
+        assert_eq!(&[0, 0, -1, -1], actual);
+    }
+}
+
 
 #[test]
 fn test_bitcast() {


### PR DESCRIPTION
I added a memset function similar to the memcpy and memmove

## Related Issue
Fixes #145

## How This Has Been Tested
Added unit tests similar to the memmove and memcpy
I also fixed the memmove test to actually call memmove not memcpy

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
