### PR TITLE
Add support for pointer and array debug types 

### DIFF
--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -132,6 +132,7 @@ use llvm_sys::debuginfo::{
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::debuginfo::{LLVMDIBuilderCreateConstantValueExpression, LLVMDIBuilderCreateGlobalVariableExpression};
 use llvm_sys::prelude::{LLVMDIBuilderRef, LLVMMetadataRef};
+use llvm_sys_140::debuginfo::LLVMDIBuilderCreateReferenceType;
 use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -698,6 +699,26 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 address_space as u32,
                 name.as_ptr() as _,
                 name.len(),
+            )
+        };
+
+        DIDerivedType {
+            metadata_ref,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a pointer type
+    pub fn create_reference_type(
+        &self,
+        pointee: DIType<'ctx>,
+        tag: u32,
+    ) -> DIDerivedType<'ctx> {
+        let metadata_ref = unsafe {
+            LLVMDIBuilderCreateReferenceType(
+                self.builder,
+                tag,
+                pointee.metadata_ref,
             )
         };
 

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -123,16 +123,15 @@ use llvm_sys::debuginfo::{
     LLVMDIBuilderCreateCompileUnit, LLVMDIBuilderCreateDebugLocation, LLVMDIBuilderCreateExpression,
     LLVMDIBuilderCreateFile, LLVMDIBuilderCreateFunction, LLVMDIBuilderCreateLexicalBlock,
     LLVMDIBuilderCreateMemberType, LLVMDIBuilderCreateNameSpace, LLVMDIBuilderCreateParameterVariable,
-    LLVMDIBuilderCreatePointerType, LLVMDIBuilderCreateStructType, LLVMDIBuilderCreateSubroutineType,
-    LLVMDIBuilderCreateUnionType, LLVMDIBuilderFinalize, LLVMDIBuilderGetOrCreateSubrange,
-    LLVMDIBuilderInsertDbgValueBefore, LLVMDIBuilderInsertDeclareAtEnd, LLVMDIBuilderInsertDeclareBefore,
-    LLVMDILocationGetColumn, LLVMDILocationGetLine, LLVMDILocationGetScope, LLVMDITypeGetAlignInBits,
-    LLVMDITypeGetOffsetInBits, LLVMDITypeGetSizeInBits,
+    LLVMDIBuilderCreatePointerType, LLVMDIBuilderCreateReferenceType, LLVMDIBuilderCreateStructType, 
+    LLVMDIBuilderCreateSubroutineType, LLVMDIBuilderCreateUnionType, LLVMDIBuilderFinalize, 
+    LLVMDIBuilderGetOrCreateSubrange, LLVMDIBuilderInsertDbgValueBefore, LLVMDIBuilderInsertDeclareAtEnd, 
+    LLVMDIBuilderInsertDeclareBefore, LLVMDILocationGetColumn, LLVMDILocationGetLine, LLVMDILocationGetScope, 
+    LLVMDITypeGetAlignInBits, LLVMDITypeGetOffsetInBits, LLVMDITypeGetSizeInBits,
 };
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::debuginfo::{LLVMDIBuilderCreateConstantValueExpression, LLVMDIBuilderCreateGlobalVariableExpression};
 use llvm_sys::prelude::{LLVMDIBuilderRef, LLVMMetadataRef};
-use llvm_sys_140::debuginfo::LLVMDIBuilderCreateReferenceType;
 use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::ops::Range;

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -417,3 +417,93 @@ fn test_global_expressions() {
         gv.print_to_string()
     );
 }
+
+#[test]
+fn test_pointer_types() {
+    let context = Context::create();
+    let module = context.create_module("bin");
+
+    let (dibuilder, _) = module.create_debug_info_builder(
+        true,
+        DWARFSourceLanguage::C,
+        "source_file",
+        ".",
+        "my llvm compiler frontend",
+        false,
+        "",
+        0,
+        "",
+        DWARFEmissionKind::Full,
+        0,
+        false,
+        false,
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
+        "",
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
+        "",
+    );
+
+    let di_type = dibuilder
+        .create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO)
+        .unwrap()
+        .as_type();
+
+    //Smoke test that the pointer gets created
+    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace::Global);
+}
+
+#[test]
+fn test_array_type() {
+    let context = Context::create();
+    let module = context.create_module("bin");
+
+    let (dibuilder, _) = module.create_debug_info_builder(
+        true,
+        DWARFSourceLanguage::C,
+        "source_file",
+        ".",
+        "my llvm compiler frontend",
+        false,
+        "",
+        0,
+        "",
+        DWARFEmissionKind::Full,
+        0,
+        false,
+        false,
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
+        "",
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
+        "",
+    );
+
+    let di_type = dibuilder
+        .create_basic_type("type_name", 8_u64, 0x00, DIFlags::ZERO)
+        .unwrap()
+        .as_type();
+
+    //Smoke test that the array gets created
+    dibuilder.create_array_type(di_type, 160, 64, &[(0..20)]);
+
+    dibuilder.create_array_type(di_type, 160, 64, &[(0..20), (-1..30), (20..55)]);
+}

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -469,6 +469,56 @@ fn test_pointer_types() {
 }
 
 #[test]
+fn test_reference_types() {
+    let context = Context::create();
+    let module = context.create_module("bin");
+
+    let (dibuilder, _) = module.create_debug_info_builder(
+        true,
+        DWARFSourceLanguage::C,
+        "source_file",
+        ".",
+        "my llvm compiler frontend",
+        false,
+        "",
+        0,
+        "",
+        DWARFEmissionKind::Full,
+        0,
+        false,
+        false,
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
+        "",
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
+        "",
+    );
+
+    let di_type = dibuilder
+        .create_basic_type(
+            "type_name",
+            8_u64,
+            0x00,
+            #[cfg(not(feature = "llvm7-0"))]
+            DIFlags::ZERO,
+        )
+        .unwrap()
+        .as_type();
+
+    //Smoke test that the pointer gets created
+    dibuilder.create_reference_type(di_type, 0x1000);
+}
+
+#[test]
 fn test_array_type() {
     let context = Context::create();
     let module = context.create_module("bin");

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -454,7 +454,13 @@ fn test_pointer_types() {
     );
 
     let di_type = dibuilder
-        .create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO)
+        .create_basic_type(
+            "type_name",
+            8_u64,
+            0x00,
+            #[cfg(not(feature = "llvm7-0"))]
+            DIFlags::ZERO,
+        )
         .unwrap()
         .as_type();
 
@@ -498,7 +504,13 @@ fn test_array_type() {
     );
 
     let di_type = dibuilder
-        .create_basic_type("type_name", 8_u64, 0x00, DIFlags::ZERO)
+        .create_basic_type(
+            "type_name",
+            8_u64,
+            0x00,
+            #[cfg(not(feature = "llvm7-0"))]
+            DIFlags::ZERO,
+        )
         .unwrap()
         .as_type();
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

The debug info can now create a pointer or array type
Arrays support multiple dimensions passed as ranges
<!--- Describe your changes in detail -->

## Related Issue

Fixes #348 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

Created smoke tests insuring the call into the DI builder returns a type

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
