### PR TITLE
Move get/set section to derive macro

### DIFF
--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -7,8 +7,8 @@ use llvm_sys::core::{
     LLVMCountBasicBlocks, LLVMCountParams, LLVMDeleteFunction, LLVMGetBasicBlocks, LLVMGetFirstBasicBlock,
     LLVMGetFirstParam, LLVMGetFunctionCallConv, LLVMGetGC, LLVMGetIntrinsicID, LLVMGetLastBasicBlock, LLVMGetLastParam,
     LLVMGetLinkage, LLVMGetNextFunction, LLVMGetNextParam, LLVMGetParam, LLVMGetParams, LLVMGetPreviousFunction,
-    LLVMGetSection, LLVMIsAFunction, LLVMIsConstant, LLVMSetFunctionCallConv, LLVMSetGC, LLVMSetLinkage,
-    LLVMSetParamAlignment, LLVMSetSection,
+    LLVMIsAFunction, LLVMIsConstant, LLVMSetFunctionCallConv, LLVMSetGC, LLVMSetLinkage,
+    LLVMSetParamAlignment,
 };
 use llvm_sys::core::{LLVMGetPersonalityFn, LLVMSetPersonalityFn};
 #[llvm_versions(7.0..=latest)]
@@ -19,7 +19,6 @@ use std::ffi::CStr;
 use std::fmt::{self, Display};
 use std::marker::PhantomData;
 use std::mem::forget;
-use std::ptr;
 
 use crate::attributes::{Attribute, AttributeLoc};
 use crate::basic_block::BasicBlock;
@@ -29,7 +28,7 @@ use crate::module::Linkage;
 use crate::support::to_c_str;
 use crate::types::{FunctionType, PointerType};
 use crate::values::traits::{AnyValue, AsValueRef};
-use crate::values::{BasicValueEnum, GlobalValue, PointerValue, Value};
+use crate::values::{BasicValueEnum, GlobalValue, Value};
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct FunctionValue<'ctx> {
@@ -504,29 +503,14 @@ impl<'ctx> FunctionValue<'ctx> {
         }
     }
 
-    // TODO: Share code with GlobalValue::set/get_section
     /// Get the section to which this function belongs
     pub fn get_section(&self) -> Option<&CStr> {
-        let ptr = unsafe { LLVMGetSection(self.as_value_ref()) };
-
-        if ptr.is_null() {
-            return None;
-        }
-
-        Some(unsafe { CStr::from_ptr(ptr) })
+        self.fn_value.get_section()
     }
 
     /// Set the section to which this function should belong
     pub fn set_section(self, section: Option<&str>) {
-        let c_string = section.map(to_c_str);
-
-        unsafe {
-            LLVMSetSection(
-                self.as_value_ref(),
-                // The as_ref call is important here so that we don't drop the cstr mid use
-                c_string.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null()),
-            )
-        }
+		self.fn_value.set_section(section)
     }
 }
 

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -11,9 +11,9 @@ use llvm_sys::core::{
 #[llvm_versions(8.0..=latest)]
 use llvm_sys::core::{
     LLVMDeleteGlobal, LLVMGetAlignment, LLVMGetDLLStorageClass, LLVMGetInitializer, LLVMGetLinkage, LLVMGetNextGlobal,
-    LLVMGetPreviousGlobal, LLVMGetSection, LLVMGetThreadLocalMode, LLVMGetVisibility, LLVMIsDeclaration,
+    LLVMGetPreviousGlobal, LLVMGetThreadLocalMode, LLVMGetVisibility, LLVMIsDeclaration,
     LLVMIsExternallyInitialized, LLVMIsGlobalConstant, LLVMIsThreadLocal, LLVMSetAlignment, LLVMSetDLLStorageClass,
-    LLVMSetExternallyInitialized, LLVMSetGlobalConstant, LLVMSetInitializer, LLVMSetLinkage, LLVMSetSection,
+    LLVMSetExternallyInitialized, LLVMSetGlobalConstant, LLVMSetInitializer, LLVMSetLinkage,
     LLVMSetThreadLocal, LLVMSetThreadLocalMode, LLVMSetVisibility,
 };
 #[llvm_versions(7.0..=latest)]
@@ -27,12 +27,10 @@ use llvm_sys::LLVMUnnamedAddr;
 
 use std::ffi::CStr;
 use std::fmt::{self, Display};
-use std::ptr;
 
 #[llvm_versions(7.0..=latest)]
 use crate::comdat::Comdat;
 use crate::module::Linkage;
-use crate::support::to_c_str;
 use crate::values::traits::AsValueRef;
 #[llvm_versions(8.0..=latest)]
 use crate::values::MetadataValue;
@@ -215,26 +213,14 @@ impl<'ctx> GlobalValue<'ctx> {
         GlobalVisibility::new(visibility)
     }
 
+	/// Get section, this global value belongs to
     pub fn get_section(&self) -> Option<&CStr> {
-        let ptr = unsafe { LLVMGetSection(self.as_value_ref()) };
-
-        if ptr.is_null() {
-            return None;
-        }
-
-        Some(unsafe { CStr::from_ptr(ptr) })
+        self.global_value.get_section()
     }
 
+	/// Set section, this global value belongs to
     pub fn set_section(self, section: Option<&str>) {
-        let c_string = section.map(to_c_str);
-
-        unsafe {
-            LLVMSetSection(
-                self.as_value_ref(),
-                // The as_ref call is important here so that we don't drop the cstr mid use
-                c_string.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null()),
-            )
-        }
+       self.global_value.set_section(section)
     }
 
     pub unsafe fn delete(self) {

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -21,7 +21,7 @@ mod struct_value;
 mod traits;
 mod vec_value;
 
-use crate::support::LLVMString;
+use crate::support::{LLVMString, to_c_str};
 pub use crate::values::array_value::ArrayValue;
 pub use crate::values::basic_value_use::BasicValueUse;
 pub use crate::values::call_site_value::CallSiteValue;
@@ -47,7 +47,7 @@ use crate::LLVMReference;
 
 use llvm_sys::core::{
     LLVMDumpValue, LLVMGetFirstUse, LLVMIsAInstruction, LLVMIsConstant, LLVMIsNull, LLVMIsUndef, LLVMPrintTypeToString,
-    LLVMPrintValueToString, LLVMReplaceAllUsesWith, LLVMTypeOf,
+    LLVMPrintValueToString, LLVMReplaceAllUsesWith, LLVMTypeOf, LLVMSetSection, LLVMGetSection
 };
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
@@ -174,6 +174,30 @@ impl<'ctx> Value<'ctx> {
 
         unsafe { Some(BasicValueUse::new(use_)) }
     }
+
+	/// Gets the section of the global value
+	pub fn get_section(&self) -> Option<&CStr> {
+		let ptr = unsafe { LLVMGetSection(self.value) };
+
+		if ptr.is_null() {
+			return None;
+		}
+
+		Some(unsafe { CStr::from_ptr(ptr) })
+	}
+
+	/// Sets the section of the global value
+	pub fn set_section(self, section: Option<&str>) {
+		let c_string = section.map(to_c_str);
+
+		unsafe {
+			LLVMSetSection(
+				self.value,
+				// The as_ref call is important here so that we don't drop the cstr mid use
+				c_string.as_ref().map(|s| s.as_ptr()).unwrap_or(std::ptr::null()),
+			)
+		}
+	}
 }
 
 impl fmt::Debug for Value<'_> {

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -120,6 +120,7 @@ fn test_section_iterator() {
                 "D" => {
                     assert!(!has_section_d);
                     has_section_d = true;
+					// FIXME: fails on arm64-apple-darwin22.1.0
                     assert_eq!(section.size(), 1);
                 },
                 _ => {},
@@ -179,6 +180,7 @@ fn test_symbol_iterator() {
             }
         }
     }
+	// FIXME: fails on arm64-apple-darwin22.1.0
     assert!(has_symbol_a);
     assert!(has_symbol_b);
     assert!(has_symbol_c);

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -161,6 +161,7 @@ fn test_default_triple() {
     let default_triple = TargetMachine::get_default_triple();
     let default_triple = default_triple.as_str().to_string_lossy();
 
+	// FIXME: arm arch
     #[cfg(target_os = "linux")]
     let cond = default_triple == "x86_64-pc-linux-gnu"
         || default_triple == "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

Move repeated code for `get_section` and `set_section` for `GlobalValue` and `FunctionValue` to derive macro

## Description

<!--- Describe your changes in detail -->

Added new derive macro `Section`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

First steps to fix test error inside `test_object_file` as in issue #345.

Later `cfg(target_os = "macos")` maybe used inside this single macro, to fix this problem.
I tried to implement this fix with replacing `"section_name"` to `",section_name"` , but now I have test errors instead of LLVM ERROR

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

`cargo test --all  --target=aarch64-apple-darwin --features=llvm14-0`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
