### PR TITLE
publish docs for each commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,12 @@
-name: Test Suite
+name: Test Suite and Doc
 
 on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
+  DOC_LLVM_FEATURE: llvm14-0
+  DOC_LLVM_VERSION: '14.0'
+  DOC_PATH: target/doc
 
 jobs:
   tests:
@@ -26,12 +29,32 @@ jobs:
           - ["14.0", "14-0"]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1.5.2
+        uses: KyleMayes/install-llvm-action@v1
         with:
           version: ${{ matrix.llvm-version[0] }}
       - name: Build
         run: cargo build --release --features llvm${{ matrix.llvm-version[1] }} --verbose
       - name: Run tests
         run: cargo test --release --features llvm${{ matrix.llvm-version[1] }} --verbose
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    needs: tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: ${{ env.DOC_LLVM_VERSION }}
+    - name: Build Documentation
+      run: cargo doc --features ${{ env.DOC_LLVM_FEATURE }} --verbose
+    - name: Doc Index Page Redirection
+      run: echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > ${{ env.DOC_PATH }}/index.html
+    - name: Deploy Documentation
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ${{ env.DOC_PATH }}
+        force_orphan: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install Rust Nightly
       run: rustup toolchain install nightly
     - name: Build Documentation
-      run: cargo +nightly doc --features ${{ env.DOC_LLVM_FEATURE }} --verbose
+      run: cargo +nightly doc --features ${{ env.DOC_LLVM_FEATURE }},nightly --verbose
     - name: Doc Index Page Redirection
       run: echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > ${{ env.DOC_PATH }}/index.html
     - name: Deploy Documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,10 @@ jobs:
     - uses: KyleMayes/install-llvm-action@v1
       with:
         version: ${{ env.DOC_LLVM_VERSION }}
+    - name: Install Rust Nightly
+      run: rustup toolchain install nightly
     - name: Build Documentation
-      run: cargo doc --features ${{ env.DOC_LLVM_FEATURE }} --verbose
+      run: cargo +nightly doc --features ${{ env.DOC_LLVM_FEATURE }} --verbose
     - name: Doc Index Page Redirection
       run: echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > ${{ env.DOC_PATH }}/index.html
     - name: Deploy Documentation


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
Modified GitHub Actions configuration to publish documentation on every push to `master`. It will only do so if the `tests` action succeeds, so we will not be publishing documentations for broken versions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
Probably related to #2.

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
The workflow runs correctly in my fork (see the log [here](https://github.com/ruifengx/inkwell/actions/runs/3187875220)), and here is the rendered documentation: <https://ruifengx.github.io/inkwell/>.

**EDIT:** note that I arranged the action to only build for `llvm14-0`. Please check if this is the desired behaviour. Also, the documentation looks very different from the old one, so please confirm it looks correct.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
