### PR TITLE
Add method to get type by its name

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -945,6 +945,10 @@ impl Context {
     /// # Example
     ///
     /// ```no_run
+    /// use inkwell::context::Context;
+	/// use inkwell::types::AnyTypeEnum;
+    ///
+    /// let context = Context::create();
     ///	let name = "opaque";
     ///	let opaque = context.opaque_struct_type(name);
     ///
@@ -1777,6 +1781,10 @@ impl<'ctx> ContextRef<'ctx> {
     /// # Example
     ///
     /// ```no_run
+    /// use inkwell::context::Context;
+	/// use inkwell::types::AnyTypeEnum;
+    ///
+    /// let context = Context::create();
     ///	let name = "opaque";
     ///	let opaque = context.opaque_struct_type(name);
     ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -1768,6 +1768,24 @@ impl<'ctx> ContextRef<'ctx> {
         self.context.opaque_struct_type(name)
     }
 
+    /// Get type by its name, if it exists.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    ///	let name = "opaque";
+    ///	let opaque = context.opaque_struct_type(name);
+    ///
+    /// let got = context.get_type(name);
+    ///	assert_eq!(got, Some(AnyTypeEnum::from(opaque)));
+    ///
+    /// assert_eq!(context.get_type("non-existent"), None);
+    /// ```
+    #[inline]
+    pub fn get_type(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
+        self.context.get_type(name)
+    }
+
     /// Creates a constant `StructValue` from constant values.
     ///
     /// # Example

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,8 @@ use llvm_sys::core::LLVMConstInlineAsm;
 use llvm_sys::core::LLVMCreateTypeAttribute;
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::core::LLVMGetInlineAsm;
+#[llvm_versions(4.0..12.0)]
+use llvm_sys::core::LLVMGetTypeByName;
 #[llvm_versions(12.0..=latest)]
 use llvm_sys::core::LLVMGetTypeByName2;
 #[llvm_versions(6.0..=latest)]
@@ -265,7 +267,7 @@ impl ContextImpl {
     }
 
     #[llvm_versions(12.0..=latest)]
-    fn get_type<'ctx>(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
+    fn get_struct_type<'ctx>(&self, name: &str) -> Option<StructType<'ctx>> {
         let c_string = to_c_str(name);
 
         let ty = unsafe { LLVMGetTypeByName2(self.0, c_string.as_ptr()) };
@@ -273,7 +275,7 @@ impl ContextImpl {
             return None;
         }
 
-        unsafe { Some(AnyTypeEnum::new(ty)) }
+        unsafe { Some(StructType::new(ty)) }
     }
 
     fn const_struct<'ctx>(&self, values: &[BasicValueEnum], packed: bool) -> StructValue<'ctx> {
@@ -940,27 +942,25 @@ impl Context {
         self.context.opaque_struct_type(name)
     }
 
-    /// Get type by its name, if it exists.
+    /// Gets a named [`StructType`] from this `Context`.
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```rust,no_run
     /// use inkwell::context::Context;
-	/// use inkwell::types::AnyTypeEnum;
     ///
     /// let context = Context::create();
-    ///	let name = "opaque";
-    ///	let opaque = context.opaque_struct_type(name);
     ///
-    /// let got = context.get_type(name);
-    ///	assert_eq!(got, Some(AnyTypeEnum::from(opaque)));
+    /// assert!(context.get_struct_type("foo").is_none());
     ///
-    /// assert_eq!(context.get_type("non-existent"), None);
+    /// let opaque = context.opaque_struct_type("foo");
+    ///
+    /// assert_eq!(context.get_struct_type("foo").unwrap(), opaque);
     /// ```
     #[inline]
     #[llvm_versions(12.0..=latest)]
-    pub fn get_type<'ctx>(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
-        self.context.get_type(name)
+    pub fn get_struct_type<'ctx>(&self, name: &str) -> Option<StructType<'ctx>> {
+        self.context.get_struct_type(name)
     }
 
     /// Creates a constant `StructValue` from constant values.
@@ -1776,27 +1776,25 @@ impl<'ctx> ContextRef<'ctx> {
         self.context.opaque_struct_type(name)
     }
 
-    /// Get type by its name, if it exists.
+    /// Gets a named [`StructType`] from this `Context`.
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```rust,no_run
     /// use inkwell::context::Context;
-	/// use inkwell::types::AnyTypeEnum;
     ///
     /// let context = Context::create();
-    ///	let name = "opaque";
-    ///	let opaque = context.opaque_struct_type(name);
     ///
-    /// let got = context.get_type(name);
-    ///	assert_eq!(got, Some(AnyTypeEnum::from(opaque)));
+    /// assert!(context.get_struct_type("foo").is_none());
     ///
-    /// assert_eq!(context.get_type("non-existent"), None);
+    /// let opaque = context.opaque_struct_type("foo");
+    ///
+    /// assert_eq!(context.get_struct_type("foo").unwrap(), opaque);
     /// ```
     #[inline]
     #[llvm_versions(12.0..=latest)]
-    pub fn get_type(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
-        self.context.get_type(name)
+    pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
+        self.context.get_struct_type(name)
     }
 
     /// Creates a constant `StructValue` from constant values.

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,13 +9,15 @@ use llvm_sys::core::LLVMConstInlineAsm;
 use llvm_sys::core::LLVMCreateTypeAttribute;
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::core::LLVMGetInlineAsm;
+#[llvm_versions(12.0..=latest)]
+use llvm_sys::core::LLVMGetTypeByName2;
 #[llvm_versions(6.0..=latest)]
 use llvm_sys::core::LLVMMetadataTypeInContext;
 use llvm_sys::core::{
     LLVMAppendBasicBlockInContext, LLVMConstStringInContext, LLVMConstStructInContext, LLVMContextCreate,
     LLVMContextDispose, LLVMContextSetDiagnosticHandler, LLVMCreateBuilderInContext, LLVMCreateEnumAttribute,
     LLVMCreateStringAttribute, LLVMDoubleTypeInContext, LLVMFP128TypeInContext, LLVMFloatTypeInContext,
-    LLVMGetGlobalContext, LLVMGetMDKindIDInContext, LLVMGetTypeByName2, LLVMGetTypeKind, LLVMHalfTypeInContext,
+    LLVMGetGlobalContext, LLVMGetMDKindIDInContext, LLVMGetTypeKind, LLVMHalfTypeInContext,
     LLVMInsertBasicBlockInContext, LLVMInt16TypeInContext, LLVMInt1TypeInContext, LLVMInt32TypeInContext,
     LLVMInt64TypeInContext, LLVMInt8TypeInContext, LLVMIntTypeInContext, LLVMMDNodeInContext, LLVMMDStringInContext,
     LLVMModuleCreateWithNameInContext, LLVMPPCFP128TypeInContext, LLVMStructCreateNamed, LLVMStructTypeInContext,
@@ -262,6 +264,7 @@ impl ContextImpl {
         unsafe { StructType::new(LLVMStructCreateNamed(self.0, c_string.as_ptr())) }
     }
 
+    #[llvm_versions(12.0..=latest)]
     fn get_type<'ctx>(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
         let c_string = to_c_str(name);
 
@@ -951,6 +954,7 @@ impl Context {
     /// assert_eq!(context.get_type("non-existent"), None);
     /// ```
     #[inline]
+    #[llvm_versions(12.0..=latest)]
     pub fn get_type<'ctx>(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
         self.context.get_type(name)
     }
@@ -1782,6 +1786,7 @@ impl<'ctx> ContextRef<'ctx> {
     /// assert_eq!(context.get_type("non-existent"), None);
     /// ```
     #[inline]
+    #[llvm_versions(12.0..=latest)]
     pub fn get_type(&self, name: &str) -> Option<AnyTypeEnum<'ctx>> {
         self.context.get_type(name)
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -6,8 +6,8 @@ use llvm_sys::bit_reader::LLVMParseBitcodeInContext;
 use llvm_sys::bit_writer::{LLVMWriteBitcodeToFile, LLVMWriteBitcodeToMemoryBuffer};
 #[llvm_versions(4.0..14.0)]
 use llvm_sys::core::LLVMGetTypeByName;
-#[llvm_versions(14.0..=latest)]
-use llvm_sys::core::LLVMGetTypeByName2;
+
+
 use llvm_sys::core::{
     LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddNamedMetadataOperand, LLVMCloneModule,
     LLVMDisposeModule, LLVMDumpModule, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetLastFunction,
@@ -349,37 +349,10 @@ impl<'ctx> Module<'ctx> {
     /// assert_eq!(module.get_struct_type("foo").unwrap(), opaque);
     /// ```
     ///
+    #[llvm_versions(4.0..12.0)]
     pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
         let c_string = to_c_str(name);
 
-        // This ugly cfg specification is due to limitation of custom attributes (for more information, see https://github.com/rust-lang/rust/issues/54727).
-        // Once custom attriutes inside methods are enabled, this should be replaced with #[llvm_version(14.0..=latest)]
-        #[cfg(not(any(
-            feature = "llvm4-0",
-            feature = "llvm5-0",
-            feature = "llvm6-0",
-            feature = "llvm7-0",
-            feature = "llvm8-0",
-            feature = "llvm9-0",
-            feature = "llvm10-0",
-            feature = "llvm11-0",
-            feature = "llvm12-0",
-            feature = "llvm13-0",
-        )))]
-        let struct_type = unsafe { LLVMGetTypeByName2(self.get_context().context.0, c_string.as_ptr()) };
-
-        #[cfg(any(
-            feature = "llvm4-0",
-            feature = "llvm5-0",
-            feature = "llvm6-0",
-            feature = "llvm7-0",
-            feature = "llvm8-0",
-            feature = "llvm9-0",
-            feature = "llvm10-0",
-            feature = "llvm11-0",
-            feature = "llvm12-0",
-            feature = "llvm13-0",
-        ))]
         let struct_type = unsafe { LLVMGetTypeByName(self.module.get(), c_string.as_ptr()) };
 
         if struct_type.is_null() {
@@ -387,6 +360,27 @@ impl<'ctx> Module<'ctx> {
         }
 
         unsafe { Some(StructType::new(struct_type)) }
+    }
+
+    /// Gets a named `StructType` from this `Module`'s `Context`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let module = context.create_module("my_module");
+    ///
+    /// assert!(module.get_struct_type("foo").is_none());
+    ///
+    /// let opaque = context.opaque_struct_type("foo");
+    ///
+    /// assert_eq!(module.get_struct_type("foo").unwrap(), opaque);
+    /// ```
+    #[llvm_versions(12.0..=latest)]
+    pub fn get_struct_type(&self, name: &str) -> Option<StructType<'ctx>> {
+        self.get_context().get_struct_type(name)
     }
 
     /// Assigns a `TargetTriple` to this `Module`.

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -67,3 +67,18 @@ fn test_values_get_context() {
     assert_eq!(i8_type.get_context(), context);
     assert_eq!(struct_type.get_context(), context);
 }
+
+#[test]
+fn test_get_type() {
+    use inkwell::types::AnyTypeEnum;
+
+    let context = Context::create();
+
+    let name = "opaque";
+    let opaque = context.opaque_struct_type(name);
+
+    let got = context.get_type(name);
+    assert_eq!(got, Some(AnyTypeEnum::from(opaque)));
+
+    assert_eq!(context.get_type("non-existent"), None);
+}

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -68,8 +68,8 @@ fn test_values_get_context() {
     assert_eq!(struct_type.get_context(), context);
 }
 
-#[test]
 #[llvm_versions(12.0..=latest)]
+#[test]
 fn test_get_type() {
     use inkwell::types::AnyTypeEnum;
 

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -70,16 +70,14 @@ fn test_values_get_context() {
 
 #[llvm_versions(12.0..=latest)]
 #[test]
-fn test_get_type() {
-    use inkwell::types::AnyTypeEnum;
-
+fn test_get_struct_type() {
     let context = Context::create();
 
     let name = "opaque";
     let opaque = context.opaque_struct_type(name);
 
-    let got = context.get_type(name);
-    assert_eq!(got, Some(AnyTypeEnum::from(opaque)));
+    let got = context.get_struct_type(name);
+    assert_eq!(got, Some(opaque));
 
-    assert_eq!(context.get_type("non-existent"), None);
+    assert_eq!(context.get_struct_type("non-existent"), None);
 }

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -69,6 +69,7 @@ fn test_values_get_context() {
 }
 
 #[test]
+#[llvm_versions(12.0..=latest)]
 fn test_get_type() {
     use inkwell::types::AnyTypeEnum;
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

Added `context.get_type("name")` method

## Description

Added new method with documentation and tests to context. It uses `LLVMGetTypeByName2` from llvm_sys, which was missing in inkwell.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

Related to my question: #367 

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Test when type is found and when not found.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
