### PR TITLE
impl Default for AddressSpace to make future changes easier

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -294,7 +294,7 @@ impl<'ctx> Builder<'ctx> {
     ///     };
     ///
     ///     // type of an exception in C++
-    ///     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+    ///     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
     ///     let i32_type = context.i32_type();
     ///     let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
     ///
@@ -403,7 +403,7 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
+    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
     ///
@@ -432,7 +432,7 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
+    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
     ///
@@ -464,7 +464,7 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
+    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
     ///
@@ -477,7 +477,7 @@ impl<'ctx> Builder<'ctx> {
     /// };
     ///
     /// // link in the C++ type info for the `int` type
-    /// let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::Generic), "_ZTIi");
+    /// let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::default()), "_ZTIi");
     /// type_info_int.set_linkage(Linkage::External);
     ///
     /// // make the catch landing pad
@@ -499,7 +499,7 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     ///
     /// // type of an exception in C++
-    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::Generic);
+    /// let i8_ptr_type = context.i8_type().ptr_type(AddressSpace::default());
     /// let i32_type = context.i32_type();
     /// let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
     ///
@@ -512,7 +512,7 @@ impl<'ctx> Builder<'ctx> {
     /// };
     ///
     /// // link in the C++ type info for the `int` type
-    /// let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::Generic), "_ZTIi");
+    /// let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::default()), "_ZTIi");
     /// type_info_int.set_linkage(Linkage::External);
     ///
     /// // make the filter landing pad
@@ -615,7 +615,7 @@ impl<'ctx> Builder<'ctx> {
     ///     };
     ///
     ///     // type of an exception in C++
-    ///     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+    ///     let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
     ///     let i32_type = context.i32_type();
     ///     let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
     ///
@@ -764,10 +764,10 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("struct_gep");
     /// let void_type = context.void_type();
     /// let i32_ty = context.i32_type();
-    /// let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::Generic);
+    /// let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::default());
     /// let field_types = &[i32_ty.into(), i32_ty.into()];
     /// let struct_ty = context.struct_type(field_types, false);
-    /// let struct_ptr_ty = struct_ty.ptr_type(AddressSpace::Generic);
+    /// let struct_ptr_ty = struct_ty.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_ty.into(), struct_ptr_ty.into()], false);
     /// let fn_value = module.add_function("", fn_type, None);
     /// let entry = context.append_basic_block(fn_value, "entry");
@@ -854,7 +854,7 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into(), i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
     /// let entry = context.append_basic_block(fn_value, "entry");
@@ -947,7 +947,7 @@ impl<'ctx> Builder<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     /// let i32_seven = i32_type.const_int(7, false);
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
@@ -977,7 +977,7 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("ret");
     /// let builder = context.create_builder();
     /// let i32_type = context.i32_type();
-    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     /// let fn_type = i32_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("ret", fn_type, None);
     /// let entry = context.append_basic_block(fn_value, "entry");
@@ -2493,7 +2493,7 @@ impl<'ctx> Builder<'ctx> {
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
     /// let i32_seven = i32_type.const_int(7, false);
-    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("rmw", fn_type, None);
     /// let entry = context.append_basic_block(fn_value, "entry");
@@ -2546,7 +2546,7 @@ impl<'ctx> Builder<'ctx> {
     /// let module = context.create_module("cmpxchg");
     /// let void_type = context.void_type();
     /// let i32_type = context.i32_type();
-    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    /// let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[i32_ptr_type.into()], false);
     /// let fn_value = module.add_function("", fn_type, None);
     /// let i32_ptr_param = fn_value.get_first_param().unwrap().into_pointer_value();

--- a/src/context.rs
+++ b/src/context.rs
@@ -216,7 +216,7 @@ impl ContextImpl {
     fn ptr_sized_int_type<'ctx>(&self, target_data: &TargetData, address_space: Option<AddressSpace>) -> IntType<'ctx> {
         let int_type_ptr = match address_space {
             Some(address_space) => unsafe {
-                LLVMIntPtrTypeForASInContext(self.0, target_data.target_data, address_space as u32)
+                LLVMIntPtrTypeForASInContext(self.0, target_data.target_data, address_space.0)
             },
             None => unsafe { LLVMIntPtrTypeInContext(self.0, target_data.target_data) },
         };

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -695,7 +695,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 pointee.metadata_ref,
                 size_in_bits,
                 align_in_bits,
-                address_space as u32,
+                address_space.0,
                 name.as_ptr() as _,
                 name.len(),
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,12 @@ pub enum AddressSpace {
     Local = 5,
 }
 
+impl Default for AddressSpace {
+    fn default() -> Self {
+        AddressSpace::Generic
+    }
+}
+
 impl TryFrom<u32> for AddressSpace {
     type Error = ();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,27 +107,31 @@ assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8
 
 /// Defines the address space in which a global will be inserted.
 ///
-/// The default address space is zero. The first six address spaces are available as associated
-/// constants. To convert any higher number, use the `TryFrom` instance. An Address space is a
-/// 24-bit number.
+/// The default address space is zero. An address space can always be created from a `u16`:
+/// ```no_run
+/// inkwell::AddressSpace::from(1u16);
+/// ```
+///
+/// An Address space is a 24-bit number. To convert from a u32, use the `TryFrom` instance
+///
+/// ```no_run
+/// inkwell::AddressSpace::try_from(42u32).expect("fits in 24-bit unsigned int");
+/// ```
 ///
 /// # Remarks
 /// See also: https://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct AddressSpace(u32);
 
-impl AddressSpace {
-    pub const ZERO: Self = Self(0);
-    pub const ONE: Self = Self(1);
-    pub const TWO: Self = Self(2);
-    pub const THREE: Self = Self(3);
-    pub const FOUR: Self = Self(4);
-    pub const FIVE: Self = Self(5);
-}
-
 impl Default for AddressSpace {
     fn default() -> Self {
         AddressSpace(0)
+    }
+}
+
+impl From<u16> for AddressSpace {
+    fn from(val: u16) -> Self {
+        AddressSpace(val as u32)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,14 +107,40 @@ assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8
 
 /// Defines the address space in which a global will be inserted.
 ///
+/// The default address space is zero. The first six address spaces are available as associated
+/// constants. To convert any higher number, use the `TryFrom` instance. An Address space is a
+/// 24-bit number.
+///
 /// # Remarks
 /// See also: https://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct AddressSpace(pub u32);
+pub struct AddressSpace(u32);
+
+impl AddressSpace {
+    pub const ZERO: Self = Self(0);
+    pub const ONE: Self = Self(1);
+    pub const TWO: Self = Self(2);
+    pub const THREE: Self = Self(3);
+    pub const FOUR: Self = Self(4);
+    pub const FIVE: Self = Self(5);
+}
 
 impl Default for AddressSpace {
     fn default() -> Self {
         AddressSpace(0)
+    }
+}
+
+impl TryFrom<u32> for AddressSpace {
+    type Error = ();
+
+    fn try_from(val: u32) -> Result<Self, Self::Error> {
+        // address space is a 24-bit integer
+        if val < 1 << 24 {
+            Ok(AddressSpace(val))
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,32 +110,11 @@ assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8
 /// # Remarks
 /// See also: https://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum AddressSpace {
-    Generic = 0,
-    Global = 1,
-    Shared = 3,
-    Const = 4,
-    Local = 5,
-}
+pub struct AddressSpace(pub u32);
 
 impl Default for AddressSpace {
     fn default() -> Self {
-        AddressSpace::Generic
-    }
-}
-
-impl TryFrom<u32> for AddressSpace {
-    type Error = ();
-
-    fn try_from(val: u32) -> Result<Self, Self::Error> {
-        match val {
-            0 => Ok(AddressSpace::Generic),
-            1 => Ok(AddressSpace::Global),
-            3 => Ok(AddressSpace::Shared),
-            4 => Ok(AddressSpace::Const),
-            5 => Ok(AddressSpace::Local),
-            _ => Err(()),
-        }
+        AddressSpace(0)
     }
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -612,7 +612,7 @@ impl<'ctx> Module<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("mod");
     /// let i8_type = context.i8_type();
-    /// let global = module.add_global(i8_type, Some(AddressSpace::ONE), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::from(1u16)), "my_global");
     ///
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// assert_eq!(module.get_last_global().unwrap(), global);
@@ -1026,7 +1026,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_first_global().is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::from(4u16)), "my_global");
     ///
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// ```
@@ -1054,7 +1054,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_last_global().is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::from(4u16)), "my_global");
     ///
     /// assert_eq!(module.get_last_global().unwrap(), global);
     /// ```
@@ -1082,7 +1082,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_global("my_global").is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::from(4u16)), "my_global");
     ///
     /// assert_eq!(module.get_global("my_global").unwrap(), global);
     /// ```

--- a/src/module.rs
+++ b/src/module.rs
@@ -612,7 +612,7 @@ impl<'ctx> Module<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("mod");
     /// let i8_type = context.i8_type();
-    /// let global = module.add_global(i8_type, Some(AddressSpace(1)), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::ONE), "my_global");
     ///
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// assert_eq!(module.get_last_global().unwrap(), global);
@@ -1026,7 +1026,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_first_global().is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace(4)), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global");
     ///
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// ```
@@ -1054,7 +1054,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_last_global().is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace(4)), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global");
     ///
     /// assert_eq!(module.get_last_global().unwrap(), global);
     /// ```
@@ -1082,7 +1082,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_global("my_global").is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace(4)), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global");
     ///
     /// assert_eq!(module.get_global("my_global").unwrap(), global);
     /// ```

--- a/src/module.rs
+++ b/src/module.rs
@@ -7,7 +7,6 @@ use llvm_sys::bit_writer::{LLVMWriteBitcodeToFile, LLVMWriteBitcodeToMemoryBuffe
 #[llvm_versions(4.0..14.0)]
 use llvm_sys::core::LLVMGetTypeByName;
 
-
 use llvm_sys::core::{
     LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddNamedMetadataOperand, LLVMCloneModule,
     LLVMDisposeModule, LLVMDumpModule, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetLastFunction,
@@ -613,7 +612,7 @@ impl<'ctx> Module<'ctx> {
     /// let context = Context::create();
     /// let module = context.create_module("mod");
     /// let i8_type = context.i8_type();
-    /// let global = module.add_global(i8_type, Some(AddressSpace::Const), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace(1)), "my_global");
     ///
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// assert_eq!(module.get_last_global().unwrap(), global);
@@ -632,7 +631,7 @@ impl<'ctx> Module<'ctx> {
                     self.module.get(),
                     type_.as_type_ref(),
                     c_string.as_ptr(),
-                    address_space as u32,
+                    address_space.0,
                 ),
                 None => LLVMAddGlobal(self.module.get(), type_.as_type_ref(), c_string.as_ptr()),
             }
@@ -1027,7 +1026,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_first_global().is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace::Const), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace(4)), "my_global");
     ///
     /// assert_eq!(module.get_first_global().unwrap(), global);
     /// ```
@@ -1055,7 +1054,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_last_global().is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace::Const), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace(4)), "my_global");
     ///
     /// assert_eq!(module.get_last_global().unwrap(), global);
     /// ```
@@ -1083,7 +1082,7 @@ impl<'ctx> Module<'ctx> {
     ///
     /// assert!(module.get_global("my_global").is_none());
     ///
-    /// let global = module.add_global(i8_type, Some(AddressSpace::Const), "my_global");
+    /// let global = module.add_global(i8_type, Some(AddressSpace(4)), "my_global");
     ///
     /// assert_eq!(module.get_global("my_global").unwrap(), global);
     /// ```

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1235,7 +1235,7 @@ impl TargetData {
     ) -> IntType<'ctx> {
         let int_type_ptr = match address_space {
             Some(address_space) => unsafe {
-                LLVMIntPtrTypeForASInContext(context.as_ctx_ref(), self.target_data, address_space as u32)
+                LLVMIntPtrTypeForASInContext(context.as_ctx_ref(), self.target_data, address_space.0)
             },
             None => unsafe { LLVMIntPtrTypeInContext(context.as_ctx_ref(), self.target_data) },
         };
@@ -1270,7 +1270,7 @@ impl TargetData {
 
     pub fn get_pointer_byte_size(&self, address_space: Option<AddressSpace>) -> u32 {
         match address_space {
-            Some(address_space) => unsafe { LLVMPointerSizeForAS(self.target_data, address_space as u32) },
+            Some(address_space) => unsafe { LLVMPointerSizeForAS(self.target_data, address_space.0) },
             None => unsafe { LLVMPointerSize(self.target_data) },
         }
     }

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -74,7 +74,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// let context = Context::create();
     /// let i8_type = context.i8_type();
     /// let i8_array_type = i8_type.array_type(3);
-    /// let i8_array_ptr_type = i8_array_type.ptr_type(AddressSpace::Generic);
+    /// let i8_array_ptr_type = i8_array_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(i8_array_ptr_type.get_element_type().into_array_type(), i8_array_type);
     /// ```

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -213,7 +213,7 @@ impl<'ctx> FloatType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_type.get_element_type().into_float_type(), f32_type);
     /// ```

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -43,7 +43,7 @@ impl<'ctx> FunctionType<'ctx> {
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
     /// let fn_type = f32_type.fn_type(&[], false);
-    /// let fn_ptr_type = fn_type.ptr_type(AddressSpace::Global);
+    /// let fn_ptr_type = fn_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(fn_ptr_type.get_element_type().into_function_type(), fn_type);
     /// ```

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -308,7 +308,7 @@ impl<'ctx> IntType<'ctx> {
     ///
     /// let context = Context::create();
     /// let i8_type = context.i8_type();
-    /// let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    /// let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(i8_ptr_type.get_element_type().into_int_type(), i8_type);
     /// ```

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -84,7 +84,7 @@ impl<'ctx> Type<'ctx> {
     }
 
     fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {
-        unsafe { PointerType::new(LLVMPointerType(self.ty, address_space as u32)) }
+        unsafe { PointerType::new(LLVMPointerType(self.ty, address_space.0)) }
     }
 
     fn vec_type(self, size: u32) -> VectorType<'ctx> {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -157,7 +157,7 @@ impl<'ctx> PointerType<'ctx> {
     pub fn get_address_space(self) -> AddressSpace {
         let addr_space = unsafe { LLVMGetPointerAddressSpace(self.as_type_ref()) };
 
-        AddressSpace::try_from(addr_space).expect("Unexpectedly found invalid AddressSpace value")
+        AddressSpace(addr_space)
     }
 
     /// Print the definition of a `PointerType` to `LLVMString`.

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -41,7 +41,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_type_size = f32_ptr_type.size_of();
     /// ```
     pub fn size_of(self) -> IntValue<'ctx> {
@@ -58,7 +58,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_type_alignment = f32_ptr_type.get_alignment();
     /// ```
     pub fn get_alignment(self) -> IntValue<'ctx> {
@@ -75,8 +75,8 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
-    /// let f32_ptr_ptr_type = f32_ptr_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
+    /// let f32_ptr_ptr_type = f32_ptr_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_ptr_type.get_element_type().into_pointer_type(), f32_ptr_type);
     /// ```
@@ -94,7 +94,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_type.get_context(), context);
     /// ```
@@ -113,7 +113,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = f32_ptr_type.fn_type(&[], false);
     /// ```
     pub fn fn_type(self, param_types: &[BasicMetadataTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
@@ -130,7 +130,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_array_type = f32_ptr_type.array_type(3);
     ///
     /// assert_eq!(f32_ptr_array_type.len(), 3);
@@ -150,9 +150,9 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     ///
-    /// assert_eq!(f32_ptr_type.get_address_space(), AddressSpace::Generic);
+    /// assert_eq!(f32_ptr_type.get_address_space(), AddressSpace::default());
     /// ```
     pub fn get_address_space(self) -> AddressSpace {
         let addr_space = unsafe { LLVMGetPointerAddressSpace(self.as_type_ref()) };
@@ -176,7 +176,7 @@ impl<'ctx> PointerType<'ctx> {
     /// // Local Context
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_null = f32_ptr_type.const_null();
     ///
     /// assert!(f32_ptr_null.is_null());
@@ -198,7 +198,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_zero = f32_ptr_type.const_zero();
     /// ```
     pub fn const_zero(self) -> PointerValue<'ctx> {
@@ -214,7 +214,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_undef = f32_ptr_type.get_undef();
     ///
     /// assert!(f32_ptr_undef.is_undef());
@@ -233,7 +233,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_vec_type = f32_ptr_type.vec_type(3);
     ///
     /// assert_eq!(f32_ptr_vec_type.get_size(), 3);
@@ -254,7 +254,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_ptr_type.get_element_type().into_float_type(), f32_type);
     /// ```
@@ -271,7 +271,7 @@ impl<'ctx> PointerType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_val = f32_ptr_type.const_null();
     /// let f32_ptr_array = f32_ptr_type.const_array(&[f32_ptr_val, f32_ptr_val]);
     ///

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -190,7 +190,7 @@ impl<'ctx> StructType<'ctx> {
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
     /// let struct_type = context.struct_type(&[f32_type.into(), f32_type.into()], false);
-    /// let struct_ptr_type = struct_type.ptr_type(AddressSpace::Generic);
+    /// let struct_ptr_type = struct_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(struct_ptr_type.get_element_type().into_struct_type(), struct_type);
     /// ```

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -126,7 +126,7 @@ pub trait BasicType<'ctx>: AnyType<'ctx> {
     /// let context = Context::create();
     /// let int = context.i32_type();
     /// let int_basic_type = int.as_basic_type_enum();
-    /// let addr_space = AddressSpace::Generic;
+    /// let addr_space = AddressSpace::default();
     /// assert_eq!(int_basic_type.ptr_type(addr_space), int.ptr_type(addr_space));
     /// ```
     fn ptr_type(&self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -179,7 +179,7 @@ impl<'ctx> VectorType<'ctx> {
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
     /// let f32_vec_type = f32_type.vec_type(3);
-    /// let f32_vec_ptr_type = f32_vec_type.ptr_type(AddressSpace::Generic);
+    /// let f32_vec_ptr_type = f32_vec_type.ptr_type(AddressSpace::default());
     ///
     /// assert_eq!(f32_vec_ptr_type.get_element_type().into_vector_type(), f32_vec_type);
     /// ```

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -35,7 +35,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -96,7 +96,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -132,7 +132,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -348,7 +348,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -408,7 +408,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -491,7 +491,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -534,7 +534,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -580,7 +580,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// let builder = context.create_builder();
     /// let void_type = context.void_type();
     /// let f32_type = context.f32_type();
-    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
     ///
     /// let function = module.add_function("take_f32_ptr", fn_type, None);

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -55,7 +55,6 @@ fn test_type_attribute() {
         context.i32_type().array_type(1).as_any_type_enum(),
         context.i32_type().fn_type(&[], false).as_any_type_enum(),
         context.i32_type().ptr_type(AddressSpace(5)).as_any_type_enum(),
-        context.i32_type().ptr_type(AddressSpace(6)).as_any_type_enum(),
         context
             .struct_type(&[context.i32_type().as_basic_type_enum()], false)
             .as_any_type_enum(),

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -54,7 +54,7 @@ fn test_type_attribute() {
         context.i32_type().vec_type(1).as_any_type_enum(),
         context.i32_type().array_type(1).as_any_type_enum(),
         context.i32_type().fn_type(&[], false).as_any_type_enum(),
-        context.i32_type().ptr_type(AddressSpace(5)).as_any_type_enum(),
+        context.i32_type().ptr_type(AddressSpace::FIVE).as_any_type_enum(),
         context
             .struct_type(&[context.i32_type().as_basic_type_enum()], false)
             .as_any_type_enum(),

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -54,7 +54,8 @@ fn test_type_attribute() {
         context.i32_type().vec_type(1).as_any_type_enum(),
         context.i32_type().array_type(1).as_any_type_enum(),
         context.i32_type().fn_type(&[], false).as_any_type_enum(),
-        context.i32_type().ptr_type(AddressSpace::Local).as_any_type_enum(),
+        context.i32_type().ptr_type(AddressSpace(5)).as_any_type_enum(),
+        context.i32_type().ptr_type(AddressSpace(6)).as_any_type_enum(),
         context
             .struct_type(&[context.i32_type().as_basic_type_enum()], false)
             .as_any_type_enum(),

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -54,7 +54,7 @@ fn test_type_attribute() {
         context.i32_type().vec_type(1).as_any_type_enum(),
         context.i32_type().array_type(1).as_any_type_enum(),
         context.i32_type().fn_type(&[], false).as_any_type_enum(),
-        context.i32_type().ptr_type(AddressSpace::FIVE).as_any_type_enum(),
+        context.i32_type().ptr_type(AddressSpace::from(5u16)).as_any_type_enum(),
         context
             .struct_type(&[context.i32_type().as_basic_type_enum()], false)
             .as_any_type_enum(),

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -120,7 +120,7 @@ fn test_build_invoke_cleanup_resume() {
         };
 
         // type of an exception in C++
-        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
         let i32_type = context.i32_type();
         let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
 
@@ -187,7 +187,7 @@ fn test_build_invoke_catch_all() {
         };
 
         // type of an exception in C++
-        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
         let i32_type = context.i32_type();
         let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
 
@@ -258,12 +258,12 @@ fn landing_pad_filter() {
         };
 
         // type of an exception in C++
-        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::Generic);
+        let i8_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
         let i32_type = context.i32_type();
         let exception_type = context.struct_type(&[i8_ptr_type.into(), i32_type.into()], false);
 
         // link in the C++ type info for the i32 type
-        let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::Generic), "_ZTIi");
+        let type_info_int = module.add_global(i8_ptr_type, Some(AddressSpace::default()), "_ZTIi");
         type_info_int.set_linkage(Linkage::External);
 
         // make the filter landing pad
@@ -301,7 +301,7 @@ fn test_null_checked_ptr_ops() {
     // }
 
     let i8_type = context.i8_type();
-    let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
     let i64_type = context.i64_type();
     let fn_type = i8_type.fn_type(&[i8_ptr_type.into()], false);
     let neg_one = i8_type.const_all_ones();
@@ -841,7 +841,7 @@ fn test_vector_pointer_ops() {
     let context = Context::create();
     let module = context.create_module("test");
     let int32_vec_type = context.i32_type().vec_type(4);
-    let i8_ptr_vec_type = context.i8_type().ptr_type(AddressSpace::Generic).vec_type(4);
+    let i8_ptr_vec_type = context.i8_type().ptr_type(AddressSpace::default()).vec_type(4);
     let bool_vec_type = context.bool_type().vec_type(4);
 
     // Here we're building a function that takes a <4 x i32>, converts it to a <4 x i8*> and returns a
@@ -990,7 +990,7 @@ fn run_memcpy_on<'ctx>(
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;
-    let fn_type = i32_type.ptr_type(AddressSpace::Generic).fn_type(&[], false);
+    let fn_type = i32_type.ptr_type(AddressSpace::default()).fn_type(&[], false);
     let fn_value = module.add_function("test_fn", fn_type, None);
     let builder = context.create_builder();
     let entry = context.append_basic_block(fn_value, "entry");
@@ -1060,7 +1060,7 @@ fn run_memmove_on<'ctx>(
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;
-    let fn_type = i32_type.ptr_type(AddressSpace::Generic).fn_type(&[], false);
+    let fn_type = i32_type.ptr_type(AddressSpace::default()).fn_type(&[], false);
     let fn_value = module.add_function("test_fn", fn_type, None);
     let builder = context.create_builder();
     let entry = context.append_basic_block(fn_value, "entry");
@@ -1131,7 +1131,7 @@ fn run_memset_on<'ctx>(
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let array_len = 4;
-    let fn_type = i32_type.ptr_type(AddressSpace::Generic).fn_type(&[], false);
+    let fn_type = i32_type.ptr_type(AddressSpace::default()).fn_type(&[], false);
     let fn_value = module.add_function("test_fn", fn_type, None);
     let builder = context.create_builder();
     let entry = context.append_basic_block(fn_value, "entry");
@@ -1194,8 +1194,8 @@ fn test_bitcast() {
     let i32_type = context.i32_type();
     let f64_type = context.f64_type();
     let i64_type = context.i64_type();
-    let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
-    let i64_ptr_type = i64_type.ptr_type(AddressSpace::Generic);
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
+    let i64_ptr_type = i64_type.ptr_type(AddressSpace::default());
     let i32_vec_type = i32_type.vec_type(2);
     let arg_types = [
         i32_type.into(),
@@ -1251,22 +1251,22 @@ fn test_atomicrmw() {
     let i31_type = context.custom_width_int_type(31);
     let i4_type = context.custom_width_int_type(4);
 
-    let ptr_value = i32_type.ptr_type(AddressSpace::Generic).get_undef();
+    let ptr_value = i32_type.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i32_type.const_zero();
     let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
     assert!(result.is_ok());
 
-    let ptr_value = i64_type.ptr_type(AddressSpace::Generic).get_undef();
+    let ptr_value = i64_type.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i32_type.const_zero();
     let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
     assert!(result.is_err());
 
-    let ptr_value = i31_type.ptr_type(AddressSpace::Generic).get_undef();
+    let ptr_value = i31_type.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i31_type.const_zero();
     let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
     assert!(result.is_err());
 
-    let ptr_value = i4_type.ptr_type(AddressSpace::Generic).get_undef();
+    let ptr_value = i4_type.ptr_type(AddressSpace::default()).get_undef();
     let zero_value = i4_type.const_zero();
     let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
     assert!(result.is_err());
@@ -1286,8 +1286,8 @@ fn test_cmpxchg() {
 
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
-    let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
-    let i32_ptr_ptr_type = i32_ptr_type.ptr_type(AddressSpace::Generic);
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
+    let i32_ptr_ptr_type = i32_ptr_type.ptr_type(AddressSpace::default());
 
     let ptr_value = i32_ptr_type.get_undef();
     let zero_value = i32_type.const_zero();
@@ -1429,10 +1429,10 @@ fn test_safe_struct_gep() {
     let module = context.create_module("struct_gep");
     let void_type = context.void_type();
     let i32_ty = context.i32_type();
-    let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::Generic);
+    let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::default());
     let field_types = &[i32_ty.into(), i32_ty.into()];
     let struct_ty = context.struct_type(field_types, false);
-    let struct_ptr_ty = struct_ty.ptr_type(AddressSpace::Generic);
+    let struct_ptr_ty = struct_ty.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[i32_ptr_ty.into(), struct_ptr_ty.into()], false);
     let fn_value = module.add_function("", fn_type, None);
     let entry = context.append_basic_block(fn_value, "entry");

--- a/tests/all/test_context.rs
+++ b/tests/all/test_context.rs
@@ -53,7 +53,7 @@ fn test_values_get_context() {
     let i8_type = context.i8_type();
     let f32_type = context.f32_type();
     let f32_vec_type = f32_type.vec_type(3);
-    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     let f32_array_type = f32_type.array_type(2);
     let fn_type = f32_type.fn_type(&[], false);
     let struct_type = context.struct_type(&[i8_type.into(), f32_type.into()], false);

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -388,7 +388,7 @@ fn test_global_expressions() {
     );
 
     let di_type = dibuilder.create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO);
-    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace(1)), "gv");
+    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::ONE), "gv");
 
     let const_v = dibuilder.create_constant_expression(10);
 
@@ -465,7 +465,7 @@ fn test_pointer_types() {
         .as_type();
 
     //Smoke test that the pointer gets created
-    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace(1));
+    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace::ONE);
 }
 
 #[test]

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -388,7 +388,7 @@ fn test_global_expressions() {
     );
 
     let di_type = dibuilder.create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO);
-    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::Global), "gv");
+    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace(1)), "gv");
 
     let const_v = dibuilder.create_constant_expression(10);
 
@@ -465,7 +465,7 @@ fn test_pointer_types() {
         .as_type();
 
     //Smoke test that the pointer gets created
-    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace::Global);
+    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace(1));
 }
 
 #[test]

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -388,7 +388,7 @@ fn test_global_expressions() {
     );
 
     let di_type = dibuilder.create_basic_type("type_name", 0_u64, 0x00, DIFlags::ZERO);
-    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::ONE), "gv");
+    let gv = module.add_global(context.i64_type(), Some(inkwell::AddressSpace::from(1u16)), "gv");
 
     let const_v = dibuilder.create_constant_expression(10);
 
@@ -465,7 +465,7 @@ fn test_pointer_types() {
         .as_type();
 
     //Smoke test that the pointer gets created
-    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace::ONE);
+    dibuilder.create_pointer_type("pointer_name", di_type, 64, 64, inkwell::AddressSpace::from(1u16));
 }
 
 #[test]

--- a/tests/all/test_execution_engine.rs
+++ b/tests/all/test_execution_engine.rs
@@ -55,8 +55,8 @@ fn test_jit_execution_engine() {
     let builder = context.create_builder();
     let i8_type = context.i8_type();
     let i32_type = context.i32_type();
-    let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
-    let i8_ptr_ptr_type = i8_ptr_type.ptr_type(AddressSpace::Generic);
+    let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
+    let i8_ptr_ptr_type = i8_ptr_type.ptr_type(AddressSpace::default());
     let one_i32 = i32_type.const_int(1, false);
     let three_i32 = i32_type.const_int(3, false);
     let fourtytwo_i32 = i32_type.const_int(42, false);

--- a/tests/all/test_instruction_conversion.rs
+++ b/tests/all/test_instruction_conversion.rs
@@ -109,7 +109,7 @@ fn test_conversion_to_pointer_value() {
 
     // Create a PointerType instruction
     let i64_type = context.i64_type();
-    let i64_ptr_type = i64_type.ptr_type(AddressSpace::Generic);
+    let i64_ptr_type = i64_type.ptr_type(AddressSpace::default());
     let alloca_instr = builder.build_alloca(i64_ptr_type, "alloca").as_instruction().unwrap();
 
     // Test the instruction conversion to a FloatValue

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -10,7 +10,7 @@ fn test_operands() {
     let builder = context.create_builder();
     let void_type = context.void_type();
     let f32_type = context.f32_type();
-    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into()], false);
 
     let function = module.add_function("take_f32_ptr", fn_type, None);
@@ -207,7 +207,7 @@ fn test_instructions() {
     let void_type = context.void_type();
     let i64_type = context.i64_type();
     let f32_type = context.f32_type();
-    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
 
     let function = module.add_function("free_f32", fn_type, None);
@@ -282,7 +282,7 @@ fn test_volatile_atomicrmw_cmpxchg() {
 
     let void_type = context.void_type();
     let i32_type = context.i32_type();
-    let i32_ptr_type = i32_type.ptr_type(AddressSpace::Generic);
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[i32_ptr_type.into(), i32_type.into()], false);
 
     let function = module.add_function("mem_inst", fn_type, None);
@@ -336,7 +336,7 @@ fn test_mem_instructions() {
 
     let void_type = context.void_type();
     let f32_type = context.f32_type();
-    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
 
     let function = module.add_function("mem_inst", fn_type, None);
@@ -400,7 +400,7 @@ fn test_mem_instructions() {
 
     let void_type = context.void_type();
     let f32_type = context.f32_type();
-    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
 
     let function = module.add_function("mem_inst", fn_type, None);
@@ -463,7 +463,7 @@ fn test_atomic_ordering_mem_instructions() {
 
     let void_type = context.void_type();
     let f32_type = context.f32_type();
-    let f32_ptr_type = f32_type.ptr_type(AddressSpace::Generic);
+    let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     let fn_type = void_type.fn_type(&[f32_ptr_type.into(), f32_type.into()], false);
 
     let function = module.add_function("mem_inst", fn_type, None);
@@ -522,7 +522,7 @@ fn test_metadata_kinds() {
 
     let i8_type = context.i8_type();
     let f32_type = context.f32_type();
-    let ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let ptr_type = i8_type.ptr_type(AddressSpace::default());
     let struct_type = context.struct_type(&[i8_type.into(), f32_type.into()], false);
     let vector_type = i8_type.vec_type(2);
 

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -303,7 +303,7 @@ fn test_ptr_sized_int() {
     let module = context.create_module("sum");
     let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
     let target_data = execution_engine.get_target_data();
-    let address_space = AddressSpace::Global;
+    let address_space = AddressSpace(1);
     let int_type = context.ptr_sized_int_type(target_data, None);
 
     assert_eq!(int_type.get_bit_width(), target_data.get_pointer_byte_size(None) * 8);

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -303,7 +303,7 @@ fn test_ptr_sized_int() {
     let module = context.create_module("sum");
     let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
     let target_data = execution_engine.get_target_data();
-    let address_space = AddressSpace::ONE;
+    let address_space = AddressSpace::from(1u16);
     let int_type = context.ptr_sized_int_type(target_data, None);
 
     assert_eq!(int_type.get_bit_width(), target_data.get_pointer_byte_size(None) * 8);

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -303,7 +303,7 @@ fn test_ptr_sized_int() {
     let module = context.create_module("sum");
     let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
     let target_data = execution_engine.get_target_data();
-    let address_space = AddressSpace(1);
+    let address_space = AddressSpace::ONE;
     let int_type = context.ptr_sized_int_type(target_data, None);
 
     assert_eq!(int_type.get_bit_width(), target_data.get_pointer_byte_size(None) * 8);

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -395,7 +395,7 @@ fn test_no_vector_zero() {
 fn test_ptr_address_space() {
     let context = Context::create();
 
-    let spaces = [0, 1, 2, 3, 4, 5, 6, 1 << 24 - 1];
+    let spaces = [0u32, 1, 2, 3, 4, 5, 6, 1 << 24 - 1];
 
     for index in spaces {
         let address_space = AddressSpace::try_from(index).unwrap();
@@ -404,5 +404,5 @@ fn test_ptr_address_space() {
         assert_eq!(ptr.get_address_space(), address_space);
     }
 
-    assert!(AddressSpace::try_from(1 << 24).is_err());
+    assert!(AddressSpace::try_from(1u32 << 24).is_err());
 }

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -390,3 +390,21 @@ fn test_no_vector_zero() {
     let int = context.i32_type();
     int.vec_type(0);
 }
+
+#[test]
+fn test_ptr_address_space() {
+    let context = Context::create();
+
+    let spaces = [0, 1, 2, 3, 4, 5, 6, 1 << 24 - 1];
+
+    for index in spaces {
+        let address_space = AddressSpace(index);
+
+        let ptr = context.i32_type().ptr_type(address_space);
+        assert_eq!(ptr.get_address_space(), address_space);
+    }
+
+    let address_space = AddressSpace(1 << 24);
+    let ptr = context.i32_type().ptr_type(address_space);
+    assert_ne!(ptr.get_address_space(), address_space);
+}

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -165,22 +165,22 @@ fn sized_types(global_ctx: &Context) {
     assert!(!fn_type3.is_sized());
     assert!(!fn_type4.is_sized());
 
-    assert!(bool_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(i8_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(i16_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(i32_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(i64_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(i128_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(f16_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(f32_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(f64_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(f80_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(f128_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(ppc_f128_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(struct_type.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(struct_type2.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(struct_type3.ptr_type(AddressSpace::Generic).is_sized());
-    assert!(struct_type4.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(bool_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(i8_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(i16_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(i32_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(i64_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(i128_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(f16_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(f32_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(f64_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(f80_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(f128_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(ppc_f128_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(struct_type.ptr_type(AddressSpace::default()).is_sized());
+    assert!(struct_type2.ptr_type(AddressSpace::default()).is_sized());
+    assert!(struct_type3.ptr_type(AddressSpace::default()).is_sized());
+    assert!(struct_type4.ptr_type(AddressSpace::default()).is_sized());
 
     assert!(bool_type.array_type(42).is_sized());
     assert!(i8_type.array_type(42).is_sized());
@@ -215,7 +215,7 @@ fn sized_types(global_ctx: &Context) {
     let opaque_struct_type = global_ctx.opaque_struct_type("opaque");
 
     assert!(!opaque_struct_type.is_sized());
-    assert!(opaque_struct_type.ptr_type(AddressSpace::Generic).is_sized());
+    assert!(opaque_struct_type.ptr_type(AddressSpace::default()).is_sized());
     assert!(!opaque_struct_type.array_type(0).is_sized());
 }
 
@@ -235,7 +235,7 @@ fn test_const_zero() {
     let f128_type = context.f128_type();
     let ppc_f128_type = context.ppc_f128_type();
     let struct_type = context.struct_type(&[i8_type.into(), f128_type.into()], false);
-    let ptr_type = f64_type.ptr_type(AddressSpace::Generic);
+    let ptr_type = f64_type.ptr_type(AddressSpace::default());
     let vec_type = f64_type.vec_type(42);
     let array_type = f64_type.array_type(42);
 
@@ -342,15 +342,15 @@ fn test_type_copies() {
 fn test_ptr_type() {
     let context = Context::create();
     let i8_type = context.i8_type();
-    let ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let ptr_type = i8_type.ptr_type(AddressSpace::default());
 
-    assert_eq!(ptr_type.get_address_space(), AddressSpace::Generic);
+    assert_eq!(ptr_type.get_address_space(), AddressSpace::default());
     assert_eq!(ptr_type.get_element_type().into_int_type(), i8_type);
 
     // Fn ptr:
     let void_type = context.void_type();
     let fn_type = void_type.fn_type(&[], false);
-    let fn_ptr_type = fn_type.ptr_type(AddressSpace::Generic);
+    let fn_ptr_type = fn_type.ptr_type(AddressSpace::default());
 
     assert_eq!(fn_ptr_type.get_element_type().into_function_type(), fn_type);
     assert_eq!(fn_ptr_type.get_context(), context);
@@ -359,7 +359,7 @@ fn test_ptr_type() {
 #[test]
 fn test_basic_type_enum() {
     let context = Context::create();
-    let addr = AddressSpace::Generic;
+    let addr = AddressSpace::default();
     let int = context.i32_type();
     let types: &[&dyn BasicType] = &[
         // ints and floats

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -398,13 +398,11 @@ fn test_ptr_address_space() {
     let spaces = [0, 1, 2, 3, 4, 5, 6, 1 << 24 - 1];
 
     for index in spaces {
-        let address_space = AddressSpace(index);
+        let address_space = AddressSpace::try_from(index).unwrap();
 
         let ptr = context.i32_type().ptr_type(address_space);
         assert_eq!(ptr.get_address_space(), address_space);
     }
 
-    let address_space = AddressSpace(1 << 24);
-    let ptr = context.i32_type().ptr_type(address_space);
-    assert_ne!(ptr.get_address_space(), address_space);
+    assert!(AddressSpace::try_from(1 << 24).is_err());
 }

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -810,7 +810,7 @@ fn test_globals() {
 
     assert!(global.get_thread_local_mode().is_none());
 
-    let global2 = module.add_global(i8_type, Some(AddressSpace::Const), "my_global2");
+    let global2 = module.add_global(i8_type, Some(AddressSpace(4)), "my_global2");
 
     assert_eq!(global2.get_previous_global().unwrap(), global);
     assert_eq!(global.get_next_global().unwrap(), global2);
@@ -1178,7 +1178,7 @@ fn test_aggregate_returns() {
     let builder = context.create_builder();
     let module = context.create_module("my_mod");
     let i32_type = context.i32_type();
-    let i32_ptr_type = i32_type.ptr_type(AddressSpace::Local);
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace(5));
     let i32_three = i32_type.const_int(3, false);
     let i32_seven = i32_type.const_int(7, false);
     let struct_type = context.struct_type(&[i32_type.into(), i32_type.into()], false);

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -87,7 +87,7 @@ fn test_set_get_name() {
     let f32_val = f32_type.const_float(0.0);
     let f64_val = f64_type.const_float(0.0);
     let f128_val = f128_type.const_float(0.0);
-    let ptr_val = bool_type.ptr_type(AddressSpace::Generic).const_null();
+    let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
     let array_val = f64_type.const_array(&[f64_val]);
     let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
     let vec_val = VectorType::const_vector(&[i8_val]);
@@ -143,7 +143,7 @@ fn test_set_get_name() {
     assert_eq!(ppc_f128_val.get_name().to_str(), Ok(""));
 
     let void_type = context.void_type();
-    let ptr_type = bool_type.ptr_type(AddressSpace::Generic);
+    let ptr_type = bool_type.ptr_type(AddressSpace::default());
     let struct_type = context.struct_type(&[bool_type.into()], false);
     let vec_type = bool_type.vec_type(1);
 
@@ -229,7 +229,7 @@ fn test_undef() {
     let f32_val = f32_type.const_float(0.0);
     let f64_val = f64_type.const_float(0.0);
     let f128_val = f128_type.const_float(0.0);
-    let ptr_val = bool_type.ptr_type(AddressSpace::Generic).const_null();
+    let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
     let array_val = f64_type.const_array(&[f64_val]);
     let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
     let vec_val = VectorType::const_vector(&[i8_val]);
@@ -261,7 +261,7 @@ fn test_undef() {
     let f32_undef = f32_type.get_undef();
     let f64_undef = f64_type.get_undef();
     let f128_undef = f128_type.get_undef();
-    let ptr_undef = bool_type.ptr_type(AddressSpace::Generic).get_undef();
+    let ptr_undef = bool_type.ptr_type(AddressSpace::default()).get_undef();
     let array_undef = array_type.get_undef();
     let struct_undef = context.struct_type(&[bool_type.into()], false).get_undef();
     let vec_undef = bool_type.vec_type(1).get_undef();
@@ -419,7 +419,7 @@ fn test_metadata() {
         // let f64_val = f64_type.const_float(0.0);
         // let f128_val = f128_type.const_float(0.0);
         // let ppc_f128_val = ppc_f128_type.const_float(0.0);
-        // let ptr_val = bool_type.ptr_type(AddressSpace::Generic).const_null();
+        // let ptr_val = bool_type.ptr_type(AddressSpace::default()).const_null();
         // let array_val = f64_type.const_array(&[f64_val]);
         // let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
         // let vec_val = VectorType::const_vector(&[i8_val]);
@@ -678,7 +678,7 @@ fn test_global_byte_array() {
     let my_str = "Hello, World";
     let i8_type = context.i8_type();
     let i8_array_type = i8_type.array_type(my_str.len() as u32);
-    let global_string = module.add_global(i8_array_type, Some(AddressSpace::Generic), "message");
+    let global_string = module.add_global(i8_array_type, Some(AddressSpace::default()), "message");
 
     let mut chars = Vec::with_capacity(my_str.len());
 
@@ -1134,7 +1134,7 @@ fn test_non_fn_ptr_called() {
     let builder = context.create_builder();
     let module = context.create_module("my_mod");
     let i8_type = context.i8_type();
-    let i8_ptr_type = i8_type.ptr_type(AddressSpace::Generic);
+    let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
     let fn_type = i8_type.fn_type(&[i8_ptr_type.into()], false);
     let fn_value = module.add_function("my_func", fn_type, None);
     let bb = context.append_basic_block(fn_value, "entry");

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -810,7 +810,7 @@ fn test_globals() {
 
     assert!(global.get_thread_local_mode().is_none());
 
-    let global2 = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global2");
+    let global2 = module.add_global(i8_type, Some(AddressSpace::from(4u16)), "my_global2");
 
     assert_eq!(global2.get_previous_global().unwrap(), global);
     assert_eq!(global.get_next_global().unwrap(), global2);
@@ -1178,7 +1178,7 @@ fn test_aggregate_returns() {
     let builder = context.create_builder();
     let module = context.create_module("my_mod");
     let i32_type = context.i32_type();
-    let i32_ptr_type = i32_type.ptr_type(AddressSpace::FIVE);
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace::from(5u16));
     let i32_three = i32_type.const_int(3, false);
     let i32_seven = i32_type.const_int(7, false);
     let struct_type = context.struct_type(&[i32_type.into(), i32_type.into()], false);

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -810,7 +810,7 @@ fn test_globals() {
 
     assert!(global.get_thread_local_mode().is_none());
 
-    let global2 = module.add_global(i8_type, Some(AddressSpace(4)), "my_global2");
+    let global2 = module.add_global(i8_type, Some(AddressSpace::FOUR), "my_global2");
 
     assert_eq!(global2.get_previous_global().unwrap(), global);
     assert_eq!(global.get_next_global().unwrap(), global2);
@@ -1178,7 +1178,7 @@ fn test_aggregate_returns() {
     let builder = context.create_builder();
     let module = context.create_module("my_mod");
     let i32_type = context.i32_type();
-    let i32_ptr_type = i32_type.ptr_type(AddressSpace(5));
+    let i32_ptr_type = i32_type.ptr_type(AddressSpace::FIVE);
     let i32_three = i32_type.const_int(3, false);
     let i32_seven = i32_type.const_int(7, false);
     let struct_type = context.struct_type(&[i32_type.into(), i32_type.into()], false);


### PR DESCRIPTION
<!--- This version of the form is by no means final -->

in #383 it came up that the current representation of an address space is not entirely correct. To make changes to that type easier, and because usually "Generic" is the address space that users want, implementing and using the default instance means that even if we change the representation of address spaces, this would not actually be noticeable by users.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## \<Breaking Changes\>

There specifically are no breaking changes in the PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
