### PR TITLE
Get all function/callsite attributes as a vector

### DIFF
--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -210,6 +210,56 @@ impl<'ctx> CallSiteValue<'ctx> {
         }
     }
 
+    /// Get all `Attribute`s on this `CallSiteValue` at an index.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::attributes::AttributeLoc;
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let builder = context.create_builder();
+    /// let module = context.create_module("my_mod");
+    /// let void_type = context.void_type();
+    /// let fn_type = void_type.fn_type(&[], false);
+    /// let fn_value = module.add_function("my_fn", fn_type, None);
+    /// let string_attribute = context.create_string_attribute("my_key", "my_val");
+    /// let enum_attribute = context.create_enum_attribute(1, 1);
+    /// let entry_bb = context.append_basic_block(fn_value, "entry");
+    ///
+    /// builder.position_at_end(entry_bb);
+    ///
+    /// let call_site_value = builder.build_call(fn_value, &[], "my_fn");
+    ///
+    /// call_site_value.add_attribute(AttributeLoc::Return, string_attribute);
+    /// call_site_value.add_attribute(AttributeLoc::Return, enum_attribute);
+    ///
+    /// assert_eq!(call_site_value.attributes(AttributeLoc::Return), vec![ string_attribute, enum_attribute ]);
+    /// ```
+    #[llvm_versions(3.9..=latest)]
+    pub fn attributes(self, loc: AttributeLoc) -> Vec<Attribute> {
+        use llvm_sys::core::LLVMGetCallSiteAttributes;
+        use std::mem::MaybeUninit;
+
+        let count = self.count_attributes(loc) as usize;
+
+        // initialize a vector, but leave each element uninitialized
+        let mut attribute_refs: Vec<MaybeUninit<Attribute>> = vec![MaybeUninit::uninit(); count];
+
+        // Safety: relies on `Attribute` having the same in-memory representation as `LLVMAttributeRef`
+        unsafe {
+            LLVMGetCallSiteAttributes(
+                self.as_value_ref(),
+                loc.get_index(),
+                attribute_refs.as_mut_ptr() as *mut _,
+            )
+        }
+
+        // Safety: everything is initialized
+        unsafe { std::mem::transmute(attribute_refs) }
+    }
+
     /// Gets an enum `Attribute` on this `CallSiteValue` at an index and kind id.
     ///
     /// # Example

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -361,6 +361,50 @@ impl<'ctx> FunctionValue<'ctx> {
         }
     }
 
+    /// Get all `Attribute`s belonging to the specified location in this `FunctionValue`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::attributes::AttributeLoc;
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let module = context.create_module("my_mod");
+    /// let void_type = context.void_type();
+    /// let fn_type = void_type.fn_type(&[], false);
+    /// let fn_value = module.add_function("my_fn", fn_type, None);
+    /// let string_attribute = context.create_string_attribute("my_key", "my_val");
+    /// let enum_attribute = context.create_enum_attribute(1, 1);
+    ///
+    /// fn_value.add_attribute(AttributeLoc::Return, string_attribute);
+    /// fn_value.add_attribute(AttributeLoc::Return, enum_attribute);
+    ///
+    /// assert_eq!(fn_value.attributes(AttributeLoc::Return), vec![ string_attribute, enum_attribute ]);
+    /// ```
+    #[llvm_versions(3.9..=latest)]
+    pub fn attributes(self, loc: AttributeLoc) -> Vec<Attribute> {
+        use llvm_sys::core::LLVMGetAttributesAtIndex;
+        use std::mem::MaybeUninit;
+
+        let count = self.count_attributes(loc) as usize;
+
+        // initialize a vector, but leave each element uninitialized
+        let mut attribute_refs: Vec<MaybeUninit<Attribute>> = vec![MaybeUninit::uninit(); count];
+
+        // Safety: relies on `Attribute` having the same in-memory representation as `LLVMAttributeRef`
+        unsafe {
+            LLVMGetAttributesAtIndex(
+                self.as_value_ref(),
+                loc.get_index(),
+                attribute_refs.as_mut_ptr() as *mut _,
+            )
+        }
+
+        // Safety: everything is initialized
+        unsafe { std::mem::transmute(attribute_refs) }
+    }
+
     /// Removes a string `Attribute` belonging to the specified location in this `FunctionValue`.
     ///
     /// # Example

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -152,6 +152,8 @@ fn test_attributes_on_call_site_values() {
     assert_eq!(call_site_value.count_arguments(), 1);
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 0);
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Param(0)), 0);
+    assert_eq!(call_site_value.attributes(AttributeLoc::Return), vec![]);
+    assert_eq!(call_site_value.attributes(AttributeLoc::Param(0)), vec![]);
 
     call_site_value.remove_string_attribute(AttributeLoc::Return, "my_key"); // Noop
     call_site_value.remove_enum_attribute(AttributeLoc::Return, alignstack_attribute); // Noop
@@ -164,14 +166,17 @@ fn test_attributes_on_call_site_values() {
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 2);
     assert_eq!(call_site_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute), Some(enum_attribute));
     assert_eq!(call_site_value.get_string_attribute(AttributeLoc::Return, "my_key"), Some(string_attribute));
+    assert_eq!(call_site_value.attributes(AttributeLoc::Return), vec![enum_attribute, string_attribute]);
 
     call_site_value.remove_string_attribute(AttributeLoc::Return, "my_key");
 
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 1);
+    assert_eq!(call_site_value.attributes(AttributeLoc::Return), vec![enum_attribute]);
 
     call_site_value.remove_enum_attribute(AttributeLoc::Return, alignstack_attribute);
 
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 0);
+    assert_eq!(call_site_value.attributes(AttributeLoc::Return), vec![]);
     assert!(call_site_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute).is_none());
     assert!(call_site_value.get_string_attribute(AttributeLoc::Return, "my_key").is_none());
     assert_eq!(call_site_value.get_called_fn_value(), fn_value);
@@ -179,5 +184,6 @@ fn test_attributes_on_call_site_values() {
     call_site_value.set_alignment_attribute(AttributeLoc::Return, 16);
 
     assert_eq!(call_site_value.count_attributes(AttributeLoc::Return), 1);
+    assert_eq!(call_site_value.attributes(AttributeLoc::Return).len(), 1);
     assert!(call_site_value.get_enum_attribute(AttributeLoc::Return, align_attribute).is_some());
 }

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -97,6 +97,8 @@ fn test_attributes_on_function_values() {
 
     assert_eq!(fn_value.count_attributes(AttributeLoc::Return), 0);
     assert_eq!(fn_value.count_attributes(AttributeLoc::Param(0)), 0);
+    assert_eq!(fn_value.attributes(AttributeLoc::Return), vec![]);
+    assert_eq!(fn_value.attributes(AttributeLoc::Param(0)), vec![]);
 
     fn_value.remove_string_attribute(AttributeLoc::Return, "my_key"); // Noop
     fn_value.remove_enum_attribute(AttributeLoc::Return, alignstack_attribute); // Noop
@@ -109,10 +111,12 @@ fn test_attributes_on_function_values() {
     assert_eq!(fn_value.count_attributes(AttributeLoc::Return), 2);
     assert_eq!(fn_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute), Some(enum_attribute));
     assert_eq!(fn_value.get_string_attribute(AttributeLoc::Return, "my_key"), Some(string_attribute));
+    assert_eq!(fn_value.attributes(AttributeLoc::Return), vec![enum_attribute, string_attribute]);
 
     fn_value.remove_string_attribute(AttributeLoc::Return, "my_key");
 
     assert_eq!(fn_value.count_attributes(AttributeLoc::Return), 1);
+    assert_eq!(fn_value.attributes(AttributeLoc::Return), vec![enum_attribute]);
 
     fn_value.remove_enum_attribute(AttributeLoc::Return, alignstack_attribute);
 
@@ -120,6 +124,8 @@ fn test_attributes_on_function_values() {
     assert_eq!(fn_value.count_attributes(AttributeLoc::Return), 0);
     assert!(fn_value.get_enum_attribute(AttributeLoc::Return, alignstack_attribute).is_none());
     assert!(fn_value.get_string_attribute(AttributeLoc::Return, "my_key").is_none());
+    assert_eq!(fn_value.attributes(AttributeLoc::Function), vec![]);
+    assert_eq!(fn_value.attributes(AttributeLoc::Return), vec![]);
 }
 
 #[test]


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

Add functions to `FunctionValue` and `CallSiteValue` that give back a vector with all attributes at a particular location on that value.

## Description

<!--- Describe your changes in detail -->

LLVM primitives have existed since llvm 3.9. The tricky bit here is that we need to give LLVM a pointer that it writes the attributes into. This requires `MaybeUninit` to do safely. Afterwards we transmute the `MaybeUninit` away (the alternative would create a second vector which is undesirable).

## How This Has Been Tested

Testing is done similarly to the `count_attributes` functions. We check the attributes we get back are as expected after adding/removing attributes.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)

---

as an aside: following the standard `cargo fmt` formatting rules would make contributing much easier/fun for me.