### PR TITLE
Add a function to build int casts that respect the target signed-ness

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,7 +4,7 @@ use llvm_sys::core::{LLVMBuildAdd, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArray
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMBuildAtomicCmpXchg;
 #[llvm_versions(8.0..=latest)]
-use llvm_sys::core::{LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMemSet};
+use llvm_sys::core::{LLVMBuildIntCast2, LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMemSet};
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 
 use crate::{AtomicOrdering, AtomicRMWBinOp, IntPredicate, FloatPredicate};
@@ -1245,6 +1245,18 @@ impl<'ctx> Builder<'ctx> {
 
         let value = unsafe {
             LLVMBuildIntCast(self.builder, int.as_value_ref(), int_type.as_type_ref(), c_string.as_ptr())
+        };
+
+        T::new(value)
+    }
+
+    /// Like `build_int_cast`, but respects the signedness of the type being cast to.
+    #[llvm_versions(8.0..=latest)]
+    pub fn build_int_cast_sign_flag<T: IntMathValue<'ctx>>(&self, int: T, int_type: T::BaseType, is_signed: bool, name: &str) -> T {
+        let c_string = to_c_str(name);
+
+        let value = unsafe {
+            LLVMBuildIntCast2(self.builder, int.as_value_ref(), int_type.as_type_ref(), is_signed.into(), c_string.as_ptr())
         };
 
         T::new(value)

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -703,6 +703,22 @@ fn test_vector_convert_ops() {
     builder.build_return(Some(&casted_vec));
     assert!(fn_value.verify(true));
 
+    #[llvm_versions(8.0..=latest)]
+    {
+    // Here we're building a function that takes in a <3 x i8> (signed) and returns it casted to and from a <3 x i8> (unsigned)
+    let fn_type = int8_vec_type.fn_type(&[int8_vec_type.into()], false);
+    let fn_value = module.add_function("test_int_vec_cast", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_vector_value();
+    let casted_vec = builder.build_int_cast_sign_flag(in_vec, int8_vec_type, true, "casted_vec");
+    let _uncasted_vec = builder.build_int_cast_sign_flag(casted_vec, int8_vec_type, true, "uncasted_vec");
+    builder.build_return(Some(&casted_vec));
+    assert!(fn_value.verify(true));
+    }
+
     // Here we're building a function that takes in a <3 x f32> and returns it casted to and from a <3 x f16>
     let fn_type = float16_vec_type.fn_type(&[float32_vec_type.into()], false);
     let fn_value = module.add_function("test_float_vec_cast", fn_type, None);


### PR DESCRIPTION
The current `build_int_cast` uses `LLVMBuildIntCast`, which is [always
signed and is deprecated](https://github.com/hdoc/llvm-project/blob/a6ad3505abc7409abd2a4118338b9c85ec2e9f09/llvm/include/llvm-c/Core.h#L3939-L3941).
This commit adds a function that uses `LLVMBuildIntCast2`, which
correctly casts ints to unsigned int types if asked to do so.
