### PR TITLE
[WIP] Expose API for getting declarations of intrinsics

### DIFF
--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -11,15 +11,40 @@ pub struct Intrinsic {
     id: u32,
 }
 
+/// A wrapper around LLVM intrinsic id
+///
+/// To call it you would need to create a declaration inside a module using [`Self::get_declaration()`].
 #[llvm_versions(9.0..=latest)]
 impl Intrinsic {
-    // SAFETY: the id is a valid LLVM intrinsic ID
+    /// Create an Intrinsic object from raw LLVM intrinsic id
+    ///
+    /// SAFETY: the id is a valid LLVM intrinsic ID
     pub(crate) unsafe fn new(id: u32) -> Self {
         Self {
             id
         }
     }
 
+    /// Find llvm intrinsic id from name
+    ///
+    /// # Example
+    /// ```no_run
+    /// use inkwell::intrinsics::Intrinsic;
+    ///
+    /// let trap_intrinsic = Intrinsic::find("llvm.trap").unwrap();
+    ///
+    /// let context = Context::create();
+    /// let module = context.create_module("trap");
+    /// let builder = context.create_builder();
+    /// let fn_type = struct_type.fn_type(&[], false);
+    /// let fn_value = module.add_function("trap", fn_type, None);
+    /// let entry = context.append_basic_block(fn_value, "entry");
+    ///
+    /// let trap_function = trap_intrinsic.get_declaration(module, &[]).unwrap();
+    ///
+    /// builder.position_at_end(entry);
+    /// builder.build(trap_function, &[], "trap_call");
+    /// ```
     pub fn find(name: &str) -> Option<Self> {
         let id = unsafe {
             LLVMLookupIntrinsicID(name.as_ptr() as *const ::libc::c_char, name.len())
@@ -34,12 +59,37 @@ impl Intrinsic {
         });
     }
 
+    /// Check if specified intrinsic is overloaded
+    ///
+    /// Overloaded intrinsics need some argument types to be specified to declare them
     pub fn is_overloaded(&self) -> bool {
         unsafe {
             LLVMIntrinsicIsOverloaded(self.id) != 0
         }
     }
 
+    /// Create or insert the declaration of an intrinsic.
+    ///
+    /// For overloaded intrinsics, parameter types must be provided to uniquely identify an overload.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use inkwell::intrinsics::Intrinsic;
+    ///
+    /// let trap_intrinsic = Intrinsic::find("llvm.trap").unwrap();
+    ///
+    /// let context = Context::create();
+    /// let module = context.create_module("trap");
+    /// let builder = context.create_builder();
+    /// let fn_type = struct_type.fn_type(&[], false);
+    /// let fn_value = module.add_function("trap", fn_type, None);
+    /// let entry = context.append_basic_block(fn_value, "entry");
+    ///
+    /// let trap_function = trap_intrinsic.get_declaration(module, &[]).unwrap();
+    ///
+    /// builder.position_at_end(entry);
+    /// builder.build(trap_function, &[], "trap_call");
+    /// ```
     pub fn get_declaration<'ctx>(&self, module: &Module<'ctx>, param_types: &[BasicTypeEnum]) -> Option<FunctionValue<'ctx>> {
         let mut param_types: Vec<LLVMTypeRef> = param_types.iter()
             .map(|val| val.as_type_ref())

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -29,21 +29,22 @@ impl Intrinsic {
     ///
     /// # Example
     /// ```no_run
-    /// use inkwell::intrinsics::Intrinsic;
+    /// use inkwell::{intrinsics::Intrinsic, context::Context};
     ///
     /// let trap_intrinsic = Intrinsic::find("llvm.trap").unwrap();
     ///
     /// let context = Context::create();
     /// let module = context.create_module("trap");
     /// let builder = context.create_builder();
-    /// let fn_type = struct_type.fn_type(&[], false);
+    /// let void_type = context.void_type();
+    /// let fn_type = void_type.fn_type(&[], false);
     /// let fn_value = module.add_function("trap", fn_type, None);
     /// let entry = context.append_basic_block(fn_value, "entry");
     ///
-    /// let trap_function = trap_intrinsic.get_declaration(module, &[]).unwrap();
+    /// let trap_function = trap_intrinsic.get_declaration(&module, &[]).unwrap();
     ///
     /// builder.position_at_end(entry);
-    /// builder.build(trap_function, &[], "trap_call");
+    /// builder.build_call(trap_function, &[], "trap_call");
     /// ```
     pub fn find(name: &str) -> Option<Self> {
         let id = unsafe {
@@ -74,21 +75,22 @@ impl Intrinsic {
     ///
     /// # Example
     /// ```no_run
-    /// use inkwell::intrinsics::Intrinsic;
+    /// use inkwell::{intrinsics::Intrinsic, context::Context};
     ///
     /// let trap_intrinsic = Intrinsic::find("llvm.trap").unwrap();
     ///
     /// let context = Context::create();
     /// let module = context.create_module("trap");
     /// let builder = context.create_builder();
-    /// let fn_type = struct_type.fn_type(&[], false);
+    /// let void_type = context.void_type();
+    /// let fn_type = void_type.fn_type(&[], false);
     /// let fn_value = module.add_function("trap", fn_type, None);
     /// let entry = context.append_basic_block(fn_value, "entry");
     ///
-    /// let trap_function = trap_intrinsic.get_declaration(module, &[]).unwrap();
+    /// let trap_function = trap_intrinsic.get_declaration(&module, &[]).unwrap();
     ///
     /// builder.position_at_end(entry);
-    /// builder.build(trap_function, &[], "trap_call");
+    /// builder.build_call(trap_function, &[], "trap_call");
     /// ```
     pub fn get_declaration<'ctx>(&self, module: &Module<'ctx>, param_types: &[BasicTypeEnum]) -> Option<FunctionValue<'ctx>> {
         let mut param_types: Vec<LLVMTypeRef> = param_types.iter()

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,4 +1,4 @@
-#[llvm_versions(8.0..=latest)]
+#[llvm_versions(9.0..=latest)]
 use llvm_sys::core::{LLVMGetIntrinsicDeclaration, LLVMIntrinsicIsOverloaded, LLVMLookupIntrinsicID};
 use llvm_sys::prelude::LLVMTypeRef;
 
@@ -11,6 +11,7 @@ pub struct Intrinsic {
     id: u32,
 }
 
+#[llvm_versions(9.0..=latest)]
 impl Intrinsic {
     // SAFETY: the id is a valid LLVM intrinsic ID
     pub(crate) unsafe fn new(id: u32) -> Self {

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,0 +1,68 @@
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::core::{LLVMGetIntrinsicDeclaration, LLVMIntrinsicIsOverloaded, LLVMLookupIntrinsicID};
+use llvm_sys::prelude::LLVMTypeRef;
+
+use crate::module::Module;
+use crate::types::{AsTypeRef, BasicTypeEnum, FunctionType};
+use crate::values::FunctionValue;
+
+#[derive(Debug)]
+pub struct Intrinsic {
+    id: u32,
+}
+
+impl Intrinsic {
+    // SAFETY: the id is a valid LLVM intrinsic ID
+    pub(crate) unsafe fn new(id: u32) -> Self {
+        Self {
+            id
+        }
+    }
+
+    pub fn find(name: &str) -> Option<Self> {
+        let id = unsafe {
+            LLVMLookupIntrinsicID(name.as_ptr() as *const ::libc::c_char, name.len())
+        };
+
+        if id == 0 {
+            return None;
+        }
+
+        return Some(unsafe {
+            Intrinsic::new(id)
+        });
+    }
+
+    pub fn is_overloaded(&self) -> bool {
+        unsafe {
+            LLVMIntrinsicIsOverloaded(self.id) != 0
+        }
+    }
+
+    pub fn get_declaration<'ctx>(&self, module: &Module<'ctx>, param_types: &[BasicTypeEnum]) -> Option<FunctionValue<'ctx>> {
+        let mut param_types: Vec<LLVMTypeRef> = param_types.iter()
+            .map(|val| val.as_type_ref())
+            .collect();
+
+        // param_types should be empty for non-overloaded intrinsics (I think?)
+        // for overloaded intrinsics they determine the overload used
+
+        if self.is_overloaded() && param_types.is_empty() {
+            // LLVM crashes otherwise
+            return None;
+        }
+
+        let res = unsafe {
+            FunctionValue::new(
+                LLVMGetIntrinsicDeclaration(
+                    module.module.get(),
+                    self.id,
+                    param_types.as_mut_ptr(),
+                    param_types.len()
+                )
+            )
+        };
+
+        res
+    }
+}

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -6,7 +6,7 @@ use crate::module::Module;
 use crate::types::{AsTypeRef, BasicTypeEnum, FunctionType};
 use crate::values::FunctionValue;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Intrinsic {
     id: u32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod passes;
 pub mod targets;
 pub mod types;
 pub mod values;
+pub mod intrinsics;
 
 // Boilerplate to select a desired llvm_sys version at compile & link time.
 #[cfg(feature="llvm3-6")]

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -28,3 +28,4 @@ mod test_targets;
 mod test_tari_example;
 mod test_types;
 mod test_values;
+mod test_intrinsics;

--- a/tests/all/test_intrinsics.rs
+++ b/tests/all/test_intrinsics.rs
@@ -1,0 +1,47 @@
+use inkwell::context::Context;
+use inkwell::intrinsics::Intrinsic;
+
+#[test]
+fn test_get_cos() {
+    Intrinsic::find("llvm.cos").unwrap();
+}
+
+#[test]
+fn test_get_nonexistent() {
+    assert!(Intrinsic::find("nonsense").is_none())
+}
+
+#[test]
+fn test_get_decl_cos() {
+    let cos = Intrinsic::find("llvm.cos").unwrap();
+
+    assert!(cos.is_overloaded());
+
+    let context = Context::create();
+    let module = context.create_module("my_module");
+
+    // overloaded, so we can't get it w/o specifying types
+    assert!(cos.get_declaration(&module, &[]).is_none());
+
+    let decl = cos.get_declaration(&module, &[context.f32_type().into()]).unwrap();
+
+    assert_eq!(decl.get_name().to_str().unwrap(), "llvm.cos.f32");
+}
+
+#[test]
+fn test_get_decl_va_copy() {
+    let va_copy = Intrinsic::find("llvm.va_copy").unwrap();
+
+    assert!(!va_copy.is_overloaded());
+
+    let context = Context::create();
+    let module = context.create_module("my_module");
+
+    assert!(va_copy.get_declaration(&module, &[]).is_some());
+
+    // even though this is nonsensial and ¿might? lead to errors later, we can still get an overloaded version for nonoverloaded intrinsic
+    // this does not assert, which is.. Ok, I guess?
+    let decl = va_copy.get_declaration(&module, &[context.f32_type().into()]).unwrap();
+
+    assert_eq!(decl.get_name().to_str().unwrap(), "llvm.va_copy.f32");
+}

--- a/tests/all/test_intrinsics.rs
+++ b/tests/all/test_intrinsics.rs
@@ -1,16 +1,19 @@
 use inkwell::context::Context;
 use inkwell::intrinsics::Intrinsic;
 
+#[llvm_versions(9.0..=latest)]
 #[test]
 fn test_get_cos() {
     Intrinsic::find("llvm.cos").unwrap();
 }
 
+#[llvm_versions(9.0..=latest)]
 #[test]
 fn test_get_nonexistent() {
     assert!(Intrinsic::find("nonsense").is_none())
 }
 
+#[llvm_versions(9.0..=latest)]
 #[test]
 fn test_get_decl_cos() {
     let cos = Intrinsic::find("llvm.cos").unwrap();
@@ -28,6 +31,7 @@ fn test_get_decl_cos() {
     assert_eq!(decl.get_name().to_str().unwrap(), "llvm.cos.f32");
 }
 
+#[llvm_versions(9.0..=latest)]
 #[test]
 fn test_get_decl_va_copy() {
     let va_copy = Intrinsic::find("llvm.va_copy").unwrap();


### PR DESCRIPTION
## Description

- Add a new type - Intrinsic which acts as a wrapper around intrinsic id. It guarantees that it contains a valid intrinsic id in it
- Add a function Intrinsic::find to safely create instances of Intrinsic
- Add a function Intrinsic::get_declaration which wraps LLVMGetIntrinsicDeclaration and allows getting a declaration of intrinsic in a module

## Related Issue

#300 

## How This Has Been Tested

Written several unit tests covering normal usages and corner-cases that I could think of. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)

Couldn't run clippy, it gives a ton of errors & warnings of code that I didn't write =(

Will write docs if the API gets approved =)
