### PR TITLE
Treat `const_string` as returning `ArrayValue`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -45,7 +45,7 @@ use crate::types::MetadataType;
 use crate::types::{AsTypeRef, BasicTypeEnum, FloatType, FunctionType, IntType, StructType, VoidType};
 use crate::values::{
     AsValueRef, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, MetadataValue, PointerValue, StructValue,
-    VectorValue,
+    ArrayValue,
 };
 use crate::AddressSpace;
 #[cfg(feature = "internal-getters")]
@@ -368,9 +368,9 @@ impl ContextImpl {
         unsafe { Attribute::new(LLVMCreateTypeAttribute(self.0, kind_id, type_ref.as_type_ref())) }
     }
 
-    fn const_string<'ctx>(&self, string: &[u8], null_terminated: bool) -> VectorValue<'ctx> {
+    fn const_string<'ctx>(&self, string: &[u8], null_terminated: bool) -> ArrayValue<'ctx> {
         unsafe {
-            VectorValue::new(LLVMConstStringInContext(
+            ArrayValue::new(LLVMConstStringInContext(
                 self.0,
                 string.as_ptr() as *const ::libc::c_char,
                 string.len() as u32,
@@ -1251,9 +1251,9 @@ impl Context {
     ///
     /// assert_eq!(string.print_to_string().to_string(), "[9 x i8] c\"my_string\"");
     /// ```
-    // SubTypes: Should return VectorValue<IntValue<i8>>
+    // SubTypes: Should return ArrayValue<IntValue<i8>>
     #[inline]
-    pub fn const_string(&self, string: &[u8], null_terminated: bool) -> VectorValue {
+    pub fn const_string(&self, string: &[u8], null_terminated: bool) -> ArrayValue {
         self.context.const_string(string, null_terminated)
     }
 
@@ -2083,9 +2083,9 @@ impl<'ctx> ContextRef<'ctx> {
     ///
     /// assert_eq!(string.print_to_string().to_string(), "[9 x i8] c\"my_string\"");
     /// ```
-    // SubTypes: Should return VectorValue<IntValue<i8>>
+    // SubTypes: Should return ArrayValue<IntValue<i8>>
     #[inline]
-    pub fn const_string(&self, string: &[u8], null_terminated: bool) -> VectorValue<'ctx> {
+    pub fn const_string(&self, string: &[u8], null_terminated: bool) -> ArrayValue<'ctx> {
         self.context.const_string(string, null_terminated)
     }
 

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -100,7 +100,8 @@ impl<'ctx> ArrayValue<'ctx> {
         unsafe { LLVMIsConstantString(self.as_value_ref()) == 1 }
     }
 
-    /// Obtain the string from a constant array of `i8`s.
+    /// Obtain the string from the ArrayValue
+    /// if the value points to a constant string.
     /// 
     /// # Example
     /// 
@@ -112,20 +113,18 @@ impl<'ctx> ArrayValue<'ctx> {
     /// let string = context.const_string(b"hello!", true);
     /// 
     /// let result = CStr::from_bytes_with_nul(b"hello!\0").unwrap();
-    /// assert_eq!(string.get_string_constant(), result);
+    /// assert_eq!(string.get_string_constant(), Some(result));
     /// ```
     // SubTypes: Impl only for ArrayValue<IntValue<i8>>
-    pub fn get_string_constant(&self) -> &CStr {
-        // REVIEW: Maybe need to check is_const_string?
-
+    pub fn get_string_constant(&self) -> Option<&CStr> {
         let mut len = 0;
         let ptr = unsafe { LLVMGetAsString(self.as_value_ref(), &mut len) };
 
         if ptr.is_null() {
-            panic!("FIXME: Need to retun an Option");
+            None
+        } else {
+            unsafe { Some(CStr::from_ptr(ptr)) }
         }
-
-        unsafe { CStr::from_ptr(ptr) }
     }
 }
 

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -1,6 +1,6 @@
 use llvm_sys::core::{
-    LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstSelect, LLVMConstShuffleVector, LLVMGetAsString,
-    LLVMGetElementAsConstant, LLVMIsAConstantDataVector, LLVMIsAConstantVector, LLVMIsConstantString,
+    LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstSelect, LLVMConstShuffleVector,
+    LLVMGetElementAsConstant, LLVMIsAConstantDataVector, LLVMIsAConstantVector,
 };
 use llvm_sys::prelude::LLVMValueRef;
 

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -103,37 +103,6 @@ impl<'ctx> VectorValue<'ctx> {
         self.vec_value.replace_all_uses_with(other.as_value_ref())
     }
 
-    /// Creates a const string which may be null terminated.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use inkwell::context::Context;
-    ///
-    /// let context = Context::create();
-    /// let string = context.const_string(b"my_string", false);
-    ///
-    /// assert!(string.is_const_string());
-    /// ```
-    // SubTypes: Impl only for VectorValue<IntValue<i8>>
-    pub fn is_const_string(self) -> bool {
-        unsafe { LLVMIsConstantString(self.as_value_ref()) == 1 }
-    }
-
-    // SubTypes: Impl only for VectorValue<IntValue<i8>>
-    pub fn get_string_constant(&self) -> &CStr {
-        // REVIEW: Maybe need to check is_const_string?
-
-        let mut len = 0;
-        let ptr = unsafe { LLVMGetAsString(self.as_value_ref(), &mut len) };
-
-        if ptr.is_null() {
-            panic!("FIXME: Need to retun an Option");
-        }
-
-        unsafe { CStr::from_ptr(ptr) }
-    }
-
     // TODOC: Value seems to be zero initialized if index out of bounds
     // SubType: VectorValue<BV> -> BV
     pub fn get_element_as_constant(self, index: u32) -> BasicValueEnum<'ctx> {

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1066,7 +1066,6 @@ fn test_consts() {
 
     assert_eq!(arbitrary_precision_int.print_to_string().to_str(), Ok("i64 1"));
 
-    assert!(!vec_val.is_const_string());
     assert!(!vec_val.is_constant_vector());
     assert!(vec_val.is_constant_data_vector());
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -988,24 +988,34 @@ fn test_string_values() {
     assert!(string_null.is_const_string());
     assert_eq!(string.get_type().get_element_type().into_int_type(), i8_type);
     assert_eq!(string_null.get_type().get_element_type().into_int_type(), i8_type);
-    assert_eq!(string.get_string_constant().to_str(), Ok("my_string"));
-    assert_eq!(string_null.get_string_constant().to_str(), Ok("my_string"));
+
+    let string_const = string.get_string_constant();
+    let string_null_const = string_null.get_string_constant();
+
+    assert!(string_const.is_some());
+    assert!(string_null_const.is_some());
+    assert_eq!(string_const.unwrap().to_str(), Ok("my_string"));
+    assert_eq!(string_null_const.unwrap().to_str(), Ok("my_string"));
 
     let i8_val = i8_type.const_int(33, false);
     let i8_val2 = i8_type.const_int(43, false);
-    let non_string_vec_i8 = VectorType::const_vector(&[i8_val, i8_val2]);
+    let non_string_vec_i8 = i8_type.const_array(&[i8_val, i8_val2]);
+    let non_string_vec_i8_const = non_string_vec_i8.get_string_constant();
 
     // TODOC: Will still interpret vec as string even if not generated with const_string:
-    assert_eq!(non_string_vec_i8.get_string_constant().to_str(), Ok("!+"));
+    assert!(non_string_vec_i8_const.is_some());
+    assert_eq!(non_string_vec_i8_const.unwrap().to_str(), Ok("!+"));
 
     let i32_type = context.i32_type();
     let i32_val = i32_type.const_int(33, false);
     let i32_val2 = i32_type.const_int(43, false);
-    let non_string_vec_i32 = VectorType::const_vector(&[i32_val, i32_val2, i32_val2]);
+    let non_string_vec_i32 = i8_type.const_array(&[i32_val, i32_val2, i32_val2]);
+    let non_string_vec_i32_const = non_string_vec_i32.get_string_constant();
 
     // TODOC: Will still interpret vec with non i8 but in unexpected ways:
     // We may want to restrict this to VectorValue<IntValue<i8>>...
-    assert_eq!(non_string_vec_i32.get_string_constant().to_str(), Ok("!"));
+    assert!(non_string_vec_i32_const.is_some());
+    assert_eq!(non_string_vec_i32_const.unwrap().to_str(), Ok("!"));
 
     // TODO: Test get_string_constant on non const...
 }

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -976,10 +976,8 @@ fn test_string_values() {
     let string = context.const_string(b"my_string", false);
     let string_null = context.const_string(b"my_string", true);
 
-    assert!(!string.is_constant_vector());
-    assert!(!string_null.is_constant_vector());
-    assert!(!string.is_constant_data_vector());
-    assert!(!string_null.is_constant_data_vector());
+    assert!(string.is_const());
+    assert!(string_null.is_const());
 
     assert_eq!(string.print_to_string().to_string(), "[9 x i8] c\"my_string\"");
     assert_eq!(


### PR DESCRIPTION
## Description

This changes the type signature of `Context::const_string` to return ArrayValue instead of VectorValue.

This alone breaks the `test_values::test_string_values` test, 
so I also added the `is_const_string` and `get_string_constant` methods from VectorValue to ArrayValue.

I didn't remove those methods from VectorValue because I wanted to avoid making any breaking changes. I'm not too sure if they are needed, though.

## Related Issue

#390 

## How This Has Been Tested

- Doc tests
- `cargo test -F llvm14-0`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
