### PR TITLE
Remove unused imports in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::execution_engine::{ExecutionEngine, JitFunction};
 use inkwell::module::Module;
-use inkwell::targets::{InitializationConfig, Target};
 use std::error::Error;
 
 /// Convenience type alias for the `sum` function.


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

```
warning: unused imports: `InitializationConfig`, `Target`
 --> src/main.rs:6:24
  |
6 | use inkwell::targets::{InitializationConfig, Target};
  |                        ^^^^^^^^^^^^^^^^^^^^  ^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
