### PR TITLE
implement print_to_string and Display trait for LLVM Values

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -791,7 +791,7 @@ impl<'ctx> Module<'ctx> {
         }
     }
 
-    /// Prints the content of the `Module` to a string.
+    /// Prints the content of the `Module` to an `LLVMString`.
     pub fn print_to_string(&self) -> LLVMString {
         unsafe { LLVMString::new(LLVMPrintModuleToString(self.module.get())) }
     }
@@ -819,6 +819,11 @@ impl<'ctx> Module<'ctx> {
         }
 
         Ok(())
+    }
+
+    /// Prints the content of the `Module` to a `String`.
+    pub fn to_string(&self) -> String {
+        self.print_to_string().to_string()
     }
 
     /// Sets the inline assembly for the `Module`.

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -4,7 +4,6 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::support::LLVMString;
 use crate::types::ArrayType;
 use crate::values::traits::{AnyValue, AsValueRef};
 use crate::values::{InstructionValue, Value};
@@ -43,11 +42,6 @@ impl<'ctx> ArrayValue<'ctx> {
     /// Determines whether or not this value is undefined.
     pub fn is_undef(self) -> bool {
         self.array_value.is_undef()
-    }
-
-    /// Print this `Array_value` to `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.array_value.print_to_string()
     }
 
     /// Prints this `ArrayValue` to standard error.

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -2,8 +2,9 @@ use llvm_sys::core::{LLVMIsAConstantArray, LLVMIsAConstantDataArray};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
-use std::fmt;
+use std::fmt::{self, Display};
 
+use crate::support::LLVMString;
 use crate::types::ArrayType;
 use crate::values::traits::{AnyValue, AsValueRef};
 use crate::values::{InstructionValue, Value};
@@ -44,6 +45,11 @@ impl<'ctx> ArrayValue<'ctx> {
         self.array_value.is_undef()
     }
 
+    /// Print this `Array_value` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.array_value.print_to_string()
+    }
+
     /// Prints this `ArrayValue` to standard error.
     pub fn print_to_stderr(self) {
         self.array_value.print_to_stderr()
@@ -82,6 +88,12 @@ impl<'ctx> ArrayValue<'ctx> {
 impl AsValueRef for ArrayValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.array_value.value
+    }
+}
+
+impl Display for ArrayValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }
 

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -11,10 +11,11 @@ use llvm_sys::LLVMTypeKind;
 #[llvm_versions(3.9..=latest)]
 use crate::attributes::Attribute;
 use crate::attributes::AttributeLoc;
-use crate::support::LLVMString;
 #[llvm_versions(3.9..=latest)]
 use crate::values::FunctionValue;
 use crate::values::{AsValueRef, BasicValueEnum, InstructionValue, Value};
+
+use super::AnyValue;
 
 /// A value resulting from a function call. It may have function attributes applied to it.
 ///
@@ -543,11 +544,6 @@ impl<'ctx> CallSiteValue<'ctx> {
         assert_eq!(alignment.count_ones(), 1, "Alignment must be a power of two.");
 
         unsafe { LLVMSetInstrParamAlignment(self.as_value_ref(), loc.get_index(), alignment) }
-    }
-
-    /// Prints the definition of a `CallSiteValue` to a `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.0.print_to_string()
     }
 }
 

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Display};
+
 use either::Either;
 use llvm_sys::core::{
     LLVMGetInstructionCallConv, LLVMGetTypeKind, LLVMIsTailCall, LLVMSetInstrParamAlignment,
@@ -552,5 +554,11 @@ impl<'ctx> CallSiteValue<'ctx> {
 impl AsValueRef for CallSiteValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.0.value
+    }
+}
+
+impl Display for CallSiteValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/callable_value.rs
+++ b/src/values/callable_value.rs
@@ -1,5 +1,6 @@
 use either::Either;
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
 
 use crate::values::AsValueRef;
 use crate::values::{AnyValue, FunctionValue, PointerValue};
@@ -118,5 +119,11 @@ impl<'ctx> TryFrom<PointerValue<'ctx>> for CallableValue<'ctx> {
         } else {
             Err(())
         }
+    }
+}
+
+impl Display for CallableValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -2,6 +2,7 @@ use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf};
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::LLVMTypeKind;
 
+use crate::support::LLVMString;
 use crate::types::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::traits::AsValueRef;
 use crate::values::{
@@ -10,6 +11,9 @@ use crate::values::{
 };
 
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
+
+use super::AnyValue;
 
 macro_rules! enum_value_set {
     ($enum_name:ident: $($args:ident),*) => (
@@ -300,6 +304,18 @@ impl<'ctx> BasicValueEnum<'ctx> {
             panic!("Found {:?} but expected the VectorValue variant", self)
         }
     }
+
+    /// Print `BasicValueEnum` to `LLVMString`
+    pub fn print_to_string(self) -> LLVMString {
+        match self {
+            BasicValueEnum::ArrayValue(v) => v.print_to_string(),
+            BasicValueEnum::IntValue(v) => v.print_to_string(),
+            BasicValueEnum::FloatValue(v) => v.print_to_string(),
+            BasicValueEnum::PointerValue(v) => v.print_to_string(),
+            BasicValueEnum::StructValue(v) => v.print_to_string(),
+            BasicValueEnum::VectorValue(v) => v.print_to_string(),
+        }
+    }
 }
 
 impl<'ctx> AggregateValueEnum<'ctx> {
@@ -438,6 +454,19 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
             panic!("Found {:?} but expected MetaData variant", self)
         }
     }
+
+    /// Print `BasicMetadataValueEnum` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        match self {
+            BasicMetadataValueEnum::ArrayValue(v) => v.print_to_string(),
+            BasicMetadataValueEnum::IntValue(v) => v.print_to_string(),
+            BasicMetadataValueEnum::FloatValue(v) => v.print_to_string(),
+            BasicMetadataValueEnum::PointerValue(v) => v.print_to_string(),
+            BasicMetadataValueEnum::StructValue(v) => v.print_to_string(),
+            BasicMetadataValueEnum::VectorValue(v) => v.print_to_string(),
+            BasicMetadataValueEnum::MetadataValue(v) => v.print_to_string(),
+        }
+    }
 }
 
 impl<'ctx> From<BasicValueEnum<'ctx>> for AnyValueEnum<'ctx> {
@@ -465,5 +494,29 @@ impl<'ctx> TryFrom<AnyValueEnum<'ctx>> for BasicValueEnum<'ctx> {
             AnyValueEnum::VectorValue(vv) => vv.into(),
             _ => return Err(()),
         })
+    }
+}
+
+impl Display for AggregateValueEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}
+
+impl Display for AnyValueEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}
+
+impl Display for BasicValueEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}
+
+impl Display for BasicMetadataValueEnum<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -2,7 +2,6 @@ use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf};
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::LLVMTypeKind;
 
-use crate::support::LLVMString;
 use crate::types::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::traits::AsValueRef;
 use crate::values::{
@@ -68,7 +67,7 @@ macro_rules! enum_value_set {
 }
 
 enum_value_set! {AggregateValueEnum: ArrayValue, StructValue}
-enum_value_set! {AnyValueEnum: ArrayValue, IntValue, FloatValue, PhiValue, FunctionValue, PointerValue, StructValue, VectorValue, InstructionValue}
+enum_value_set! {AnyValueEnum: ArrayValue, IntValue, FloatValue, PhiValue, FunctionValue, PointerValue, StructValue, VectorValue, InstructionValue, MetadataValue}
 enum_value_set! {BasicValueEnum: ArrayValue, IntValue, FloatValue, PointerValue, StructValue, VectorValue}
 enum_value_set! {BasicMetadataValueEnum: ArrayValue, IntValue, FloatValue, PointerValue, StructValue, VectorValue, MetadataValue}
 
@@ -304,18 +303,6 @@ impl<'ctx> BasicValueEnum<'ctx> {
             panic!("Found {:?} but expected the VectorValue variant", self)
         }
     }
-
-    /// Print `BasicValueEnum` to `LLVMString`
-    pub fn print_to_string(self) -> LLVMString {
-        match self {
-            BasicValueEnum::ArrayValue(v) => v.print_to_string(),
-            BasicValueEnum::IntValue(v) => v.print_to_string(),
-            BasicValueEnum::FloatValue(v) => v.print_to_string(),
-            BasicValueEnum::PointerValue(v) => v.print_to_string(),
-            BasicValueEnum::StructValue(v) => v.print_to_string(),
-            BasicValueEnum::VectorValue(v) => v.print_to_string(),
-        }
-    }
 }
 
 impl<'ctx> AggregateValueEnum<'ctx> {
@@ -452,19 +439,6 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
             v
         } else {
             panic!("Found {:?} but expected MetaData variant", self)
-        }
-    }
-
-    /// Print `BasicMetadataValueEnum` to `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        match self {
-            BasicMetadataValueEnum::ArrayValue(v) => v.print_to_string(),
-            BasicMetadataValueEnum::IntValue(v) => v.print_to_string(),
-            BasicMetadataValueEnum::FloatValue(v) => v.print_to_string(),
-            BasicMetadataValueEnum::PointerValue(v) => v.print_to_string(),
-            BasicMetadataValueEnum::StructValue(v) => v.print_to_string(),
-            BasicMetadataValueEnum::VectorValue(v) => v.print_to_string(),
-            BasicMetadataValueEnum::MetadataValue(v) => v.print_to_string(),
         }
     }
 }

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -7,11 +7,12 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value};
 use crate::FloatPredicate;
+
+use super::AnyValue;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FloatValue<'ctx> {
@@ -43,10 +44,6 @@ impl<'ctx> FloatValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.float_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -5,7 +5,9 @@ use llvm_sys::core::{
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
+use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, IntType};
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value};
@@ -41,6 +43,10 @@ impl<'ctx> FloatValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.float_value.is_undef()
+    }
+
+    pub fn print_to_string(self) -> LLVMString {
+        self.print_to_string()
     }
 
     pub fn print_to_stderr(self) {
@@ -151,5 +157,11 @@ impl<'ctx> FloatValue<'ctx> {
 impl AsValueRef for FloatValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.float_value.value
+    }
+}
+
+impl Display for FloatValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -18,7 +18,7 @@ use llvm_sys::debuginfo::{LLVMGetSubprogram, LLVMSetSubprogram};
 use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
 
 use std::ffi::CStr;
-use std::fmt;
+use std::fmt::{self, Display};
 use std::marker::PhantomData;
 use std::mem::forget;
 
@@ -543,6 +543,12 @@ impl<'ctx> FunctionValue<'ctx> {
 impl AsValueRef for FunctionValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.fn_value.value
+    }
+}
+
+impl Display for FunctionValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }
 

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -31,12 +31,14 @@ use std::fmt::{self, Display};
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::module::Linkage;
-use crate::support::{to_c_str, LLVMString};
+use crate::support::to_c_str;
 use crate::values::traits::AsValueRef;
 #[llvm_versions(8.0..=latest)]
 use crate::values::MetadataValue;
 use crate::values::{BasicValue, BasicValueEnum, PointerValue, Value};
 use crate::{DLLStorageClass, GlobalVisibility, ThreadLocalMode};
+
+use super::AnyValue;
 
 // REVIEW: GlobalValues are always PointerValues. With SubTypes, we should
 // compress this into a PointerValue<Global> type
@@ -283,10 +285,6 @@ impl<'ctx> GlobalValue<'ctx> {
 
     pub fn set_linkage(self, linkage: Linkage) {
         unsafe { LLVMSetLinkage(self.as_value_ref(), linkage.into()) }
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.global_value.print_to_string()
     }
 }
 

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -26,6 +26,7 @@ use llvm_sys::LLVMThreadLocalMode;
 use llvm_sys::LLVMUnnamedAddr;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
@@ -292,6 +293,12 @@ impl<'ctx> GlobalValue<'ctx> {
 impl AsValueRef for GlobalValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.global_value.value
+    }
+}
+
+impl Display for GlobalValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -20,11 +20,12 @@ use llvm_sys::LLVMOpcode;
 
 use std::{fmt, fmt::Display};
 
-use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, MetadataValue, Value};
 use crate::{basic_block::BasicBlock, types::AnyTypeEnum};
 use crate::{AtomicOrdering, FloatPredicate, IntPredicate};
+
+use super::AnyValue;
 
 // REVIEW: Split up into structs for SubTypes on InstructionValues?
 // REVIEW: This should maybe be split up into InstructionOpcode and ConstOpcode?
@@ -652,11 +653,6 @@ impl<'ctx> InstructionValue<'ctx> {
         }
 
         Ok(())
-    }
-
-    /// Print `InstructionValue` to `LLVMString`.
-    pub fn print_to_string(self) -> LLVMString {
-        self.instruction_value.print_to_string()
     }
 }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -18,6 +18,9 @@ use llvm_sys::core::{LLVMIsAAtomicCmpXchgInst, LLVMIsAAtomicRMWInst};
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::LLVMOpcode;
 
+use std::{fmt, fmt::Display};
+
+use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, MetadataValue, Value};
 use crate::{basic_block::BasicBlock, types::AnyTypeEnum};
@@ -650,6 +653,11 @@ impl<'ctx> InstructionValue<'ctx> {
 
         Ok(())
     }
+
+    /// Print `InstructionValue` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.instruction_value.print_to_string()
+    }
 }
 
 impl Clone for InstructionValue<'_> {
@@ -663,5 +671,11 @@ impl Clone for InstructionValue<'_> {
 impl AsValueRef for InstructionValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.instruction_value.value
+    }
+}
+
+impl Display for InstructionValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -14,11 +14,12 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, IntType, PointerType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value};
 use crate::IntPredicate;
+
+use super::AnyValue;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct IntValue<'ctx> {
@@ -50,10 +51,6 @@ impl<'ctx> IntValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.int_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.int_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -12,7 +12,9 @@ use llvm_sys::core::{
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
+use crate::support::LLVMString;
 use crate::types::{AsTypeRef, FloatType, IntType, PointerType};
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, FloatValue, InstructionValue, PointerValue, Value};
@@ -48,6 +50,10 @@ impl<'ctx> IntValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.int_value.is_undef()
+    }
+
+    pub fn print_to_string(self) -> LLVMString {
+        self.int_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {
@@ -331,5 +337,11 @@ impl<'ctx> IntValue<'ctx> {
 impl AsValueRef for IntValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.int_value.value
+    }
+}
+
+impl Display for IntValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -13,7 +13,7 @@ use crate::values::traits::AsValueRef;
 use crate::values::{BasicMetadataValueEnum, Value};
 
 use std::ffi::CStr;
-use std::fmt;
+use std::fmt::{self, Display};
 
 // FIXME: use #[doc(cfg(...))] for this rustdoc comment when it's stabilized:
 // https://github.com/rust-lang/rust/issues/43781
@@ -136,6 +136,12 @@ impl<'ctx> MetadataValue<'ctx> {
 impl AsValueRef for MetadataValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.metadata_value.value
+    }
+}
+
+impl Display for MetadataValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }
 

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -8,9 +8,10 @@ use llvm_sys::core::LLVMValueAsMetadata;
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::prelude::LLVMMetadataRef;
 
-use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicMetadataValueEnum, Value};
+
+use super::AnyValue;
 
 use std::ffi::CStr;
 use std::fmt::{self, Display};
@@ -118,10 +119,6 @@ impl<'ctx> MetadataValue<'ctx> {
         vec.iter()
             .map(|val| unsafe { BasicMetadataValueEnum::new(*val) })
             .collect()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.metadata_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -6,9 +6,10 @@ use std::ffi::CStr;
 use std::fmt::{self, Display};
 
 use crate::basic_block::BasicBlock;
-use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, InstructionOpcode, InstructionValue, Value};
+
+use super::AnyValue;
 
 // REVIEW: Metadata for phi values?
 /// A Phi Instruction returns a value based on which basic block branched into
@@ -93,10 +94,6 @@ impl<'ctx> PhiValue<'ctx> {
 
     pub fn as_basic_value(self) -> BasicValueEnum<'ctx> {
         unsafe { BasicValueEnum::new(self.as_value_ref()) }
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.phi_value.print_to_string()
     }
 }
 

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -3,8 +3,10 @@ use llvm_sys::prelude::{LLVMBasicBlockRef, LLVMValueRef};
 use std::convert::TryFrom;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
 use crate::basic_block::BasicBlock;
+use crate::support::LLVMString;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, InstructionOpcode, InstructionValue, Value};
 
@@ -92,6 +94,10 @@ impl<'ctx> PhiValue<'ctx> {
     pub fn as_basic_value(self) -> BasicValueEnum<'ctx> {
         unsafe { BasicValueEnum::new(self.as_value_ref()) }
     }
+
+    pub fn print_to_string(self) -> LLVMString {
+        self.phi_value.print_to_string()
+    }
 }
 
 impl AsValueRef for PhiValue<'_> {
@@ -109,5 +115,11 @@ impl TryFrom<InstructionValue<'_>> for PhiValue<'_> {
         } else {
             Err(())
         }
+    }
+}
+
+impl Display for PhiValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -6,9 +6,10 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::support::LLVMString;
 use crate::types::{AsTypeRef, IntType, PointerType};
 use crate::values::{AsValueRef, InstructionValue, IntValue, Value};
+
+use super::AnyValue;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct PointerValue<'ctx> {
@@ -55,10 +56,6 @@ impl<'ctx> PointerValue<'ctx> {
     /// ```
     pub fn is_const(self) -> bool {
         self.ptr_value.is_const()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.ptr_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -4,7 +4,9 @@ use llvm_sys::core::{
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
+use crate::support::LLVMString;
 use crate::types::{AsTypeRef, IntType, PointerType};
 use crate::values::{AsValueRef, InstructionValue, IntValue, Value};
 
@@ -53,6 +55,10 @@ impl<'ctx> PointerValue<'ctx> {
     /// ```
     pub fn is_const(self) -> bool {
         self.ptr_value.is_const()
+    }
+
+    pub fn print_to_string(self) -> LLVMString {
+        self.ptr_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {
@@ -112,5 +118,11 @@ impl<'ctx> PointerValue<'ctx> {
 impl AsValueRef for PointerValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.ptr_value.value
+    }
+}
+
+impl Display for PointerValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -3,10 +3,11 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::support::LLVMString;
 use crate::types::StructType;
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, Value};
+
+use super::AnyValue;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct StructValue<'ctx> {
@@ -38,10 +39,6 @@ impl<'ctx> StructValue<'ctx> {
 
     pub fn is_undef(self) -> bool {
         self.struct_value.is_undef()
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.struct_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -1,7 +1,9 @@
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
+use crate::support::LLVMString;
 use crate::types::StructType;
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, Value};
@@ -38,6 +40,10 @@ impl<'ctx> StructValue<'ctx> {
         self.struct_value.is_undef()
     }
 
+    pub fn print_to_string(self) -> LLVMString {
+        self.struct_value.print_to_string()
+    }
+
     pub fn print_to_stderr(self) {
         self.struct_value.print_to_stderr()
     }
@@ -54,5 +60,11 @@ impl<'ctx> StructValue<'ctx> {
 impl AsValueRef for StructValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.struct_value.value
+    }
+}
+
+impl Display for StructValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -10,6 +10,8 @@ use crate::values::{
     FunctionValue, GlobalValue, InstructionValue, IntValue, PhiValue, PointerValue, StructValue, Value, VectorValue,
 };
 
+use super::{MetadataValue, BasicMetadataValueEnum};
+
 // This is an ugly privacy hack so that Type can stay private to this module
 // and so that super traits using this trait will be not be implementable
 // outside this library
@@ -140,7 +142,7 @@ pub trait AnyValue<'ctx>: AsValueRef + Debug {
 }
 
 trait_value_set! {AggregateValue: ArrayValue, AggregateValueEnum, StructValue}
-trait_value_set! {AnyValue: AnyValueEnum, BasicValueEnum, AggregateValueEnum, ArrayValue, IntValue, FloatValue, GlobalValue, PhiValue, PointerValue, FunctionValue, StructValue, VectorValue, InstructionValue, CallSiteValue}
+trait_value_set! {AnyValue: AnyValueEnum, BasicValueEnum, BasicMetadataValueEnum, AggregateValueEnum, ArrayValue, IntValue, FloatValue, GlobalValue, PhiValue, PointerValue, FunctionValue, StructValue, VectorValue, InstructionValue, CallSiteValue, MetadataValue}
 trait_value_set! {BasicValue: ArrayValue, BasicValueEnum, AggregateValueEnum, IntValue, FloatValue, GlobalValue, StructValue, PointerValue, VectorValue}
 math_trait_value_set! {IntMathValue: (IntValue => IntType), (VectorValue => VectorType)}
 math_trait_value_set! {FloatMathValue: (FloatValue => FloatType), (VectorValue => VectorType)}

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -5,7 +5,9 @@ use llvm_sys::core::{
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
+use std::fmt::{self, Display};
 
+use crate::support::LLVMString;
 use crate::types::VectorType;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, InstructionValue, IntValue, Value};
@@ -48,6 +50,10 @@ impl<'ctx> VectorValue<'ctx> {
 
     pub fn is_constant_data_vector(self) -> bool {
         unsafe { !LLVMIsAConstantDataVector(self.as_value_ref()).is_null() }
+    }
+
+    pub fn print_to_string(self) -> LLVMString {
+        self.vec_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {
@@ -158,5 +164,11 @@ impl<'ctx> VectorValue<'ctx> {
 impl AsValueRef for VectorValue<'_> {
     fn as_value_ref(&self) -> LLVMValueRef {
         self.vec_value.value
+    }
+}
+
+impl Display for VectorValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
     }
 }

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -7,10 +7,11 @@ use llvm_sys::prelude::LLVMValueRef;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::support::LLVMString;
 use crate::types::VectorType;
 use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, InstructionValue, IntValue, Value};
+
+use super::AnyValue;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct VectorValue<'ctx> {
@@ -50,10 +51,6 @@ impl<'ctx> VectorValue<'ctx> {
 
     pub fn is_constant_data_vector(self) -> bool {
         unsafe { !LLVMIsAConstantDataVector(self.as_value_ref()).is_null() }
-    }
-
-    pub fn print_to_string(self) -> LLVMString {
-        self.vec_value.print_to_string()
     }
 
     pub fn print_to_stderr(self) {

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -1,6 +1,7 @@
 use inkwell::context::Context;
 use inkwell::debug_info::{AsDIScope, DIFlags, DIFlagsConstants, DISubprogram, DWARFEmissionKind, DWARFSourceLanguage};
 use inkwell::module::FlagBehavior;
+use inkwell::values::AnyValue;
 
 #[test]
 fn test_smoke() {


### PR DESCRIPTION
Hi,

## Description

This PR implements the `Display` trait for the current LLVM Values. This feature is currently missing in the current code base.

## Related Issue

It is related to PR https://github.com/TheDan64/inkwell/pull/327, but implement for LLVM Value instead.

## How This Has Been Tested

The trait Display is implemented by simply calling the function `print_to_string` from the trait `AnyValue`, like below. 

``` rust
use super::AnyValue;
....
impl Display for IntValue<'_> {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        write!(f, "{}", self.print_to_string())
    }
}
```
Test cases of the function `print_to_string` are already included in the `tests` directory.

So, maybe more unit tests are not necessary.

## Option\<Breaking Changes\>

No breaking changes.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
