### PR TITLE
Add new TryFrom implementations for enums

### DIFF
--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -237,7 +237,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm14-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
-			// FIXME: should inkwell support metadata as AnyType?
+            // FIXME: should inkwell support metadata as AnyType?
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Metadata type is not supported as AnyType."),
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("FIXME: Unsupported type: MMX"),
             #[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0"))]
@@ -531,27 +531,63 @@ impl<'ctx> TryFrom<AnyTypeEnum<'ctx>> for BasicTypeEnum<'ctx> {
     type Error = ();
 
     fn try_from(value: AnyTypeEnum<'ctx>) -> Result<Self, Self::Error> {
+        use AnyTypeEnum::*;
         Ok(match value {
-            AnyTypeEnum::ArrayType(at) => at.into(),
-            AnyTypeEnum::FloatType(ft) => ft.into(),
-            AnyTypeEnum::IntType(it) => it.into(),
-            AnyTypeEnum::PointerType(pt) => pt.into(),
-            AnyTypeEnum::StructType(st) => st.into(),
-            AnyTypeEnum::VectorType(vt) => vt.into(),
-            _ => return Err(()),
+            ArrayType(at) => at.into(),
+            FloatType(ft) => ft.into(),
+            IntType(it) => it.into(),
+            PointerType(pt) => pt.into(),
+            StructType(st) => st.into(),
+            VectorType(vt) => vt.into(),
+            VoidType(_) | FunctionType(_) => return Err(()),
+        })
+    }
+}
+
+impl<'ctx> TryFrom<AnyTypeEnum<'ctx>> for BasicMetadataTypeEnum<'ctx> {
+    type Error = ();
+
+    fn try_from(value: AnyTypeEnum<'ctx>) -> Result<Self, Self::Error> {
+        use AnyTypeEnum::*;
+        Ok(match value {
+            ArrayType(at) => at.into(),
+            FloatType(ft) => ft.into(),
+            IntType(it) => it.into(),
+            PointerType(pt) => pt.into(),
+            StructType(st) => st.into(),
+            VectorType(vt) => vt.into(),
+            VoidType(_) | FunctionType(_) => return Err(()),
+        })
+    }
+}
+
+impl<'ctx> TryFrom<BasicMetadataTypeEnum<'ctx>> for BasicTypeEnum<'ctx> {
+    type Error = ();
+
+    fn try_from(value: BasicMetadataTypeEnum<'ctx>) -> Result<Self, Self::Error> {
+        use BasicMetadataTypeEnum::*;
+        Ok(match value {
+            ArrayType(at) => at.into(),
+            FloatType(ft) => ft.into(),
+            IntType(it) => it.into(),
+            PointerType(pt) => pt.into(),
+            StructType(st) => st.into(),
+            VectorType(vt) => vt.into(),
+            MetadataType(_) => return Err(()),
         })
     }
 }
 
 impl<'ctx> From<BasicTypeEnum<'ctx>> for BasicMetadataTypeEnum<'ctx> {
     fn from(value: BasicTypeEnum<'ctx>) -> Self {
+        use BasicTypeEnum::*;
         match value {
-            BasicTypeEnum::ArrayType(at) => at.into(),
-            BasicTypeEnum::FloatType(ft) => ft.into(),
-            BasicTypeEnum::IntType(it) => it.into(),
-            BasicTypeEnum::PointerType(pt) => pt.into(),
-            BasicTypeEnum::StructType(st) => st.into(),
-            BasicTypeEnum::VectorType(vt) => vt.into(),
+            ArrayType(at) => at.into(),
+            FloatType(ft) => ft.into(),
+            IntType(it) => it.into(),
+            PointerType(pt) => pt.into(),
+            StructType(st) => st.into(),
+            VectorType(vt) => vt.into(),
         }
     }
 }

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -474,14 +474,50 @@ impl<'ctx> TryFrom<AnyValueEnum<'ctx>> for BasicValueEnum<'ctx> {
     type Error = ();
 
     fn try_from(value: AnyValueEnum<'ctx>) -> Result<Self, Self::Error> {
+        use AnyValueEnum::*;
         Ok(match value {
-            AnyValueEnum::ArrayValue(av) => av.into(),
-            AnyValueEnum::IntValue(iv) => iv.into(),
-            AnyValueEnum::FloatValue(fv) => fv.into(),
-            AnyValueEnum::PointerValue(pv) => pv.into(),
-            AnyValueEnum::StructValue(sv) => sv.into(),
-            AnyValueEnum::VectorValue(vv) => vv.into(),
-            _ => return Err(()),
+            ArrayValue(av) => av.into(),
+            IntValue(iv) => iv.into(),
+            FloatValue(fv) => fv.into(),
+            PointerValue(pv) => pv.into(),
+            StructValue(sv) => sv.into(),
+            VectorValue(vv) => vv.into(),
+            MetadataValue(_) | PhiValue(_) | FunctionValue(_) | InstructionValue(_) => return Err(()),
+        })
+    }
+}
+
+impl<'ctx> TryFrom<AnyValueEnum<'ctx>> for BasicMetadataValueEnum<'ctx> {
+    type Error = ();
+
+    fn try_from(value: AnyValueEnum<'ctx>) -> Result<Self, Self::Error> {
+        use AnyValueEnum::*;
+        Ok(match value {
+            ArrayValue(av) => av.into(),
+            IntValue(iv) => iv.into(),
+            FloatValue(fv) => fv.into(),
+            PointerValue(pv) => pv.into(),
+            StructValue(sv) => sv.into(),
+            VectorValue(vv) => vv.into(),
+            MetadataValue(mv) => mv.into(),
+            PhiValue(_) | FunctionValue(_) | InstructionValue(_) => return Err(()),
+        })
+    }
+}
+
+impl<'ctx> TryFrom<BasicMetadataValueEnum<'ctx>> for BasicValueEnum<'ctx> {
+    type Error = ();
+
+    fn try_from(value: BasicMetadataValueEnum<'ctx>) -> Result<Self, Self::Error> {
+        use BasicMetadataValueEnum::*;
+        Ok(match value {
+            ArrayValue(av) => av.into(),
+            IntValue(iv) => iv.into(),
+            FloatValue(fv) => fv.into(),
+            PointerValue(pv) => pv.into(),
+            StructValue(sv) => sv.into(),
+            VectorValue(vv) => vv.into(),
+            MetadataValue(_) => return Err(()),
         })
     }
 }


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

While using inkwell, I found some useful enum conversions to be missing. It's just inconvenient to implement them outside of inkwell, so why not add it.

Adds:
* `TryFrom<AnyTypeEnum<'ctx>> for BasicMetadataTypeEnum<'ctx>`
* `TryFrom<BasicMetadataTypeEnum<'ctx>> for BasicTypeEnum<'ctx>`
* `TryFrom<AnyValueEnum<'ctx>> for BasicMetadataValueEnum<'ctx>`
* `TryFrom<BasicMetadataValueEnum<'ctx>> for BasicValueEnum<'ctx>`

P.S: plan to implement `From<BasicMetadataTypeEnum<'ctx>> for AnyTypeEnum<'ctx>` as well, but that requires adding metadata to AnyTypeEnum, that's why it will be in another pull request 

## How This Has Been Tested

```
cargo test --features llvm14-0
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
