### PR TITLE
Add `llvm-latest` feature and enable it by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools::ffi"]
 edition = "2021"
 
 [features]
-default = ["target-all"]
+default = ["target-all", "llvm-latest"]
 # Please update internal_macros::FEATURE_VERSIONS when adding a new LLVM version
 llvm4-0 = ["llvm-sys-40"]
 llvm5-0 = ["llvm-sys-50"]
@@ -25,6 +25,8 @@ llvm11-0 = ["llvm-sys-110"]
 llvm12-0 = ["llvm-sys-120"]
 llvm13-0 = ["llvm-sys-130"]
 llvm14-0 = ["llvm-sys-140"]
+# TODO: use latest installed version
+llvm-latest = ["llvm14-0"]
 # Don't link aganist LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
 # `no-llvm-linking` feature across the board of llvm versions, as it'll cause
@@ -41,6 +43,7 @@ llvm11-0-no-llvm-linking = ["llvm11-0", "llvm-sys-110/no-llvm-linking"]
 llvm12-0-no-llvm-linking = ["llvm12-0", "llvm-sys-120/no-llvm-linking"]
 llvm13-0-no-llvm-linking = ["llvm13-0", "llvm-sys-130/no-llvm-linking"]
 llvm14-0-no-llvm-linking = ["llvm14-0", "llvm-sys-140/no-llvm-linking"]
+llvm-latest-no-llvm-linking = ["llvm-latest", "llvm14-0-no-llvm-linking"]
 # Don't force linking to libffi on non-windows platforms. Without this feature
 # inkwell always links to libffi on non-windows platforms.
 no-libffi-linking = []


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

Adds default `llvm-latest` feature.

## Description

<!--- Describe your changes in detail -->

Without default specified llvm version feature, completion in IDE doesn't know about `llvm_sys` code.


## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

In VSCode. Tested for build with `cargo test --all --target=aarch64-apple-darwin --features=llvm14-0`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
