### PR TITLE
Add the runpasses option to the module

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -14,6 +14,10 @@ use llvm_sys::prelude::{LLVMModuleRef, LLVMValueRef};
 use llvm_sys::LLVMLinkage;
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMModuleFlagBehavior;
+#[llvm_versions(13.0..=latest)]
+use llvm_sys::transforms::pass_builder::LLVMRunPasses;
+#[llvm_versions(8.0..=latest)]
+use llvm_sys::error::LLVMGetErrorMessage;
 
 use std::cell::{Cell, RefCell, Ref};
 use std::ffi::CStr;
@@ -34,11 +38,13 @@ use crate::debug_info::{DebugInfoBuilder, DICompileUnit, DWARFEmissionKind, DWAR
 use crate::execution_engine::ExecutionEngine;
 use crate::memory_buffer::MemoryBuffer;
 use crate::support::{to_c_str, LLVMString};
-use crate::targets::{InitializationConfig, Target, TargetTriple};
+use crate::targets::{InitializationConfig, Target, TargetTriple, TargetMachine};
 use crate::types::{AsTypeRef, BasicType, FunctionType, StructType};
 use crate::values::{AsValueRef, FunctionValue, GlobalValue, MetadataValue};
 #[llvm_versions(7.0..=latest)]
 use crate::values::BasicValue;
+#[llvm_versions(13.0..=latest)]
+use crate::passes::PassBuilderOptions;
 
 #[llvm_enum(LLVMLinkage)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -1399,6 +1405,27 @@ impl<'ctx> Module<'ctx> {
                               #[cfg(any(feature = "llvm11-0", feature = "llvm12-0", feature = "llvm13-0"))]
                               sdk
         )
+    }
+
+
+    /// Construct and run a set of passes over a module.
+    /// This function takes a string with the passes that should be used. 
+    /// The format of this string is the same as opt's -passes argument for the new pass manager. 
+    /// Individual passes may be specified, separated by commas. 
+    /// Full pipelines may also be invoked using default<O3> and friends. 
+    /// See opt for full reference of the Passes format.
+    #[llvm_versions(13.0..=latest)]
+    pub fn run_passes(&self, passes : &str, machine : &TargetMachine, options : PassBuilderOptions) -> Result<(), LLVMString> {
+        unsafe {
+            let error = LLVMRunPasses(self.module.get(), to_c_str(passes).as_ptr(), machine.target_machine , options.options_ref);
+            if error == std::ptr::null_mut() {
+                Ok(())
+            } else {
+                let message = LLVMGetErrorMessage(error);
+                Err(LLVMString::new(message as *const libc::c_char))
+            }
+        }
+
     }
 }
 

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -19,6 +19,18 @@ use llvm_sys::transforms::scalar::LLVMAddConstantPropagationPass;
 
 #[llvm_versions(12.0..=latest)]
 use llvm_sys::transforms::scalar::LLVMAddInstructionSimplifyPass;
+#[llvm_versions(13.0..=latest)]
+use llvm_sys::transforms::pass_builder::{LLVMPassBuilderOptionsRef,LLVMCreatePassBuilderOptions,LLVMPassBuilderOptionsSetVerifyEach,LLVMPassBuilderOptionsSetDebugLogging,
+LLVMPassBuilderOptionsSetLoopInterleaving,
+LLVMPassBuilderOptionsSetLoopVectorization,
+LLVMPassBuilderOptionsSetSLPVectorization,
+LLVMPassBuilderOptionsSetLoopUnrolling,
+LLVMPassBuilderOptionsSetForgetAllSCEVInLoopUnroll,
+LLVMPassBuilderOptionsSetLicmMssaOptCap,
+LLVMPassBuilderOptionsSetLicmMssaNoAccForPromotionCap,
+LLVMPassBuilderOptionsSetCallGraphProfile,
+LLVMPassBuilderOptionsSetMergeFunctions,
+LLVMDisposePassBuilderOptions};
 
 use crate::OptimizationLevel;
 use crate::module::Module;
@@ -1267,6 +1279,101 @@ impl PassRegistry {
 
         unsafe {
             LLVMInitializeAggressiveInstCombiner(self.pass_registry)
+        }
+    }
+}
+
+#[llvm_versions(13.0..=latest)]
+#[derive(Debug)]
+pub struct PassBuilderOptions {
+    pub(crate) options_ref : LLVMPassBuilderOptionsRef,
+}
+
+#[llvm_versions(13.0..=latest)]
+impl PassBuilderOptions {
+    /// Create a new set of options for a PassBuilder
+    pub fn create() -> Self{
+        unsafe {
+            PassBuilderOptions {
+                options_ref : LLVMCreatePassBuilderOptions(),
+            }
+        }
+    }
+
+    ///Toggle adding the VerifierPass for the PassBuilder, ensuring all functions inside the module is valid. 
+    pub fn set_verify_each(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetVerifyEach(self.options_ref, value as i32);
+        }
+    }
+
+    ///Toggle debug logging when running the PassBuilder. 
+    pub fn set_debug_logging(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetDebugLogging(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_loop_interleaving(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetLoopInterleaving(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_loop_vectorization(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetLoopVectorization(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_loop_slp_vectorization(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetSLPVectorization(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_loop_unrolling(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetLoopUnrolling(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_forget_all_scev_in_loop_unroll(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetForgetAllSCEVInLoopUnroll(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_licm_mssa_opt_cap(&self, value : u32) {
+        unsafe {
+            LLVMPassBuilderOptionsSetLicmMssaOptCap(self.options_ref, value);
+        }
+    }
+
+    pub fn set_licm_mssa_no_acc_for_promotion_cap(&self, value : u32) {
+        unsafe {
+            LLVMPassBuilderOptionsSetLicmMssaNoAccForPromotionCap(self.options_ref, value);
+        }
+    }
+
+    pub fn set_call_graph_profile(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetCallGraphProfile(self.options_ref, value as i32);
+        }
+    }
+
+    pub fn set_merge_functions(&self, value : bool) {
+        unsafe {
+            LLVMPassBuilderOptionsSetMergeFunctions(self.options_ref, value as i32);
+        }
+    }
+}
+
+#[llvm_versions(13.0..=latest)]
+impl Drop for PassBuilderOptions {
+    fn drop(&mut self) {
+        unsafe {
+            LLVMDisposePassBuilderOptions(self.options_ref);
         }
     }
 }


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description
Added a method to the `Module` to run the llvm passes

## Related Issue
Issue #309 

## How This Has Been Tested
I tested this on a separate project.
I am not sure what kind of tests I could add to the module here, suggestions are appreciated.
The change only applies from LLVM13, as the API was introduced then, the feature flags are set appropriately

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
