### PR TITLE
change AnyValueEnum constructor to fix Issue #71

### DIFF
--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -1,6 +1,6 @@
 use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf};
 use llvm_sys::prelude::LLVMValueRef;
-use llvm_sys::LLVMTypeKind;
+use llvm_sys::{LLVMTypeKind,LLVMValueKind};
 
 use crate::types::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::traits::AsValueRef;
@@ -82,7 +82,12 @@ impl<'ctx> AnyValueEnum<'ctx> {
             | LLVMTypeKind::LLVMPPC_FP128TypeKind => AnyValueEnum::FloatValue(FloatValue::new(value)),
             LLVMTypeKind::LLVMIntegerTypeKind => AnyValueEnum::IntValue(IntValue::new(value)),
             LLVMTypeKind::LLVMStructTypeKind => AnyValueEnum::StructValue(StructValue::new(value)),
-            LLVMTypeKind::LLVMPointerTypeKind => AnyValueEnum::PointerValue(PointerValue::new(value)),
+            LLVMTypeKind::LLVMPointerTypeKind => {
+                match LLVMGetValueKind(value){
+                    LLVMValueKind::LLVMFunctionValueKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),
+                    _ =>  AnyValueEnum::PointerValue(PointerValue::new(value)),
+                }
+            }
             LLVMTypeKind::LLVMArrayTypeKind => AnyValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyValueEnum::VectorValue(VectorValue::new(value)),
             LLVMTypeKind::LLVMFunctionTypeKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -1,6 +1,6 @@
-use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf,LLVMGetValueKind};
+use llvm_sys::core::{LLVMGetTypeKind, LLVMGetValueKind, LLVMIsAInstruction, LLVMTypeOf};
 use llvm_sys::prelude::LLVMValueRef;
-use llvm_sys::{LLVMTypeKind,LLVMValueKind};
+use llvm_sys::{LLVMTypeKind, LLVMValueKind};
 
 use crate::types::{AnyTypeEnum, BasicTypeEnum};
 use crate::values::traits::AsValueRef;
@@ -82,12 +82,10 @@ impl<'ctx> AnyValueEnum<'ctx> {
             | LLVMTypeKind::LLVMPPC_FP128TypeKind => AnyValueEnum::FloatValue(FloatValue::new(value)),
             LLVMTypeKind::LLVMIntegerTypeKind => AnyValueEnum::IntValue(IntValue::new(value)),
             LLVMTypeKind::LLVMStructTypeKind => AnyValueEnum::StructValue(StructValue::new(value)),
-            LLVMTypeKind::LLVMPointerTypeKind => {
-                match LLVMGetValueKind(value){
-                    LLVMValueKind::LLVMFunctionValueKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),
-                    _ =>  AnyValueEnum::PointerValue(PointerValue::new(value)),
-                }
-            }
+            LLVMTypeKind::LLVMPointerTypeKind => match LLVMGetValueKind(value) {
+                LLVMValueKind::LLVMFunctionValueKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),
+                _ => AnyValueEnum::PointerValue(PointerValue::new(value)),
+            },
             LLVMTypeKind::LLVMArrayTypeKind => AnyValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyValueEnum::VectorValue(VectorValue::new(value)),
             LLVMTypeKind::LLVMFunctionTypeKind => AnyValueEnum::FunctionValue(FunctionValue::new(value).unwrap()),

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -1,4 +1,4 @@
-use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf};
+use llvm_sys::core::{LLVMGetTypeKind, LLVMIsAInstruction, LLVMTypeOf,LLVMGetValueKind};
 use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::{LLVMTypeKind,LLVMValueKind};
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description
This PR change the constructors of AnyValueEnum to properly create a FunctionValue instead of PointerValue from LLVMValueRef, and thus addressed the error when calling 'into_function_value'.
<!--- Describe your changes in detail -->

## Related Issue
 #71 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested
LLVM version 14.0, i just modified it to properly run in my project, so only a bit of testing is done.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->


<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
