### PR TITLE
Add RISCV AsmParser/AsmPrinter/Disassembler support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,11 @@ llvm-sys-50 = { package = "llvm-sys", version = "50.4", optional = true }
 llvm-sys-60 = { package = "llvm-sys", version = "60.6", optional = true }
 llvm-sys-70 = { package = "llvm-sys", version = "70.4", optional = true }
 llvm-sys-80 = { package = "llvm-sys", version = "80.3", optional = true }
-llvm-sys-90 = { package = "llvm-sys", version = "90.2", optional = true }
-llvm-sys-100 = { package = "llvm-sys", version = "100.2", optional = true }
-llvm-sys-110 = { package = "llvm-sys", version = "110.0", optional = true }
-llvm-sys-120 = { package = "llvm-sys", version = "120.2", optional = true }
-llvm-sys-130 = { package = "llvm-sys", version = "130.0", optional = true }
+llvm-sys-90 = { package = "llvm-sys", version = "90.2.1", optional = true }
+llvm-sys-100 = { package = "llvm-sys", version = "100.2.3", optional = true }
+llvm-sys-110 = { package = "llvm-sys", version = "110.0.3", optional = true }
+llvm-sys-120 = { package = "llvm-sys", version = "120.2.2", optional = true }
+llvm-sys-130 = { package = "llvm-sys", version = "130.0.2", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.11"
 static-alloc = { version = "0.2", optional = true }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -752,6 +752,7 @@ impl Target {
     #[llvm_versions(9.0..=latest)]
     pub fn initialize_riscv(config: &InitializationConfig) {
         use llvm_sys::target::{
+            LLVMInitializeRISCVAsmParser, LLVMInitializeRISCVAsmPrinter, LLVMInitializeRISCVDisassembler,
             LLVMInitializeRISCVTarget, LLVMInitializeRISCVTargetInfo, LLVMInitializeRISCVTargetMC,
         };
 
@@ -765,11 +766,20 @@ impl Target {
             unsafe { LLVMInitializeRISCVTargetInfo() };
         }
 
-        // No asm printer
+        if config.asm_printer {
+            let _guard = TARGET_LOCK.write();
+            unsafe { LLVMInitializeRISCVAsmPrinter() };
+        }
 
-        // No asm parser
+        if config.asm_printer {
+            let _guard = TARGET_LOCK.write();
+            unsafe { LLVMInitializeRISCVAsmPrinter() };
+        }
 
-        // No disassembler
+        if config.asm_parser {
+            let _guard = TARGET_LOCK.write();
+            unsafe { LLVMInitializeRISCVAsmParser() };
+        }
 
         if config.machine_code {
             let _guard = TARGET_LOCK.write();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
Add RISCV AsmParser/AsmPrinter/Disassembler support on initialize_riscv.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
https://github.com/TheDan64/inkwell/issues/291

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

`cargo test --features llvm13-0`

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
