### PR TITLE
Make a public AsValueRef trait

### DIFF
--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -39,7 +39,7 @@ pub use crate::values::metadata_value::{MetadataValue, FIRST_CUSTOM_METADATA_KIN
 pub use crate::values::phi_value::PhiValue;
 pub use crate::values::ptr_value::PointerValue;
 pub use crate::values::struct_value::StructValue;
-pub(crate) use crate::values::traits::AsValueRef;
+pub use crate::values::traits::AsValueRef;
 pub use crate::values::traits::{AggregateValue, AnyValue, BasicValue, FloatMathValue, IntMathValue, PointerMathValue};
 pub use crate::values::vec_value::VectorValue;
 #[cfg(feature = "internal-getters")]


### PR DESCRIPTION
Making a public `AsValueRef` trait allows to fully implement a `AnyValue` trait which can be usefull in some cases.
For example if in my own compiler I want to add some kind of type
```
#[derive(Debug)]
pub enum CompiledLiteral<'ctx> {
    Number(FloatValue<'ctx>),
    String(VectorValue<'ctx>),
}
```
It will be great if it will be possible to implement a `AnyValue` trait for it.