### PR TITLE
Fix `get_ref` for contexts

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1233,7 +1233,7 @@ impl Drop for Context {
 #[cfg(feature = "internal-getters")]
 impl LLVMReference<LLVMContextRef> for Context {
     unsafe fn get_ref(&self) -> LLVMContextRef {
-        self.context
+        self.context.0
     }
 }
 
@@ -2027,6 +2027,6 @@ impl<'ctx> ContextRef<'ctx> {
 #[cfg(feature = "internal-getters")]
 impl LLVMReference<LLVMContextRef> for ContextRef<'_> {
     unsafe fn get_ref(&self) -> LLVMContextRef {
-        self.context
+        self.context.0
     }
 }


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

Unwrap ContextImpl to get the LLVMContextRef before returning from get_ref.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

Closes #363.

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested by compiling Inkwell. It seems like CI doesn't build with the internal-getters feature.

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)