### PR TITLE
Add API to set a section for function values

### DIFF
--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -1,5 +1,5 @@
 use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyFunction, LLVMViewFunctionCFG, LLVMViewFunctionCFGOnly};
-use llvm_sys::core::{LLVMIsAFunction, LLVMIsConstant, LLVMGetLinkage, LLVMGetPreviousFunction, LLVMGetNextFunction, LLVMGetParam, LLVMCountParams, LLVMGetLastParam, LLVMCountBasicBlocks, LLVMGetFirstParam, LLVMGetNextParam, LLVMGetBasicBlocks, LLVMDeleteFunction, LLVMGetLastBasicBlock, LLVMGetFirstBasicBlock, LLVMGetIntrinsicID, LLVMGetFunctionCallConv, LLVMSetFunctionCallConv, LLVMGetGC, LLVMSetGC, LLVMSetLinkage, LLVMSetParamAlignment, LLVMGetParams};
+use llvm_sys::core::{LLVMIsAFunction, LLVMIsConstant, LLVMGetLinkage, LLVMGetPreviousFunction, LLVMGetNextFunction, LLVMGetParam, LLVMCountParams, LLVMGetLastParam, LLVMCountBasicBlocks, LLVMGetFirstParam, LLVMGetNextParam, LLVMGetBasicBlocks, LLVMDeleteFunction, LLVMGetLastBasicBlock, LLVMGetFirstBasicBlock, LLVMGetIntrinsicID, LLVMGetFunctionCallConv, LLVMSetFunctionCallConv, LLVMGetGC, LLVMSetGC, LLVMSetLinkage, LLVMSetParamAlignment, LLVMGetParams, LLVMSetSection};
 #[llvm_versions(3.7..=latest)]
 use llvm_sys::core::{LLVMGetPersonalityFn, LLVMSetPersonalityFn};
 #[llvm_versions(3.9..=latest)]
@@ -570,6 +570,15 @@ impl<'ctx> FunctionValue<'ctx> {
                 metadata_ref,
                 _marker: PhantomData,
             })
+        }
+    }
+
+    /// Set the section to which this function should belong
+    pub fn set_section(self, section: &str) {
+        let c_string = to_c_str(section);
+
+        unsafe {
+            LLVMSetSection(self.as_value_ref(), c_string.as_ptr())
         }
     }
 }

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -87,6 +87,15 @@ fn test_section_iterator() {
     gv_c.set_initializer(&context.i32_type().const_zero().as_basic_value_enum());
     gv_c.set_section("C");
 
+    let func = module.add_function("d", context.void_type().fn_type(&[], false), None);
+    func.set_section("D");
+
+    // add a body to the function to make the section non-empty
+    let basic_block = context.append_basic_block(func, "entry");
+    let builder = context.create_builder();
+    builder.position_at_end(basic_block);
+    builder.build_return(None);
+
     apply_target_to_module(&target_machine, &module);
 
     let memory_buffer = target_machine
@@ -97,6 +106,7 @@ fn test_section_iterator() {
     let mut has_section_a = false;
     let mut has_section_b = false;
     let mut has_section_c = false;
+    let mut has_section_d = false;
     for section in object_file.get_sections() {
         if let Some(name) = section.get_name() {
             match name.to_str().unwrap() {
@@ -115,6 +125,11 @@ fn test_section_iterator() {
                     has_section_c = true;
                     assert_eq!(section.size(), 4);
                 }
+                "D" => {
+                    assert!(!has_section_d);
+                    has_section_d = true;
+                    assert_eq!(section.size(), 1);
+                }
                 _ => {}
             }
         }
@@ -122,6 +137,7 @@ fn test_section_iterator() {
     assert!(has_section_a);
     assert!(has_section_b);
     assert!(has_section_c);
+    assert!(has_section_d);
 }
 
 #[test]


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Currently, it's only possible to set sections for `GlobalValue`s. In certain cases (e.g., for BPF programs) you need to set specific sections for functions too. This PR adds the corresponding public API for `FunctionValue`.

<!--- Describe your changes in detail -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
