### PR TITLE
make get_enum_kind_id work on type attributes

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -124,6 +124,25 @@ impl Attribute {
     ///
     /// assert_eq!(enum_attribute.get_enum_kind_id(), 0);
     /// ```
+    #[llvm_versions(3.6..12.0)]
+    pub fn get_enum_kind_id(self) -> u32 {
+        assert!(self.get_enum_kind_id_is_valid()); // FIXME: SubTypes
+
+        unsafe { LLVMGetEnumAttributeKind(self.attribute) }
+    }
+
+    /// Gets the kind id associated with an enum `Attribute`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let enum_attribute = context.create_enum_attribute(0, 10);
+    ///
+    /// assert_eq!(enum_attribute.get_enum_kind_id(), 0);
+    /// ```
     ///
     /// This function also works for type `Attribute`s.
     ///
@@ -142,6 +161,7 @@ impl Attribute {
     ///
     /// assert_eq!(type_attribute.get_enum_kind_id(), kind_id);
     /// ```
+    #[llvm_versions(12.0..=latest)]
     pub fn get_enum_kind_id(self) -> u32 {
         assert!(self.get_enum_kind_id_is_valid()); // FIXME: SubTypes
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -140,12 +140,22 @@ impl Attribute {
     ///     any_type,
     /// );
     ///
-    /// assert_eq!(type_attribute.get_type_kind_id(), kind_id);
+    /// assert_eq!(type_attribute.get_enum_kind_id(), kind_id);
     /// ```
     pub fn get_enum_kind_id(self) -> u32 {
-        assert!(self.is_enum() || self.is_type()); // FIXME: SubTypes
+        assert!(self.get_enum_kind_id_is_valid()); // FIXME: SubTypes
 
         unsafe { LLVMGetEnumAttributeKind(self.attribute) }
+    }
+
+    #[llvm_versions(3.6..12.0)]
+    fn get_enum_kind_id_is_valid(self) -> bool {
+        self.is_enum()
+    }
+
+    #[llvm_versions(12.0..=latest)]
+    fn get_enum_kind_id_is_valid(self) -> bool {
+        self.is_enum() || self.is_type()
     }
 
     /// Gets the last enum kind id associated with builtin names.

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -124,8 +124,26 @@ impl Attribute {
     ///
     /// assert_eq!(enum_attribute.get_enum_kind_id(), 0);
     /// ```
+    ///
+    /// This function also works for type `Attribute`s.
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::attributes::Attribute;
+    /// use inkwell::types::AnyType;
+    ///
+    /// let context = Context::create();
+    /// let kind_id = Attribute::get_named_enum_kind_id("sret");
+    /// let any_type = context.i32_type().as_any_type_enum();
+    /// let type_attribute = context.create_type_attribute(
+    ///     kind_id,
+    ///     any_type,
+    /// );
+    ///
+    /// assert_eq!(type_attribute.get_type_kind_id(), kind_id);
+    /// ```
     pub fn get_enum_kind_id(self) -> u32 {
-        assert!(self.is_enum()); // FIXME: SubTypes
+        assert!(self.is_enum() || self.is_type()); // FIXME: SubTypes
 
         unsafe { LLVMGetEnumAttributeKind(self.attribute) }
     }

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -332,7 +332,6 @@ impl<'ctx> IntType<'ctx> {
         self.int_type.print_to_string()
     }
 
-
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]

--- a/src/types/metadata_type.rs
+++ b/src/types/metadata_type.rs
@@ -57,7 +57,6 @@ impl<'ctx> MetadataType<'ctx> {
         self.metadata_type.get_context()
     }
 
-
     /// Print the definition of a `MetadataType` to `LLVMString`.
     pub fn print_to_string(self) -> LLVMString {
         self.metadata_type.print_to_string()
@@ -75,7 +74,6 @@ impl AsTypeRef for MetadataType<'_> {
         unimplemented!("MetadataType is only available in LLVM > 6.0")
     }
 }
-
 
 impl Display for MetadataType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -298,7 +298,6 @@ impl AsTypeRef for PointerType<'_> {
     }
 }
 
-
 impl Display for PointerType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.print_to_string())

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -10,7 +10,7 @@ use crate::values::{
     FunctionValue, GlobalValue, InstructionValue, IntValue, PhiValue, PointerValue, StructValue, Value, VectorValue,
 };
 
-use super::{MetadataValue, BasicMetadataValueEnum};
+use super::{BasicMetadataValueEnum, MetadataValue};
 
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -20,12 +20,12 @@ mod test_context;
 )))]
 mod test_debug_info;
 mod test_execution_engine;
+mod test_instruction_conversion;
 mod test_instruction_values;
 mod test_intrinsics;
 mod test_module;
 mod test_object_file;
 mod test_passes;
-mod test_instruction_conversion;
 mod test_targets;
 mod test_tari_example;
 mod test_types;


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

remove an assert that makes `get_enum_kind_id` panic when given a type attribute. 

I'm not entirely sure what the difference is between enum and type attributes. It looks like enum is a superclass. By default they have integer values, but since version 12.0 they can also have type as the value. And then some specific functions are added for type attributes, but specifically the kind ID is still only available with the "enum" functions, e.g. `get_named_enum_kind_id`.

So the choice I made here is that inkwell should give the same answer as LLVM for a type attribute, rather than panicking.

An alternative is to add a new function `get_type_kind_id` which has the same implementation as `get_enum_kind_id` and would assert that `attribute.is_type()`.

Finally, some docs in the module hint at a more radical change in how inkwell represents attributes. 

> Determines whether or not an `Attribute` is an enum. This method will
> likely be removed in the future in favor of `Attribute`s being generically
> defined.

Does that allude to attributes as described here https://llvm.org/docs/HowToUseAttributes.html? or is this some different idea?
## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
