### PR TITLE
Fix warnings by removing unused imports

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1055,7 +1055,7 @@ impl<'ctx> ContextRef<'ctx> {
         }
     }
 
-    /// Gets a usable context object with a correct lifetime.
+    // /// Gets a usable context object with a correct lifetime.
     // FIXME: Not safe :(
     // #[cfg(feature = "experimental")]
     // pub unsafe fn get(&self) -> &'ctx Context {

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -3,7 +3,7 @@ use llvm_sys::core::{LLVMGetIntrinsicDeclaration, LLVMIntrinsicIsOverloaded, LLV
 use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::module::Module;
-use crate::types::{AsTypeRef, BasicTypeEnum, FunctionType};
+use crate::types::{AsTypeRef, BasicTypeEnum};
 use crate::values::FunctionValue;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -8,7 +8,6 @@ use crate::types::{ArrayType, FloatType, FunctionType, IntType, PointerType, Str
 use crate::values::{BasicValue, BasicValueEnum, IntValue};
 
 use std::convert::TryFrom;
-use std::iter::FromIterator;
 
 macro_rules! enum_type_set {
     ($(#[$enum_attrs:meta])* $enum_name:ident: { $($(#[$variant_attrs:meta])* $args:ident,)+ }) => (

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -5,7 +5,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use crate::context::ContextRef;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, BasicTypeEnum, FunctionType, PointerType, Type, VectorType};
+use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
 use crate::values::{ArrayValue, AsValueRef, FloatValue, GenericValue, IntValue};
 use crate::AddressSpace;
 

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -7,7 +7,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, BasicTypeEnum, FunctionType, PointerType, Type, VectorType};
+use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
 use crate::values::{ArrayValue, AsValueRef, GenericValue, IntValue};
 use crate::AddressSpace;
 

--- a/src/types/metadata_type.rs
+++ b/src/types/metadata_type.rs
@@ -3,8 +3,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 use crate::context::ContextRef;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, BasicTypeEnum, FunctionType, Type, VectorType};
-use crate::values::{IntValue, MetadataValue};
+use crate::types::{FunctionType, Type};
 
 /// A `MetadataType` is the type of a metadata.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -3,7 +3,7 @@ use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
 use crate::types::traits::AsTypeRef;
-use crate::types::{AnyTypeEnum, ArrayType, BasicTypeEnum, FunctionType, Type, VectorType};
+use crate::types::{AnyTypeEnum, ArrayType, FunctionType, Type, VectorType};
 use crate::values::{ArrayValue, AsValueRef, IntValue, PointerValue};
 use crate::AddressSpace;
 

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -3,7 +3,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 use crate::context::ContextRef;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
-use crate::types::{BasicTypeEnum, FunctionType, Type};
+use crate::types::{FunctionType, Type};
 
 /// A `VoidType` is a special type with no possible direct instances. It's only
 /// useful as a function return type.

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -1227,7 +1227,7 @@ fn test_bitcast() {
 
     builder.build_return(None);
 
-    assert!(module.verify().is_ok(), module.print_to_string().to_string());
+    assert!(module.verify().is_ok(), "{}", module.print_to_string().to_string());
 
     let first_iv = cast.as_instruction_value().unwrap();
 

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -412,6 +412,7 @@ fn test_global_expressions() {
     // therefore, it's currently not possible to test that the data was set without generating the IR
     assert!(
         gv.print_to_string().to_string().contains("!dbg"),
-        format!("expected !dbg but generated gv was {}", gv.print_to_string())
+        "expected !dbg but generated gv was {}",
+        gv.print_to_string()
     );
 }

--- a/tests/all/test_phi_conversion.rs
+++ b/tests/all/test_phi_conversion.rs
@@ -1,8 +1,7 @@
 use std::convert::TryInto;
 
 use inkwell::context::Context;
-use inkwell::values::{BasicValue, BasicValueEnum, InstructionOpcode::*, InstructionValue, PhiValue};
-use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
+use inkwell::values::PhiValue;
 
 #[test]
 fn test_phi_conversion() {


### PR DESCRIPTION
## Description

Fix warnings by removing unused imports.
Also fixes the build error that's caused by an unused doc comment.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
