### PR TITLE
Support llvm-15 for inkwell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
-  DOC_LLVM_FEATURE: llvm14-0
-  DOC_LLVM_VERSION: '14.0'
+  DOC_LLVM_FEATURE: llvm15-0
+  DOC_LLVM_VERSION: '15.0'
   DOC_PATH: target/doc
 
 jobs:
@@ -27,6 +27,7 @@ jobs:
           - ["12.0", "12-0"]
           - ["13.0", "13-0"]
           - ["14.0", "14-0"]
+          - ["15.0", "15-0"]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ llvm11-0 = ["llvm-sys-110"]
 llvm12-0 = ["llvm-sys-120"]
 llvm13-0 = ["llvm-sys-130"]
 llvm14-0 = ["llvm-sys-140"]
+llvm15-0 = ["llvm-sys-150"]
 # Don't link aganist LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
 # `no-llvm-linking` feature across the board of llvm versions, as it'll cause
@@ -41,6 +42,7 @@ llvm11-0-no-llvm-linking = ["llvm11-0", "llvm-sys-110/no-llvm-linking"]
 llvm12-0-no-llvm-linking = ["llvm12-0", "llvm-sys-120/no-llvm-linking"]
 llvm13-0-no-llvm-linking = ["llvm13-0", "llvm-sys-130/no-llvm-linking"]
 llvm14-0-no-llvm-linking = ["llvm14-0", "llvm-sys-140/no-llvm-linking"]
+llvm15-0-no-llvm-linking = ["llvm15-0", "llvm-sys-150/no-llvm-linking"]
 # Don't force linking to libffi on non-windows platforms. Without this feature
 # inkwell always links to libffi on non-windows platforms.
 no-libffi-linking = []
@@ -97,6 +99,7 @@ llvm-sys-110 = { package = "llvm-sys", version = "110.0.3", optional = true }
 llvm-sys-120 = { package = "llvm-sys", version = "120.2.4", optional = true }
 llvm-sys-130 = { package = "llvm-sys", version = "130.0.4", optional = true }
 llvm-sys-140 = { package = "llvm-sys", version = "140.0.2", optional = true }
+llvm-sys-150 = { package = "llvm-sys", version = "150.0.0", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.12"
 static-alloc = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ llvm-sys-110 = { package = "llvm-sys", version = "110.0.3", optional = true }
 llvm-sys-120 = { package = "llvm-sys", version = "120.2.4", optional = true }
 llvm-sys-130 = { package = "llvm-sys", version = "130.0.4", optional = true }
 llvm-sys-140 = { package = "llvm-sys", version = "140.0.2", optional = true }
-llvm-sys-150 = { package = "llvm-sys", version = "150.0.0", optional = true }
+llvm-sys-150 = { package = "llvm-sys", version = "150.0.3", optional = true }
 once_cell = "1.4.1"
 parking_lot = "0.12"
 static-alloc = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Supported versions:
 | 12.0.x       | llvm12-0      |
 | 13.0.x       | llvm13-0      |
 | 14.0.x       | llvm14-0      |
+| 15.0.x [WIP] | llvm15-0      |
 
 Please be aware that we may make breaking changes on master from time to time since we are
 pre-v1.0.0, in compliance with semver. Please prefer a crates.io release whenever possible!
@@ -133,6 +134,13 @@ you need `unsafe` when calling into C).
 ### LLVM's [Kaleidoscope Tutorial](https://llvm.org/docs/tutorial/index.html)
 
 Can be found in the examples directory.
+
+### Build and Test instructions
+
+```sh
+$ cargo build --features llvm15-0
+$ cargo test --features llvm15-0
+```
 
 ## Alternative Crate(s)
 

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -12,9 +12,9 @@ use syn::{parenthesized, parse_macro_input, parse_quote};
 use syn::{Attribute, Field, Ident, Item, LitFloat, Token, Variant};
 
 // This array should match the LLVM features in the top level Cargo manifest
-const FEATURE_VERSIONS: [&str; 11] = [
+const FEATURE_VERSIONS: [&str; 12] = [
     "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0",
-    "llvm14-0",
+    "llvm14-0", "llvm15-0",
 ];
 
 /// Gets the index of the feature version that represents `latest`

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -185,14 +185,16 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
-            feature = "llvm14-0"
+            feature = "llvm14-0",
+            feature = "llvm15-0"
         ))]
         sysroot: &str,
         #[cfg(any(
             feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
-            feature = "llvm14-0"
+            feature = "llvm14-0",
+            feature = "llvm15-0"
         ))]
         sdk: &str,
     ) -> (Self, DICompileUnit<'ctx>) {
@@ -227,14 +229,16 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             sysroot,
             #[cfg(any(
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             sdk,
         );
@@ -272,14 +276,16 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
-            feature = "llvm14-0"
+            feature = "llvm14-0",
+            feature = "llvm15-0"
         ))]
         sysroot: &str,
         #[cfg(any(
             feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
-            feature = "llvm14-0"
+            feature = "llvm14-0",
+            feature = "llvm15-0"
         ))]
         sdk: &str,
     ) -> DICompileUnit<'ctx> {
@@ -317,7 +323,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             {
                 LLVMDIBuilderCreateCompileUnit(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ extern crate llvm_sys_120 as llvm_sys;
 extern crate llvm_sys_130 as llvm_sys;
 #[cfg(feature = "llvm14-0")]
 extern crate llvm_sys_140 as llvm_sys;
+#[cfg(feature = "llvm15-0")]
+extern crate llvm_sys_150 as llvm_sys;
 #[cfg(feature = "llvm4-0")]
 extern crate llvm_sys_40 as llvm_sys;
 #[cfg(feature = "llvm5-0")]
@@ -103,7 +105,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0", "llvm14-0"}
+assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0", "llvm14-0", "llvm15-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,8 +331,12 @@ pub enum AtomicRMWBinOp {
     #[llvm_versions(10.0..=latest)]
     #[llvm_variant(LLVMAtomicRMWBinOpFSub)]
     FSub,
+
+    #[llvm_versions(15.0..=latest)]
     #[llvm_variant(LLVMAtomicRMWBinOpFMax)]
     FMax,
+
+    #[llvm_versions(15.0..=latest)]
     #[llvm_variant(LLVMAtomicRMWBinOpFMin)]
     FMin,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,10 @@ pub enum AtomicRMWBinOp {
     #[llvm_versions(10.0..=latest)]
     #[llvm_variant(LLVMAtomicRMWBinOpFSub)]
     FSub,
+    #[llvm_variant(LLVMAtomicRMWBinOpFMax)]
+    FMax,
+    #[llvm_variant(LLVMAtomicRMWBinOpFMin)]
+    FMin,
 }
 
 /// Defines the optimization level used to compile a `Module`.

--- a/src/module.rs
+++ b/src/module.rs
@@ -1416,14 +1416,16 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
-            feature = "llvm14-0"
+            feature = "llvm14-0",
+            feature = "llvm15-0"
         ))]
         sysroot: &str,
         #[cfg(any(
             feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
-            feature = "llvm14-0"
+            feature = "llvm14-0",
+            feature = "llvm15-0"
         ))]
         sdk: &str,
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
@@ -1446,14 +1448,16 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             sysroot,
             #[cfg(any(
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             sdk,
         )

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -11,27 +11,41 @@ use llvm_sys::initialization::{
 use llvm_sys::prelude::{LLVMPassManagerRef, LLVMPassRegistryRef};
 #[llvm_versions(10.0..=latest)]
 use llvm_sys::transforms::ipo::LLVMAddMergeFunctionsPass;
+
+#[llvm_versions(10.0..=14.0)]
 use llvm_sys::transforms::ipo::{
-    LLVMAddAlwaysInlinerPass, LLVMAddArgumentPromotionPass, LLVMAddConstantMergePass, LLVMAddDeadArgEliminationPass,
+    LLVMAddArgumentPromotionPass
+};
+
+use llvm_sys::transforms::ipo::{
+    LLVMAddAlwaysInlinerPass, LLVMAddConstantMergePass, LLVMAddDeadArgEliminationPass,
     LLVMAddFunctionAttrsPass, LLVMAddFunctionInliningPass, LLVMAddGlobalDCEPass, LLVMAddGlobalOptimizerPass,
     LLVMAddIPSCCPPass, LLVMAddInternalizePass, LLVMAddPruneEHPass, LLVMAddStripDeadPrototypesPass,
     LLVMAddStripSymbolsPass,
 };
+
+#[llvm_versions(10.0..=14.0)]
+use llvm_sys::transforms::pass_manager_builder::LLVMPassManagerBuilderPopulateLTOPassManager;
+
 use llvm_sys::transforms::pass_manager_builder::{
     LLVMPassManagerBuilderCreate, LLVMPassManagerBuilderDispose, LLVMPassManagerBuilderPopulateFunctionPassManager,
-    LLVMPassManagerBuilderPopulateLTOPassManager, LLVMPassManagerBuilderPopulateModulePassManager,
+    LLVMPassManagerBuilderPopulateModulePassManager,
     LLVMPassManagerBuilderRef, LLVMPassManagerBuilderSetDisableSimplifyLibCalls,
     LLVMPassManagerBuilderSetDisableUnitAtATime, LLVMPassManagerBuilderSetDisableUnrollLoops,
     LLVMPassManagerBuilderSetOptLevel, LLVMPassManagerBuilderSetSizeLevel,
     LLVMPassManagerBuilderUseInlinerWithThreshold,
 };
+
+#[llvm_versions(10.0..=14.0)]
+use llvm_sys::transforms::scalar::LLVMAddLoopUnswitchPass;
+
 use llvm_sys::transforms::scalar::{
     LLVMAddAggressiveDCEPass, LLVMAddAlignmentFromAssumptionsPass, LLVMAddBasicAliasAnalysisPass,
     LLVMAddBitTrackingDCEPass, LLVMAddCFGSimplificationPass, LLVMAddCorrelatedValuePropagationPass,
     LLVMAddDeadStoreEliminationPass, LLVMAddDemoteMemoryToRegisterPass, LLVMAddEarlyCSEPass, LLVMAddGVNPass,
     LLVMAddIndVarSimplifyPass, LLVMAddInstructionCombiningPass, LLVMAddJumpThreadingPass, LLVMAddLICMPass,
     LLVMAddLoopDeletionPass, LLVMAddLoopIdiomPass, LLVMAddLoopRerollPass, LLVMAddLoopRotatePass, LLVMAddLoopUnrollPass,
-    LLVMAddLoopUnswitchPass, LLVMAddLowerExpectIntrinsicPass, LLVMAddMemCpyOptPass, LLVMAddMergedLoadStoreMotionPass,
+    LLVMAddLowerExpectIntrinsicPass, LLVMAddMemCpyOptPass, LLVMAddMergedLoadStoreMotionPass,
     LLVMAddPartiallyInlineLibCallsPass, LLVMAddReassociatePass, LLVMAddSCCPPass, LLVMAddScalarReplAggregatesPass,
     LLVMAddScalarReplAggregatesPassSSA, LLVMAddScalarReplAggregatesPassWithThreshold, LLVMAddScalarizerPass,
     LLVMAddScopedNoAliasAAPass, LLVMAddSimplifyLibCallsPass, LLVMAddTailCallEliminationPass,
@@ -183,6 +197,7 @@ impl PassManagerBuilder {
     ///
     /// pass_manager_builder.populate_lto_pass_manager(&lpm, false, false);
     /// ```
+    #[llvm_versions(10.0..=14.0)]
     pub fn populate_lto_pass_manager(&self, pass_manager: &PassManager<Module>, internalize: bool, run_inliner: bool) {
         unsafe {
             LLVMPassManagerBuilderPopulateLTOPassManager(
@@ -300,6 +315,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// only stored to (returning the value instead), but does not currently.
     /// This case would be best handled when and if LLVM starts supporting multiple
     /// return values from functions.
+    #[llvm_versions(10.0..=14.0)]
     pub fn add_argument_promotion_pass(&self) {
         unsafe { LLVMAddArgumentPromotionPass(self.pass_manager) }
     }
@@ -721,6 +737,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// to be run before it to hoist invariant conditions
     /// out of the loop, to make the unswitching opportunity
     /// obvious.
+    #[llvm_versions(10.0..=14.0)]
     pub fn add_loop_unswitch_pass(&self) {
         unsafe { LLVMAddLoopUnswitchPass(self.pass_manager) }
     }
@@ -1008,28 +1025,28 @@ impl<T: PassManagerSubType> PassManager<T> {
         unsafe { LLVMAddLoopUnrollAndJamPass(self.pass_manager) }
     }
 
-    #[llvm_versions(8.0..=latest)]
+    #[llvm_versions(8.0..=14.0)]
     pub fn add_coroutine_early_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroEarlyPass;
 
         unsafe { LLVMAddCoroEarlyPass(self.pass_manager) }
     }
 
-    #[llvm_versions(8.0..=latest)]
+    #[llvm_versions(8.0..=14.0)]
     pub fn add_coroutine_split_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroSplitPass;
 
         unsafe { LLVMAddCoroSplitPass(self.pass_manager) }
     }
 
-    #[llvm_versions(8.0..=latest)]
+    #[llvm_versions(8.0..=14.0)]
     pub fn add_coroutine_elide_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroElidePass;
 
         unsafe { LLVMAddCoroElidePass(self.pass_manager) }
     }
 
-    #[llvm_versions(8.0..=latest)]
+    #[llvm_versions(8.0..=14.0)]
     pub fn add_coroutine_cleanup_pass(&self) {
         use llvm_sys::transforms::coroutines::LLVMAddCoroCleanupPass;
 

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -216,7 +216,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMLabelTypeKind => panic!("FIXME: Unsupported type: Label"),
@@ -230,12 +231,13 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => unreachable!("Metadata type is not supported as AnyType."),
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("FIXME: Unsupported type: MMX"),
-            #[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0"))]
+            #[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm15-0"))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => panic!("FIXME: Unsupported type: AMX"),
             LLVMTypeKind::LLVMTokenTypeKind => panic!("FIXME: Unsupported type: Token"),
         }
@@ -383,7 +385,8 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMIntegerTypeKind => BasicTypeEnum::IntType(IntType::new(type_)),
@@ -395,14 +398,15 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm11-0",
                 feature = "llvm12-0",
                 feature = "llvm13-0",
-                feature = "llvm14-0"
+                feature = "llvm14-0",
+                feature = "llvm15-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => unreachable!("Unsupported basic type: Metadata"),
             // see https://llvm.org/docs/LangRef.html#x86-mmx-type
             LLVMTypeKind::LLVMX86_MMXTypeKind => unreachable!("Unsupported basic type: MMX"),
             // see https://llvm.org/docs/LangRef.html#x86-amx-type
-            #[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0"))]
+            #[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm15-0"))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => unreachable!("Unsupported basic type: AMX"),
             LLVMTypeKind::LLVMLabelTypeKind => unreachable!("Unsupported basic type: Label"),
             LLVMTypeKind::LLVMVoidTypeKind => unreachable!("Unsupported basic type: VoidType"),

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -1,7 +1,13 @@
+#[llvm_versions(10.0..=14.0)]
 use llvm_sys::core::{
-    LLVMConstFAdd, LLVMConstFCmp, LLVMConstFDiv, LLVMConstFMul, LLVMConstFNeg, LLVMConstFPCast, LLVMConstFPExt,
-    LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc, LLVMConstFRem, LLVMConstFSub, LLVMConstRealGetDouble,
+    LLVMConstFAdd, LLVMConstFMul, LLVMConstFDiv, LLVMConstFRem, LLVMConstFSub,
 };
+
+use llvm_sys::core::{
+    LLVMConstFCmp, LLVMConstFNeg, LLVMConstFPCast, LLVMConstFPExt,
+    LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc,  LLVMConstRealGetDouble,
+};
+
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::convert::TryFrom;
@@ -64,22 +70,27 @@ impl<'ctx> FloatValue<'ctx> {
         unsafe { FloatValue::new(LLVMConstFNeg(self.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_add(self, rhs: FloatValue<'ctx>) -> Self {
         unsafe { FloatValue::new(LLVMConstFAdd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_sub(self, rhs: FloatValue<'ctx>) -> Self {
         unsafe { FloatValue::new(LLVMConstFSub(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_mul(self, rhs: FloatValue<'ctx>) -> Self {
         unsafe { FloatValue::new(LLVMConstFMul(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_div(self, rhs: FloatValue<'ctx>) -> Self {
         unsafe { FloatValue::new(LLVMConstFDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_remainder(self, rhs: FloatValue<'ctx>) -> Self {
         unsafe { FloatValue::new(LLVMConstFRem(self.as_value_ref(), rhs.as_value_ref())) }
     }

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -1,12 +1,17 @@
-#[llvm_versions(4.0..=latest)]
+#[llvm_versions(4.0..=14.0)]
 use llvm_sys::core::LLVMConstExactUDiv;
+#[llvm_versions(10.0..=14.0)]
 use llvm_sys::core::{
-    LLVMConstAShr, LLVMConstAdd, LLVMConstAnd, LLVMConstBitCast, LLVMConstExactSDiv, LLVMConstICmp, LLVMConstIntCast,
+    LLVMConstExactSDiv, LLVMConstSDiv, LLVMConstSRem, LLVMConstURem, LLVMConstUDiv
+};
+
+use llvm_sys::core::{
+    LLVMConstAShr, LLVMConstAdd, LLVMConstAnd, LLVMConstBitCast, LLVMConstICmp, LLVMConstIntCast,
     LLVMConstIntGetSExtValue, LLVMConstIntGetZExtValue, LLVMConstIntToPtr, LLVMConstLShr, LLVMConstMul,
     LLVMConstNSWAdd, LLVMConstNSWMul, LLVMConstNSWNeg, LLVMConstNSWSub, LLVMConstNUWAdd, LLVMConstNUWMul,
-    LLVMConstNUWNeg, LLVMConstNUWSub, LLVMConstNeg, LLVMConstNot, LLVMConstOr, LLVMConstSDiv, LLVMConstSExt,
-    LLVMConstSExtOrBitCast, LLVMConstSIToFP, LLVMConstSRem, LLVMConstSelect, LLVMConstShl, LLVMConstSub,
-    LLVMConstTrunc, LLVMConstTruncOrBitCast, LLVMConstUDiv, LLVMConstUIToFP, LLVMConstURem, LLVMConstXor,
+    LLVMConstNUWNeg, LLVMConstNUWSub, LLVMConstNeg, LLVMConstNot, LLVMConstOr, LLVMConstSExt,
+    LLVMConstSExtOrBitCast, LLVMConstSIToFP, LLVMConstSelect, LLVMConstShl, LLVMConstSub,
+    LLVMConstTrunc, LLVMConstTruncOrBitCast, LLVMConstUIToFP, LLVMConstXor,
     LLVMConstZExt, LLVMConstZExtOrBitCast, LLVMIsAConstantInt,
 };
 use llvm_sys::prelude::LLVMValueRef;
@@ -120,27 +125,32 @@ impl<'ctx> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstNUWMul(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_unsigned_div(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstUDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_signed_div(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstSDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_exact_signed_div(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstExactSDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
-    #[llvm_versions(4.0..=latest)]
+    #[llvm_versions(4.0..=14.0)]
     pub fn const_exact_unsigned_div(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstExactUDiv(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_unsigned_remainder(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstURem(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(10.0..=14.0)]
     pub fn const_signed_remainder(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstSRem(self.as_value_ref(), rhs.as_value_ref())) }
     }

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -32,7 +32,7 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 26;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 28;
 #[cfg(any(feature = "llvm10-0", feature = "llvm11-0"))]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 30;
-#[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0"))]
+#[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0", feature = "llvm15-0"))]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 31;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]

--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -1,4 +1,6 @@
+#[llvm_versions(4.0..=14.0)]
 use llvm_sys::core::{LLVMConstExtractValue, LLVMConstInsertValue};
+
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::fmt::Debug;
@@ -55,6 +57,7 @@ pub trait AggregateValue<'ctx>: BasicValue<'ctx> {
     // REVIEW: How does LLVM treat out of bound index? Maybe we should return an Option?
     // or is that only in bounds GEP
     // REVIEW: Should this be AggregatePointerValue?
+    #[llvm_versions(4.0..=14.0)]
     fn const_extract_value(&self, indexes: &mut [u32]) -> BasicValueEnum<'ctx> {
         unsafe {
             BasicValueEnum::new(LLVMConstExtractValue(
@@ -66,6 +69,7 @@ pub trait AggregateValue<'ctx>: BasicValue<'ctx> {
     }
 
     // SubTypes: value should really be T in self: VectorValue<T> I think
+    #[llvm_versions(4.0..=14.0)]
     fn const_insert_value<BV: BasicValue<'ctx>>(&self, value: BV, indexes: &mut [u32]) -> BasicValueEnum<'ctx> {
         unsafe {
             BasicValueEnum::new(LLVMConstInsertValue(


### PR DESCRIPTION
## Description

Added llvm-15 support
https://github.com/TheDan64/inkwell/issues/359

## Issues
Still has build errors.

```sh
argo build
   Compiling inkwell v0.1.0 (/run/media/inkwell)
error: One of the LLVM feature flags must be provided: llvm4-0 llvm5-0 llvm6-0 llvm7-0 llvm8-0 llvm9-0 llvm10-0 llvm11-0 llvm12-0 llvm13-0 llvm14-0 llvm15-0 
   --> src/lib.rs:97:9
    |
97  |         compile_error!(concat!("One of the LLVM feature flags must be provided: ", $($all, " "),*));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
108 | assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0", "llvm14-0", "llvm15-0"}
    | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `assert_used_features` which comes from the expansion of the macro `assert_unique_used_features` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: use of undeclared crate or module `llvm_sys`
 --> src/support/error_handling.rs:4:5
  |
4 | use llvm_sys::core::{LLVMGetDiagInfoDescription, LLVMGetDiagInfoSeverity};
  |     ^^^^^^^^ use of undeclared crate or module `llvm_sys`
```