### PR TITLE
API to get type of InstructionValue

### DIFF
--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -9,7 +9,7 @@ use llvm_sys::core::{LLVMIsAAtomicRMWInst, LLVMIsAAtomicCmpXchgInst};
 use llvm_sys::LLVMOpcode;
 use llvm_sys::prelude::LLVMValueRef;
 
-use crate::basic_block::BasicBlock;
+use crate::{basic_block::BasicBlock, types::AnyTypeEnum};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, Value, MetadataValue};
 use crate::{AtomicOrdering, IntPredicate, FloatPredicate};
@@ -134,6 +134,11 @@ impl<'ctx> InstructionValue<'ctx> {
         InstructionValue {
             instruction_value: value,
         }
+    }
+
+    /// Get type of the current InstructionValue
+    pub fn get_type(self) -> AnyTypeEnum<'ctx> {
+        unsafe { AnyTypeEnum::new(self.instruction_value.get_type()) }
     }
 
     pub fn get_opcode(self) -> InstructionOpcode {

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -1,4 +1,5 @@
 use inkwell::context::Context;
+use inkwell::types::AnyTypeEnum;
 use inkwell::values::{BasicValue, InstructionOpcode::*};
 use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
 
@@ -236,6 +237,11 @@ fn test_instructions() {
     assert_eq!(fcmp.as_instruction().unwrap().get_fcmp_predicate().unwrap(), FloatPredicate::OEQ);
     assert_eq!(free_instruction.get_opcode(), Call);
     assert_eq!(return_instruction.get_opcode(), Return);
+
+    // test instruction type
+    assert_eq!(store_instruction.get_type(), AnyTypeEnum::from(void_type));
+    assert_eq!(free_instruction.get_type(), AnyTypeEnum::from(void_type));
+    assert_eq!(f32_sum.as_instruction().unwrap().get_type(), AnyTypeEnum::from(f32_type));
 
     // test instruction cloning
     let instruction_clone = return_instruction.clone();


### PR DESCRIPTION
## Description

I added a new function to the `InstructionValue` module to get type of an instruction.

## Related Issue

https://github.com/TheDan64/inkwell/issues/321

## How This Has Been Tested

I created unit tests and tested them with LLVM 13.0 under a Linux environment.

## Option\<Breaking Changes\>

N/A

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
