### PR TITLE
Replace deprecated functions in LLVM14 with new ones

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,25 +3,35 @@
 use llvm_sys::core::{
     LLVMAddCase, LLVMAddClause, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast,
     LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc,
-    LLVMBuildAtomicCmpXchg, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall, LLVMBuildCast,
-    LLVMBuildCondBr, LLVMBuildExactSDiv, LLVMBuildExtractElement, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp,
-    LLVMBuildFDiv, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI,
-    LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGEP, LLVMBuildGlobalString,
-    LLVMBuildGlobalStringPtr, LLVMBuildICmp, LLVMBuildInBoundsGEP, LLVMBuildIndirectBr, LLVMBuildInsertElement,
-    LLVMBuildInsertValue, LLVMBuildIntCast, LLVMBuildIntToPtr, LLVMBuildInvoke, LLVMBuildIsNotNull, LLVMBuildIsNull,
-    LLVMBuildLShr, LLVMBuildLandingPad, LLVMBuildLoad, LLVMBuildMalloc, LLVMBuildMul, LLVMBuildNSWAdd, LLVMBuildNSWMul,
-    LLVMBuildNSWNeg, LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul, LLVMBuildNUWNeg, LLVMBuildNUWSub, LLVMBuildNeg,
-    LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast, LLVMBuildPtrDiff, LLVMBuildPtrToInt,
-    LLVMBuildResume, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSExtOrBitCast,
-    LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore,
-    LLVMBuildStructGEP, LLVMBuildSub, LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv,
+    LLVMBuildAtomicCmpXchg, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCast, LLVMBuildCondBr,
+    LLVMBuildExactSDiv, LLVMBuildExtractElement, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv,
+    LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc,
+    LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr,
+    LLVMBuildICmp, LLVMBuildIndirectBr, LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntCast,
+    LLVMBuildIntToPtr, LLVMBuildIsNotNull, LLVMBuildIsNull, LLVMBuildLShr, LLVMBuildLandingPad, LLVMBuildMalloc,
+    LLVMBuildMul, LLVMBuildNSWAdd, LLVMBuildNSWMul, LLVMBuildNSWNeg, LLVMBuildNSWSub, LLVMBuildNUWAdd, LLVMBuildNUWMul,
+    LLVMBuildNUWNeg, LLVMBuildNUWSub, LLVMBuildNeg, LLVMBuildNot, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPointerCast,
+    LLVMBuildPtrToInt, LLVMBuildResume, LLVMBuildRet, LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt,
+    LLVMBuildSExtOrBitCast, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector,
+    LLVMBuildStore, LLVMBuildSub, LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildTruncOrBitCast, LLVMBuildUDiv,
     LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt,
     LLVMBuildZExtOrBitCast, LLVMClearInsertionPosition, LLVMDisposeBuilder, LLVMGetInsertBlock, LLVMInsertIntoBuilder,
     LLVMInsertIntoBuilderWithName, LLVMPositionBuilder, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore,
     LLVMSetCleanup,
 };
+#[llvm_versions(4.0..14.0)]
+use llvm_sys::core::{
+    LLVMBuildCall, LLVMBuildGEP, LLVMBuildInBoundsGEP, LLVMBuildInvoke, LLVMBuildLoad, LLVMBuildPtrDiff,
+    LLVMBuildStructGEP,
+};
+#[llvm_versions(14.0..=latest)]
+use llvm_sys::core::{
+    LLVMBuildCall2, LLVMBuildGEP2, LLVMBuildInBoundsGEP2, LLVMBuildInvoke2, LLVMBuildLoad2, LLVMBuildPtrDiff2,
+    LLVMBuildStructGEP2,
+};
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{LLVMBuildIntCast2, LLVMBuildMemCpy, LLVMBuildMemMove, LLVMBuildMemSet};
+
 use llvm_sys::prelude::{LLVMBuilderRef, LLVMValueRef};
 
 use crate::basic_block::BasicBlock;
@@ -120,7 +130,185 @@ impl<'ctx> Builder<'ctx> {
 
         unsafe { InstructionValue::new(value) }
     }
+}
 
+#[llvm_versions(14.0..=latest)]
+impl<'ctx> Builder<'ctx> {
+    /// Builds a function call instruction.
+    /// [`FunctionValue`]s can be implicitly converted into a [`CallableValue`].
+    /// See [`CallableValue`] for details on calling a [`PointerValue`] that points to a function.
+    ///
+    /// [`FunctionValue`]: crate::values::FunctionValue
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// // A simple function which calls itself:
+    /// let context = Context::create();
+    /// let module = context.create_module("ret");
+    /// let builder = context.create_builder();
+    /// let i32_type = context.i32_type();
+    /// let fn_type = i32_type.fn_type(&[i32_type.into()], false);
+    /// let fn_value = module.add_function("ret", fn_type, None);
+    /// let entry = context.append_basic_block(fn_value, "entry");
+    /// let i32_arg = fn_value.get_first_param().unwrap();
+    /// let md_string = context.metadata_string("a metadata");
+    ///
+    /// builder.position_at_end(entry);
+    ///
+    /// let ret_val = builder.build_call(fn_value, &[i32_arg.into(), md_string.into()], "call")
+    ///     .try_as_basic_value()
+    ///     .left()
+    ///     .unwrap();
+    ///
+    /// builder.build_return(Some(&ret_val));
+    /// ```
+    pub fn build_call<F>(&self, function: F, args: &[BasicMetadataValueEnum<'ctx>], name: &str) -> CallSiteValue<'ctx>
+    where
+        F: Into<CallableValue<'ctx>>,
+    {
+        let callable_value = function.into();
+        let fn_ty_ref = callable_value.as_type_ref();
+        let fn_val_ref = callable_value.as_value_ref();
+
+        // LLVM gets upset when void return calls are named because they don't return anything
+        let name = if callable_value.returns_void() { "" } else { name };
+
+        let c_string = to_c_str(name);
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let value = unsafe {
+            LLVMBuildCall2(
+                self.builder,
+                fn_ty_ref,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe { CallSiteValue::new(value) }
+    }
+
+    /// An invoke is similar to a normal function call, but used to
+    /// call functions that may throw an exception, and then respond to the exception.
+    ///
+    /// When the called function returns normally, the `then` block is evaluated next. If instead
+    /// the function threw an exception, the `catch` block is entered. The first non-phi
+    /// instruction of the catch block must be a `landingpad` instruction. See also
+    /// [`Builder::build_landing_pad`].
+    ///
+    /// The [`add_prune_eh_pass`] turns an invoke into a call when the called function is
+    /// guaranteed to never throw an exception.
+    ///
+    /// [`add_prune_eh_pass`]: crate::passes::PassManager::add_prune_eh_pass
+    ///
+    /// This example catches C++ exceptions of type `int`, and returns `0` if an exceptions is thrown.
+    /// For usage of a cleanup landing pad and the `resume` instruction, see [`Builder::build_resume`]
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    /// use inkwell::module::Linkage;
+    ///
+    /// let context = Context::create();
+    /// let module = context.create_module("sum");
+    /// let builder = context.create_builder();
+    ///
+    /// let f32_type = context.f32_type();
+    /// let fn_type = f32_type.fn_type(&[], false);
+    ///
+    /// // we will pretend this function can throw an exception
+    /// let function = module.add_function("bomb", fn_type, None);
+    /// let basic_block = context.append_basic_block(function, "entry");
+    ///
+    /// builder.position_at_end(basic_block);
+    ///
+    /// let pi = f32_type.const_float(::std::f64::consts::PI);
+    ///
+    /// builder.build_return(Some(&pi));
+    ///
+    /// let function2 = module.add_function("wrapper", fn_type, None);
+    /// let basic_block2 = context.append_basic_block(function2, "entry");
+    ///
+    /// builder.position_at_end(basic_block2);
+    ///
+    /// let then_block = context.append_basic_block(function2, "then_block");
+    /// let catch_block = context.append_basic_block(function2, "catch_block");
+    ///
+    /// let call_site = builder.build_invoke(function, &[], then_block, catch_block, "get_pi");
+    ///
+    /// {
+    ///     builder.position_at_end(then_block);
+    ///
+    ///     // in the then_block, the `call_site` value is defined and can be used
+    ///     let result = call_site.try_as_basic_value().left().unwrap();
+    ///
+    ///     builder.build_return(Some(&result));
+    /// }
+    ///
+    /// {
+    ///     builder.position_at_end(catch_block);
+    ///
+    ///     // the personality function used by C++
+    ///     let personality_function = {
+    ///         let name = "__gxx_personality_v0";
+    ///         let linkage = Some(Linkage::External);
+    ///
+    ///         module.add_function(name, context.i64_type().fn_type(&[], false), linkage)
+    ///     };
+    ///
+    ///     // type of an exception in C++
+    ///     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+    ///     let i32_type = context.i32_type();
+    ///     let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
+    ///
+    ///     let null = i8_ptr_type.const_zero();
+    ///     let res = builder.build_landing_pad(exception_type, personality_function, &[null.into()], false, "res");
+    ///
+    ///     // we handle the exception by returning a default value
+    ///     builder.build_return(Some(&f32_type.const_zero()));
+    /// }
+    /// ```
+    pub fn build_invoke<F>(
+        &self,
+        function: F,
+        args: &[BasicValueEnum<'ctx>],
+        then_block: BasicBlock<'ctx>,
+        catch_block: BasicBlock<'ctx>,
+        name: &str,
+    ) -> CallSiteValue<'ctx>
+    where
+        F: Into<CallableValue<'ctx>>,
+    {
+        let callable_value: CallableValue<'ctx> = function.into();
+        let fn_ty_ref = callable_value.as_type_ref();
+        let fn_val_ref = callable_value.as_value_ref();
+
+        // LLVM gets upset when void return calls are named because they don't return anything
+        let name = if callable_value.returns_void() { "" } else { name };
+
+        let c_string = to_c_str(name);
+        let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
+        let value = unsafe {
+            LLVMBuildInvoke2(
+                self.builder,
+                fn_ty_ref,
+                fn_val_ref,
+                args.as_mut_ptr(),
+                args.len() as u32,
+                then_block.basic_block,
+                catch_block.basic_block,
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe { CallSiteValue::new(value) }
+    }
+}
+#[llvm_versions(4.0..14.0)]
+impl<'ctx> Builder<'ctx> {
     /// Builds a function call instruction.
     /// [`FunctionValue`]s can be implicitly converted into a [`CallableValue`].
     /// See [`CallableValue`] for details on calling a [`PointerValue`] that points to a function.
@@ -289,7 +477,9 @@ impl<'ctx> Builder<'ctx> {
 
         unsafe { CallSiteValue::new(value) }
     }
+}
 
+impl<'ctx> Builder<'ctx> {
     /// Landing pads are places where control flow jumps to if a [`Builder::build_invoke`] triggered an exception.
     /// The landing pad will match the exception against its *clauses*. Depending on the clause
     /// that is matched, the exception can then be handled, or resumed after some optional cleanup,
@@ -542,7 +732,167 @@ impl<'ctx> Builder<'ctx> {
 
         unsafe { InstructionValue::new(val) }
     }
+}
 
+#[llvm_versions(14.0..=latest)]
+impl<'ctx> Builder<'ctx> {
+    // REVIEW: Doesn't GEP work on array too?
+    /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
+    pub unsafe fn build_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        ordered_indexes: &[IntValue<'ctx>],
+        name: &str,
+    ) -> PointerValue<'ctx> {
+        let c_string = to_c_str(name);
+
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
+        let value = LLVMBuildGEP2(
+            self.builder,
+            ptr.get_type().get_element_type().as_type_ref(),
+            ptr.as_value_ref(),
+            index_values.as_mut_ptr(),
+            index_values.len() as u32,
+            c_string.as_ptr(),
+        );
+
+        PointerValue::new(value)
+    }
+
+    // REVIEW: Doesn't GEP work on array too?
+    // REVIEW: This could be merge in with build_gep via a in_bounds: bool param
+    /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
+    pub unsafe fn build_in_bounds_gep(
+        &self,
+        ptr: PointerValue<'ctx>,
+        ordered_indexes: &[IntValue<'ctx>],
+        name: &str,
+    ) -> PointerValue<'ctx> {
+        let c_string = to_c_str(name);
+
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
+        let value = LLVMBuildInBoundsGEP2(
+            self.builder,
+            ptr.get_type().get_element_type().as_type_ref(),
+            ptr.as_value_ref(),
+            index_values.as_mut_ptr(),
+            index_values.len() as u32,
+            c_string.as_ptr(),
+        );
+
+        PointerValue::new(value)
+    }
+
+    /// Builds a GEP instruction on a struct pointer. Returns `Err(())` if input `PointerValue` doesn't
+    /// point to a struct or if index is out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::AddressSpace;
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let builder = context.create_builder();
+    /// let module = context.create_module("struct_gep");
+    /// let void_type = context.void_type();
+    /// let i32_ty = context.i32_type();
+    /// let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::Generic);
+    /// let field_types = &[i32_ty.into(), i32_ty.into()];
+    /// let struct_ty = context.struct_type(field_types, false);
+    /// let struct_ptr_ty = struct_ty.ptr_type(AddressSpace::Generic);
+    /// let fn_type = void_type.fn_type(&[i32_ptr_ty.into(), struct_ptr_ty.into()], false);
+    /// let fn_value = module.add_function("", fn_type, None);
+    /// let entry = context.append_basic_block(fn_value, "entry");
+    ///
+    /// builder.position_at_end(entry);
+    ///
+    /// let i32_ptr = fn_value.get_first_param().unwrap().into_pointer_value();
+    /// let struct_ptr = fn_value.get_last_param().unwrap().into_pointer_value();
+    ///
+    /// assert!(builder.build_struct_gep(i32_ptr, 0, "struct_gep").is_err());
+    /// assert!(builder.build_struct_gep(i32_ptr, 10, "struct_gep").is_err());
+    /// assert!(builder.build_struct_gep(struct_ptr, 0, "struct_gep").is_ok());
+    /// assert!(builder.build_struct_gep(struct_ptr, 1, "struct_gep").is_ok());
+    /// assert!(builder.build_struct_gep(struct_ptr, 2, "struct_gep").is_err());
+    /// ```
+    pub fn build_struct_gep(&self, ptr: PointerValue<'ctx>, index: u32, name: &str) -> Result<PointerValue<'ctx>, ()> {
+        let ptr_ty = ptr.get_type();
+        let pointee_ty = ptr_ty.get_element_type();
+
+        if !pointee_ty.is_struct_type() {
+            return Err(());
+        }
+
+        let struct_ty = pointee_ty.into_struct_type();
+
+        if index >= struct_ty.count_fields() {
+            return Err(());
+        }
+
+        let c_string = to_c_str(name);
+        let value = unsafe {
+            LLVMBuildStructGEP2(
+                self.builder,
+                ptr.get_type().get_element_type().as_type_ref(),
+                ptr.as_value_ref(),
+                index,
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe { Ok(PointerValue::new(value)) }
+    }
+
+    /// Builds an instruction which calculates the difference of two pointers.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
+    /// // Builds a function which diffs two pointers
+    /// let context = Context::create();
+    /// let module = context.create_module("ret");
+    /// let builder = context.create_builder();
+    /// let void_type = context.void_type();
+    /// let i32_type = context.i32_type();
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let fn_type = void_type.fn_type(&[i32_ptr_type.into(), i32_ptr_type.into()], false);
+    /// let fn_value = module.add_function("ret", fn_type, None);
+    /// let entry = context.append_basic_block(fn_value, "entry");
+    /// let i32_ptr_param1 = fn_value.get_first_param().unwrap().into_pointer_value();
+    /// let i32_ptr_param2 = fn_value.get_nth_param(1).unwrap().into_pointer_value();
+    ///
+    /// builder.position_at_end(entry);
+    /// builder.build_ptr_diff(i32_ptr_param1, i32_ptr_param2, "diff");
+    /// builder.build_return(None);
+    /// ```
+    pub fn build_ptr_diff(
+        &self,
+        lhs_ptr: PointerValue<'ctx>,
+        rhs_ptr: PointerValue<'ctx>,
+        name: &str,
+    ) -> IntValue<'ctx> {
+        let c_string = to_c_str(name);
+
+        let value = unsafe {
+            LLVMBuildPtrDiff2(
+                self.builder,
+                lhs_ptr.get_type().as_type_ref(),
+                lhs_ptr.as_value_ref(),
+                rhs_ptr.as_value_ref(),
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe { IntValue::new(value) }
+    }
+}
+
+#[llvm_versions(4.0..14.0)]
+impl<'ctx> Builder<'ctx> {
     // REVIEW: Doesn't GEP work on array too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
     pub unsafe fn build_gep(
@@ -684,7 +1034,9 @@ impl<'ctx> Builder<'ctx> {
 
         unsafe { IntValue::new(value) }
     }
+}
 
+impl<'ctx> Builder<'ctx> {
     // SubTypes: Maybe this should return PhiValue<T>? That way we could force incoming values to be of T::Value?
     // That is, assuming LLVM complains about different phi types.. which I imagine it would. But this would get
     // tricky with VoidType since it has no instance value?
@@ -753,6 +1105,47 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&pointee));
     /// ```
+    #[llvm_versions(14.0..=latest)]
+    pub fn build_load(&self, ptr: PointerValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
+        let c_string = to_c_str(name);
+        let value = unsafe {
+            LLVMBuildLoad2(
+                self.builder,
+                ptr.get_type().get_element_type().as_type_ref(),
+                ptr.as_value_ref(),
+                c_string.as_ptr(),
+            )
+        };
+
+        unsafe { BasicValueEnum::new(value) }
+    }
+
+    /// Builds a load instruction. It allows you to retrieve a value of type `T` from a pointer to a type `T`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
+    /// // Builds a function which takes an i32 pointer and returns the pointed at i32.
+    /// let context = Context::create();
+    /// let module = context.create_module("ret");
+    /// let builder = context.create_builder();
+    /// let i32_type = context.i32_type();
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let fn_type = i32_type.fn_type(&[i32_ptr_type.into()], false);
+    /// let fn_value = module.add_function("ret", fn_type, None);
+    /// let entry = context.append_basic_block(fn_value, "entry");
+    /// let i32_ptr_param = fn_value.get_first_param().unwrap().into_pointer_value();
+    ///
+    /// builder.position_at_end(entry);
+    ///
+    /// let pointee = builder.build_load(i32_ptr_param, "load");
+    ///
+    /// builder.build_return(Some(&pointee));
+    /// ```
+    #[llvm_versions(4.0..14.0)]
     pub fn build_load(&self, ptr: PointerValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
         let value = unsafe { LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -175,7 +175,18 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
         let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
 
-        #[cfg(feature = "llvm14-0")]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = unsafe {
             let fn_ty_ref = callable_value.as_type_ref();
             LLVMBuildCall2(
@@ -188,7 +199,18 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = unsafe {
             LLVMBuildCall(
                 self.builder,
@@ -301,7 +323,20 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
         let mut args: Vec<LLVMValueRef> = args.iter().map(|val| val.as_value_ref()).collect();
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = unsafe {
             let fn_ty_ref = callable_value.as_type_ref();
             LLVMBuildInvoke2(
@@ -316,7 +351,18 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = unsafe {
             LLVMBuildInvoke(
                 self.builder,
@@ -596,7 +642,21 @@ impl<'ctx> Builder<'ctx> {
         let c_string = to_c_str(name);
 
         let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
-        #[cfg(feature = "llvm14-0")]
+
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = LLVMBuildGEP2(
             self.builder,
             ptr.get_type().get_element_type().as_type_ref(),
@@ -606,7 +666,18 @@ impl<'ctx> Builder<'ctx> {
             c_string.as_ptr(),
         );
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = LLVMBuildGEP(
             self.builder,
             ptr.as_value_ref(),
@@ -631,7 +702,20 @@ impl<'ctx> Builder<'ctx> {
 
         let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = LLVMBuildInBoundsGEP2(
             self.builder,
             ptr.get_type().get_element_type().as_type_ref(),
@@ -641,7 +725,18 @@ impl<'ctx> Builder<'ctx> {
             c_string.as_ptr(),
         );
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = LLVMBuildInBoundsGEP(
             self.builder,
             ptr.as_value_ref(),
@@ -702,7 +797,20 @@ impl<'ctx> Builder<'ctx> {
 
         let c_string = to_c_str(name);
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = unsafe {
             LLVMBuildStructGEP2(
                 self.builder,
@@ -713,7 +821,18 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = unsafe { LLVMBuildStructGEP(self.builder, ptr.as_value_ref(), index, c_string.as_ptr()) };
 
         unsafe { Ok(PointerValue::new(value)) }
@@ -752,7 +871,20 @@ impl<'ctx> Builder<'ctx> {
     ) -> IntValue<'ctx> {
         let c_string = to_c_str(name);
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = unsafe {
             LLVMBuildPtrDiff2(
                 self.builder,
@@ -763,7 +895,18 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = unsafe {
             LLVMBuildPtrDiff(
                 self.builder,
@@ -847,7 +990,20 @@ impl<'ctx> Builder<'ctx> {
     pub fn build_load(&self, ptr: PointerValue<'ctx>, name: &str) -> BasicValueEnum<'ctx> {
         let c_string = to_c_str(name);
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = unsafe {
             LLVMBuildLoad2(
                 self.builder,
@@ -857,7 +1013,18 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = unsafe { LLVMBuildLoad(self.builder, ptr.as_value_ref(), c_string.as_ptr()) };
 
         unsafe { BasicValueEnum::new(value) }

--- a/src/module.rs
+++ b/src/module.rs
@@ -349,39 +349,13 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(module.get_struct_type("foo").unwrap(), opaque);
     /// ```
     ///
-    #[llvm_versions(14.0..=latest)]
     pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
         let c_string = to_c_str(name);
 
+        #[cfg(feature = "llvm14-0")]
         let struct_type = unsafe { LLVMGetTypeByName2(self.get_context().context, c_string.as_ptr()) };
 
-        if struct_type.is_null() {
-            return None;
-        }
-
-        unsafe { Some(StructType::new(struct_type)) }
-    }
-
-    /// Gets a named `StructType` from this `Module`'s `Context`.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use inkwell::context::Context;
-    ///
-    /// let context = Context::create();
-    /// let module = context.create_module("my_module");
-    ///
-    /// assert!(module.get_struct_type("foo").is_none());
-    ///
-    /// let opaque = context.opaque_struct_type("foo");
-    ///
-    /// assert_eq!(module.get_struct_type("foo").unwrap(), opaque);
-    /// ```
-    #[llvm_versions(4.0..14.0)]
-    pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
-        let c_string = to_c_str(name);
-
+        #[cfg(not(feature = "llvm14-0"))]
         let struct_type = unsafe { LLVMGetTypeByName(self.module.get(), c_string.as_ptr()) };
 
         if struct_type.is_null() {

--- a/src/module.rs
+++ b/src/module.rs
@@ -352,10 +352,34 @@ impl<'ctx> Module<'ctx> {
     pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
         let c_string = to_c_str(name);
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let struct_type = unsafe { LLVMGetTypeByName2(self.get_context().context, c_string.as_ptr()) };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let struct_type = unsafe { LLVMGetTypeByName(self.module.get(), c_string.as_ptr()) };
 
         if struct_type.is_null() {

--- a/src/values/callable_value.rs
+++ b/src/values/callable_value.rs
@@ -7,7 +7,6 @@ use crate::values::AsValueRef;
 use crate::values::{AnyValue, FunctionValue, PointerValue};
 
 use llvm_sys::core::{LLVMGetElementType, LLVMGetReturnType, LLVMGetTypeKind, LLVMTypeOf};
-#[llvm_versions(14.0..=latest)]
 use llvm_sys::prelude::LLVMTypeRef;
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::LLVMTypeKind;

--- a/src/values/callable_value.rs
+++ b/src/values/callable_value.rs
@@ -93,7 +93,6 @@ impl<'ctx> AsValueRef for CallableValue<'ctx> {
 
 impl<'ctx> AnyValue<'ctx> for CallableValue<'ctx> {}
 
-#[llvm_versions(14.0..=latest)]
 impl<'ctx> AsTypeRef for CallableValue<'ctx> {
     fn as_type_ref(&self) -> LLVMTypeRef {
         use either::Either::*;

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -1,6 +1,9 @@
-use llvm_sys::core::{
-    LLVMConstAddrSpaceCast, LLVMConstGEP, LLVMConstInBoundsGEP, LLVMConstPointerCast, LLVMConstPtrToInt,
-};
+#[llvm_versions(4.0..14.0)]
+use llvm_sys::core::{LLVMConstGEP, LLVMConstInBoundsGEP};
+#[llvm_versions(14.0..=latest)]
+use llvm_sys::core::{LLVMConstGEP2, LLVMConstInBoundsGEP2};
+
+use llvm_sys::core::{LLVMConstAddrSpaceCast, LLVMConstPointerCast, LLVMConstPtrToInt};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::convert::TryFrom;
@@ -66,7 +69,44 @@ impl<'ctx> PointerValue<'ctx> {
     pub fn as_instruction(self) -> Option<InstructionValue<'ctx>> {
         self.ptr_value.as_instruction()
     }
+}
 
+#[llvm_versions(14.0..=latest)]
+impl<'ctx> PointerValue<'ctx> {
+    // REVIEW: Should this be on array value too?
+    /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
+    pub unsafe fn const_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
+        let value = {
+            LLVMConstGEP2(
+                self.get_type().get_element_type().as_type_ref(),
+                self.as_value_ref(),
+                index_values.as_mut_ptr(),
+                index_values.len() as u32,
+            )
+        };
+
+        PointerValue::new(value)
+    }
+
+    /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
+    pub unsafe fn const_in_bounds_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
+        let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
+        let value = {
+            LLVMConstInBoundsGEP2(
+                self.get_type().get_element_type().as_type_ref(),
+                self.as_value_ref(),
+                index_values.as_mut_ptr(),
+                index_values.len() as u32,
+            )
+        };
+
+        PointerValue::new(value)
+    }
+}
+
+#[llvm_versions(4.0..14.0)]
+impl<'ctx> PointerValue<'ctx> {
     // REVIEW: Should this be on array value too?
     /// GEP is very likely to segfault if indexes are used incorrectly, and is therefore an unsafe function. Maybe we can change this in the future.
     pub unsafe fn const_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
@@ -95,7 +135,9 @@ impl<'ctx> PointerValue<'ctx> {
 
         PointerValue::new(value)
     }
+}
 
+impl<'ctx> PointerValue<'ctx> {
     pub fn const_to_int(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstPtrToInt(self.as_value_ref(), int_type.as_type_ref())) }
     }

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -75,7 +75,20 @@ impl<'ctx> PointerValue<'ctx> {
     pub unsafe fn const_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
         let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = {
             LLVMConstGEP2(
                 self.get_type().get_element_type().as_type_ref(),
@@ -85,7 +98,18 @@ impl<'ctx> PointerValue<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = {
             LLVMConstGEP(
                 self.as_value_ref(),
@@ -101,7 +125,20 @@ impl<'ctx> PointerValue<'ctx> {
     pub unsafe fn const_in_bounds_gep(self, ordered_indexes: &[IntValue<'ctx>]) -> PointerValue<'ctx> {
         let mut index_values: Vec<LLVMValueRef> = ordered_indexes.iter().map(|val| val.as_value_ref()).collect();
 
-        #[cfg(feature = "llvm14-0")]
+        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
+        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
+        #[cfg(not(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        )))]
         let value = {
             LLVMConstInBoundsGEP2(
                 self.get_type().get_element_type().as_type_ref(),
@@ -111,7 +148,18 @@ impl<'ctx> PointerValue<'ctx> {
             )
         };
 
-        #[cfg(not(feature = "llvm14-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+        ))]
         let value = {
             LLVMConstInBoundsGEP(
                 self.as_value_ref(),


### PR DESCRIPTION
## Description
All functions deprecated since llvm14 are replaced with recommended alternatives.
Other deprecations (e.g. `LLVMSetCurrentDebugLocation` in `builder.rs`, deprecated since llvm9.0 ) are **untouched**.

## Related Issue
I thought it might fix SEGV in https://github.com/TheDan64/inkwell/issues/343, but actually it doesn't.
However, such deprecation removal is always recommended and seems to have no room to argument, I just have directly opened this issue 😃.

## How This Has Been Tested
I have run test on Ubuntu22.04 LTS (x86_64 VM instance).
Since this is change only related to `llvm14-0` feature, I tested with:
```shell
cargo test --target=x86_64-unknown-linux-gnu --features=llvm14-0 --all
```
All tests and doctests are successfully passed.

## Breaking Changes

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

It does not break existing APIs, but I added implementation of `AsTypeRef` for `CallableValue` in order to get function type because it's required by `LLVMBuildCall2` and `LLVMBuildInvoke2`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
