### PR TITLE
print LLVM Types to LLVMString and implement Display trait

### DIFF
--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -2,11 +2,14 @@ use llvm_sys::core::{LLVMConstArray, LLVMGetArrayLength};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{BasicTypeEnum, FunctionType, PointerType, Type};
 use crate::values::{ArrayValue, AsValueRef, IntValue};
 use crate::AddressSpace;
+
+use std::fmt::{self, Display};
 
 /// An `ArrayType` is the type of contiguous constants or variables.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -185,6 +188,11 @@ impl<'ctx> ArrayType<'ctx> {
         unsafe { LLVMGetArrayLength(self.as_type_ref()) }
     }
 
+    /// Print the definition of an `ArrayType` to `LLVMString`
+    pub fn print_to_string(self) -> LLVMString {
+        self.array_type.print_to_string()
+    }
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `ArrayType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -231,5 +239,11 @@ impl<'ctx> ArrayType<'ctx> {
 impl AsTypeRef for ArrayType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.array_type.ty
+    }
+}
+
+impl Display for ArrayType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -2,12 +2,14 @@ use llvm_sys::core::LLVMGetTypeKind;
 use llvm_sys::prelude::LLVMTypeRef;
 use llvm_sys::LLVMTypeKind;
 
+use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::MetadataType;
 use crate::types::{ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, VectorType, VoidType};
 use crate::values::{BasicValue, BasicValueEnum, IntValue};
 
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
 
 macro_rules! enum_type_set {
     ($(#[$enum_attrs:meta])* $enum_name:ident: { $($(#[$variant_attrs:meta])* $args:ident,)+ }) => (
@@ -185,6 +187,19 @@ impl<'ctx> BasicMetadataTypeEnum<'ctx> {
     pub fn is_vector_type(self) -> bool {
         matches!(self, BasicMetadataTypeEnum::VectorType(_))
     }
+
+    /// Print the definition of a `BasicMetadataTypeEnum` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        match self {
+            BasicMetadataTypeEnum::ArrayType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::IntType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::FloatType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::PointerType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::StructType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::VectorType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::MetadataType(t) => t.print_to_string(),
+        }
+    }
 }
 
 impl<'ctx> AnyTypeEnum<'ctx> {
@@ -340,6 +355,20 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             AnyTypeEnum::FunctionType(_) => None,
         }
     }
+
+    /// Print the definition of a `AnyTypeEnum` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        match self {
+            AnyTypeEnum::ArrayType(t) => t.print_to_string(),
+            AnyTypeEnum::FloatType(t) => t.print_to_string(),
+            AnyTypeEnum::IntType(t) => t.print_to_string(),
+            AnyTypeEnum::PointerType(t) => t.print_to_string(),
+            AnyTypeEnum::StructType(t) => t.print_to_string(),
+            AnyTypeEnum::VectorType(t) => t.print_to_string(),
+            AnyTypeEnum::VoidType(t) => t.print_to_string(),
+            AnyTypeEnum::FunctionType(t) => t.print_to_string(),
+        }
+    }
 }
 
 impl<'ctx> BasicTypeEnum<'ctx> {
@@ -477,6 +506,18 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             BasicTypeEnum::VectorType(ty) => ty.const_zero().as_basic_value_enum(),
         }
     }
+
+    /// Print the definition of a `BasicTypeEnum` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        match self {
+            BasicTypeEnum::ArrayType(t) => t.print_to_string(),
+            BasicTypeEnum::FloatType(t) => t.print_to_string(),
+            BasicTypeEnum::IntType(t) => t.print_to_string(),
+            BasicTypeEnum::PointerType(t) => t.print_to_string(),
+            BasicTypeEnum::StructType(t) => t.print_to_string(),
+            BasicTypeEnum::VectorType(t) => t.print_to_string(),
+        }
+    }
 }
 
 impl<'ctx> TryFrom<AnyTypeEnum<'ctx>> for BasicTypeEnum<'ctx> {
@@ -505,5 +546,23 @@ impl<'ctx> From<BasicTypeEnum<'ctx>> for BasicMetadataTypeEnum<'ctx> {
             BasicTypeEnum::StructType(st) => st.into(),
             BasicTypeEnum::VectorType(vt) => vt.into(),
         }
+    }
+}
+
+impl Display for AnyTypeEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}
+
+impl Display for BasicTypeEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}
+
+impl Display for BasicMetadataTypeEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -3,11 +3,14 @@ use llvm_sys::execution_engine::LLVMCreateGenericValueOfFloat;
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
 use crate::values::{ArrayValue, AsValueRef, FloatValue, GenericValue, IntValue};
 use crate::AddressSpace;
+
+use std::fmt::{self, Display};
 
 /// A `FloatType` is the type of a floating point constant or variable.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -214,6 +217,11 @@ impl<'ctx> FloatType<'ctx> {
         self.float_type.ptr_type(address_space)
     }
 
+    /// Print the definition of a `FloatType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.float_type.print_to_string()
+    }
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -271,5 +279,11 @@ impl<'ctx> FloatType<'ctx> {
 impl AsTypeRef for FloatType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.float_type.ty
+    }
+}
+
+impl Display for FloatType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -4,10 +4,11 @@ use llvm_sys::core::{
 use llvm_sys::prelude::LLVMTypeRef;
 use llvm_sys::LLVMTypeKind;
 
-use std::fmt;
+use std::fmt::{self, Display};
 use std::mem::forget;
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{AnyType, BasicTypeEnum, PointerType, Type};
 use crate::AddressSpace;
@@ -152,6 +153,11 @@ impl<'ctx> FunctionType<'ctx> {
         self.fn_type.get_context()
     }
 
+    /// Print the definition of a `FunctionType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.fn_type.print_to_string()
+    }
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -207,5 +213,11 @@ impl fmt::Debug for FunctionType<'_> {
 impl AsTypeRef for FunctionType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.fn_type.ty
+    }
+}
+
+impl Display for FunctionType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -6,6 +6,7 @@ use llvm_sys::execution_engine::LLVMCreateGenericValueOfInt;
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
 use crate::values::{ArrayValue, AsValueRef, GenericValue, IntValue};
@@ -13,6 +14,7 @@ use crate::AddressSpace;
 
 use crate::types::enums::BasicMetadataTypeEnum;
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
 
 /// How to interpret a string or digits used to construct an integer constant.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -325,6 +327,12 @@ impl<'ctx> IntType<'ctx> {
         unsafe { LLVMGetIntTypeWidth(self.as_type_ref()) }
     }
 
+    /// Print the definition of an `IntType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.int_type.print_to_string()
+    }
+
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -383,5 +391,11 @@ impl<'ctx> IntType<'ctx> {
 impl AsTypeRef for IntType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.int_type.ty
+    }
+}
+
+impl Display for IntType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/metadata_type.rs
+++ b/src/types/metadata_type.rs
@@ -1,9 +1,12 @@
 use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{FunctionType, Type};
+
+use std::fmt::{self, Display};
 
 /// A `MetadataType` is the type of a metadata.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -53,6 +56,12 @@ impl<'ctx> MetadataType<'ctx> {
     pub fn get_context(self) -> ContextRef<'ctx> {
         self.metadata_type.get_context()
     }
+
+
+    /// Print the definition of a `MetadataType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.metadata_type.print_to_string()
+    }
 }
 
 impl AsTypeRef for MetadataType<'_> {
@@ -64,5 +73,12 @@ impl AsTypeRef for MetadataType<'_> {
     #[llvm_versions(3.6..6.0)]
     fn as_type_ref(&self) -> LLVMTypeRef {
         unimplemented!("MetadataType is only available in LLVM > 6.0")
+    }
+}
+
+
+impl Display for MetadataType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -2,6 +2,7 @@ use llvm_sys::core::{LLVMConstArray, LLVMGetPointerAddressSpace};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{AnyTypeEnum, ArrayType, FunctionType, Type, VectorType};
 use crate::values::{ArrayValue, AsValueRef, IntValue, PointerValue};
@@ -9,6 +10,7 @@ use crate::AddressSpace;
 
 use crate::types::enums::BasicMetadataTypeEnum;
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
 
 /// A `PointerType` is the type of a pointer constant or variable.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -154,6 +156,11 @@ impl<'ctx> PointerType<'ctx> {
         AddressSpace::try_from(addr_space).expect("Unexpectedly found invalid AddressSpace value")
     }
 
+    /// Print the definition of a `PointerType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.ptr_type.print_to_string()
+    }
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `IntType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -288,5 +295,12 @@ impl<'ctx> PointerType<'ctx> {
 impl AsTypeRef for PointerType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.ptr_type.ty
+    }
+}
+
+
+impl Display for PointerType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -7,9 +7,11 @@ use llvm_sys::core::{
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 use std::mem::forget;
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{ArrayType, BasicTypeEnum, FunctionType, PointerType, Type};
@@ -312,6 +314,11 @@ impl<'ctx> StructType<'ctx> {
         raw_vec.iter().map(|val| unsafe { BasicTypeEnum::new(*val) }).collect()
     }
 
+    /// Print the definition of a `StructType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.struct_type.print_to_string()
+    }
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of an `StructType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -404,5 +411,11 @@ impl<'ctx> StructType<'ctx> {
 impl AsTypeRef for StructType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.struct_type.ty
+    }
+}
+
+impl Display for StructType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -2,10 +2,13 @@ use llvm_sys::core::{LLVMConstArray, LLVMConstVector, LLVMGetVectorSize};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::{traits::AsTypeRef, ArrayType, BasicTypeEnum, FunctionType, PointerType, Type};
 use crate::values::{ArrayValue, AsValueRef, BasicValue, IntValue, VectorValue};
 use crate::AddressSpace;
+
+use std::fmt::{self, Display};
 
 /// A `VectorType` is the type of a multiple value SIMD constant or variable.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -117,6 +120,11 @@ impl<'ctx> VectorType<'ctx> {
     /// ```
     pub fn const_zero(self) -> VectorValue<'ctx> {
         unsafe { VectorValue::new(self.vec_type.const_zero()) }
+    }
+
+    /// Print the definition of a `VectorType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.vec_type.print_to_string()
     }
 
     // See Type::print_to_stderr note on 5.0+ status
@@ -267,5 +275,11 @@ impl<'ctx> VectorType<'ctx> {
 impl AsTypeRef for VectorType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.vec_type.ty
+    }
+}
+
+impl Display for VectorType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/types/void_type.rs
+++ b/src/types/void_type.rs
@@ -1,9 +1,12 @@
 use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
+use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{FunctionType, Type};
+
+use std::fmt::{self, Display};
 
 /// A `VoidType` is a special type with no possible direct instances. It's only
 /// useful as a function return type.
@@ -71,6 +74,11 @@ impl<'ctx> VoidType<'ctx> {
         self.void_type.fn_type(param_types, is_var_args)
     }
 
+    /// Print the definition of a `VoidType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.void_type.print_to_string()
+    }
+
     // See Type::print_to_stderr note on 5.0+ status
     /// Prints the definition of a `VoidType` to stderr. Not available in newer LLVM versions.
     #[llvm_versions(3.7..=4.0)]
@@ -82,5 +90,11 @@ impl<'ctx> VoidType<'ctx> {
 impl AsTypeRef for VoidType<'_> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         self.void_type.ty
+    }
+}
+
+impl Display for VoidType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }


### PR DESCRIPTION
## Description

In this PR, I implemented the function `print_to_string` for all existing LLVM Types, which prints the type definition to LLVMString.

This function will be used to implement the `Display` trait for all existing LLVM Types in the folder https://github.com/TheDan64/inkwell/tree/master/src/types

## Related Issue

There is no issue discussing the `print_to_string` before, so maybe we can discuss directly in this PR, instead of creating a new issue?

## How This Has Been Tested

The function `print_to_string` is basically a wrapper function that expose the `print_to_string` of the corresponding underlying type of each LLVM Type, like below:

``` rust
    /// Print the definition of a `FloatType` to `LLVMString`.
    pub fn print_to_string(self) -> LLVMString {
        self.float_type.print_to_string()
    }
```

So, maybe unit test is not necessary?

## Option\<Breaking Changes\>

No breaking changes.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
