### PR TITLE
Support LLVM 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
-  DOC_LLVM_FEATURE: llvm15-0
-  DOC_LLVM_VERSION: '15.0'
+  DOC_LLVM_FEATURE: llvm16-0
+  DOC_LLVM_VERSION: '16.0'
   DOC_PATH: target/doc
 
 jobs:
@@ -28,6 +28,7 @@ jobs:
           - ["13.0", "13-0"]
           - ["14.0", "14-0"]
           - ["15.0", "15-0"]
+          - ["16.0", "16-0"]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ llvm12-0 = ["llvm-sys-120"]
 llvm13-0 = ["llvm-sys-130"]
 llvm14-0 = ["llvm-sys-140"]
 llvm15-0 = ["llvm-sys-150"]
+llvm16-0 = ["llvm-sys-160"]
 # Don't link aganist LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
 # `no-llvm-linking` feature across the board of llvm versions, as it'll cause
@@ -43,6 +44,7 @@ llvm12-0-no-llvm-linking = ["llvm12-0", "llvm-sys-120/no-llvm-linking"]
 llvm13-0-no-llvm-linking = ["llvm13-0", "llvm-sys-130/no-llvm-linking"]
 llvm14-0-no-llvm-linking = ["llvm14-0", "llvm-sys-140/no-llvm-linking"]
 llvm15-0-no-llvm-linking = ["llvm15-0", "llvm-sys-150/no-llvm-linking"]
+llvm16-0-no-llvm-linking = ["llvm16-0", "llvm-sys-160/no-llvm-linking"]
 # Don't force linking to libffi on non-windows platforms. Without this feature
 # inkwell always links to libffi on non-windows platforms.
 no-libffi-linking = []
@@ -100,6 +102,7 @@ llvm-sys-120 = { package = "llvm-sys", version = "120.2.4", optional = true }
 llvm-sys-130 = { package = "llvm-sys", version = "130.0.4", optional = true }
 llvm-sys-140 = { package = "llvm-sys", version = "140.0.2", optional = true }
 llvm-sys-150 = { package = "llvm-sys", version = "150.0.3", optional = true }
+llvm-sys-160 = { package = "llvm-sys", version = "160.0.2", optional = true }
 once_cell = "1.16"
 parking_lot = "0.12"
 static-alloc = { version = "0.2", optional = true }

--- a/examples/kaleidoscope/main.rs
+++ b/examples/kaleidoscope/main.rs
@@ -21,7 +21,7 @@ use inkwell::OptimizationLevel;
 
 use inkwell_internals::llvm_versions;
 
-#[cfg(not(any(feature = "llvm15-0")))]
+#[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0")))]
 mod implementation_typed_pointers;
 
 #[llvm_versions(4.0..=14.0)]

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -12,9 +12,9 @@ use syn::{parenthesized, parse_macro_input, parse_quote};
 use syn::{Attribute, Field, Ident, Item, LitFloat, Token, Variant};
 
 // This array should match the LLVM features in the top level Cargo manifest
-const FEATURE_VERSIONS: [&str; 12] = [
+const FEATURE_VERSIONS: [&str; 13] = [
     "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0",
-    "llvm14-0", "llvm15-0",
+    "llvm14-0", "llvm15-0", "llvm16-0",
 ];
 
 /// Gets the index of the feature version that represents `latest`

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2314,9 +2314,21 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// let array_alloca = builder.build_alloca(array_type, "array_alloca");
     ///
-    /// #[cfg(not(any(feature = "llvm15-0")))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// let array = builder.build_load(array_alloca, "array_load").into_array_value();
-    /// #[cfg(any(feature = "llvm15-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     /// let array = builder.build_load(i32_type, array_alloca, "array_load").into_array_value();
     ///
     /// let const_int1 = i32_type.const_int(2, false);
@@ -2379,9 +2391,21 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// let array_alloca = builder.build_alloca(array_type, "array_alloca");
     ///
-    /// #[cfg(not(any(feature = "llvm15-0")))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// let array = builder.build_load(array_alloca, "array_load").into_array_value();
-    /// #[cfg(any(feature = "llvm15-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     /// let array = builder.build_load(i32_type, array_alloca, "array_load").into_array_value();
     ///
     /// let const_int1 = i32_type.const_int(2, false);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2753,7 +2753,7 @@ impl<'ctx> Builder<'ctx> {
             return Err("The bitwidth of value must be a power of 2 and greater than 8.");
         }
 
-        #[cfg(not(any(feature = "llvm15-0")))]
+        #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0")))]
         if ptr.get_type().get_element_type() != value.get_type().into() {
             return Err("Pointer's pointee type must match the value's type.");
         }
@@ -2813,7 +2813,7 @@ impl<'ctx> Builder<'ctx> {
             return Err("The values must have pointer or integer type.");
         }
 
-        #[cfg(not(any(feature = "llvm15-0")))]
+        #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0")))]
         if ptr.get_type().get_element_type().to_basic_type_enum() != cmp.get_type() {
             return Err("The pointer does not point to an element of the value type.");
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -550,14 +550,26 @@ impl Context {
     /// );
     /// let params = &[context.i64_type().const_int(60, false).into(), context.i64_type().const_int(1, false).into()];
     ///
-    /// #[cfg(not(any(feature = "llvm15-0")))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// {
     ///     use inkwell::values::CallableValue;
     ///     let callable_value = CallableValue::try_from(asm).unwrap();
     ///     builder.build_call(callable_value, params, "exit");
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit");
     ///
     /// builder.build_return(None);
@@ -1386,14 +1398,26 @@ impl<'ctx> ContextRef<'ctx> {
     /// );
     /// let params = &[context.i64_type().const_int(60, false).into(), context.i64_type().const_int(1, false).into()];
     ///
-    /// #[cfg(not(any(feature = "llvm15-0")))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// {
     ///     use inkwell::values::CallableValue;
     ///     let callable_value = CallableValue::try_from(asm).unwrap();
     ///     builder.build_call(callable_value, params, "exit");
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit");
     ///
     /// builder.build_return(None);

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -191,7 +191,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -199,7 +200,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         sdk: &str,
     ) -> (Self, DICompileUnit<'ctx>) {
@@ -235,7 +237,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             sysroot,
             #[cfg(any(
@@ -243,7 +246,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             sdk,
         );
@@ -287,7 +291,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -295,7 +300,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         sdk: &str,
     ) -> DICompileUnit<'ctx> {
@@ -334,7 +340,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             {
                 LLVMDIBuilderCreateCompileUnit(
@@ -1551,5 +1558,32 @@ mod flags {
         GOOGLERenderScript,
         #[llvm_variant(LLVMDWARFSourceLanguageBORLAND_Delphi)]
         BORLANDDelphi,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageKotlin)]
+        Kotlin,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageZig)]
+        Zig,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageCrystal)]
+        Crystal,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageC_plus_plus_17)]
+        CPlusPlus17,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageC_plus_plus_20)]
+        CPlusPlus20,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageC17)]
+        C17,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageFortran18)]
+        Fortran18,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageAda2005)]
+        Ada2005,
+        #[llvm_versions(16.0..=latest)]
+        #[llvm_variant(LLVMDWARFSourceLanguageAda2012)]
+        Ada2012,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ extern crate llvm_sys_130 as llvm_sys;
 extern crate llvm_sys_140 as llvm_sys;
 #[cfg(feature = "llvm15-0")]
 extern crate llvm_sys_150 as llvm_sys;
+#[cfg(feature = "llvm16-0")]
+extern crate llvm_sys_160 as llvm_sys;
 #[cfg(feature = "llvm4-0")]
 extern crate llvm_sys_40 as llvm_sys;
 #[cfg(feature = "llvm5-0")]
@@ -105,7 +107,7 @@ macro_rules! assert_unique_used_features {
     }
 }
 
-assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0", "llvm14-0", "llvm15-0"}
+assert_unique_used_features! {"llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0", "llvm14-0", "llvm15-0", "llvm16-0"}
 
 /// Defines the address space in which a global will be inserted.
 ///

--- a/src/module.rs
+++ b/src/module.rs
@@ -1424,7 +1424,8 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -1432,7 +1433,8 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         sdk: &str,
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
@@ -1456,7 +1458,8 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             sysroot,
             #[cfg(any(
@@ -1464,7 +1467,8 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             sdk,
         )

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -5,16 +5,20 @@ use llvm_sys::core::{
 };
 use llvm_sys::initialization::{
     LLVMInitializeAnalysis, LLVMInitializeCodeGen, LLVMInitializeCore, LLVMInitializeIPA, LLVMInitializeIPO,
-    LLVMInitializeInstCombine, LLVMInitializeInstrumentation, LLVMInitializeObjCARCOpts, LLVMInitializeScalarOpts,
-    LLVMInitializeTarget, LLVMInitializeTransformUtils, LLVMInitializeVectorization,
+    LLVMInitializeInstCombine, LLVMInitializeScalarOpts, LLVMInitializeTarget, LLVMInitializeTransformUtils,
+    LLVMInitializeVectorization,
 };
+#[llvm_versions(4.0..=15.0)]
+use llvm_sys::initialization::{LLVMInitializeInstrumentation, LLVMInitializeObjCARCOpts};
 use llvm_sys::prelude::{LLVMPassManagerRef, LLVMPassRegistryRef};
 #[llvm_versions(10.0..=latest)]
 use llvm_sys::transforms::ipo::LLVMAddMergeFunctionsPass;
+#[llvm_versions(4.0..=15.0)]
+use llvm_sys::transforms::ipo::LLVMAddPruneEHPass;
 use llvm_sys::transforms::ipo::{
     LLVMAddAlwaysInlinerPass, LLVMAddConstantMergePass, LLVMAddDeadArgEliminationPass, LLVMAddFunctionAttrsPass,
     LLVMAddFunctionInliningPass, LLVMAddGlobalDCEPass, LLVMAddGlobalOptimizerPass, LLVMAddIPSCCPPass,
-    LLVMAddInternalizePass, LLVMAddPruneEHPass, LLVMAddStripDeadPrototypesPass, LLVMAddStripSymbolsPass,
+    LLVMAddInternalizePass, LLVMAddStripDeadPrototypesPass, LLVMAddStripSymbolsPass,
 };
 use llvm_sys::transforms::pass_manager_builder::{
     LLVMPassManagerBuilderCreate, LLVMPassManagerBuilderDispose, LLVMPassManagerBuilderPopulateFunctionPassManager,
@@ -398,6 +402,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// call instructions if and only if the callee cannot throw
     /// an exception. It implements this as a bottom-up traversal
     /// of the call-graph.
+    #[llvm_versions(4.0..=15.0)]
     pub fn add_prune_eh_pass(&self) {
         unsafe { LLVMAddPruneEHPass(self.pass_manager) }
     }
@@ -1005,7 +1010,7 @@ impl<T: PassManagerSubType> PassManager<T> {
         unsafe { LLVMAddBasicAliasAnalysisPass(self.pass_manager) }
     }
 
-    #[llvm_versions(7.0..=latest)]
+    #[llvm_versions(7.0..=15.0)]
     pub fn add_aggressive_inst_combiner_pass(&self) {
         #[cfg(not(feature = "llvm7-0"))]
         use llvm_sys::transforms::aggressive_instcombine::LLVMAddAggressiveInstCombinerPass;
@@ -1092,6 +1097,7 @@ impl PassRegistry {
         unsafe { LLVMInitializeScalarOpts(self.pass_registry) }
     }
 
+    #[llvm_versions(4.0..=15.0)]
     pub fn initialize_obj_carc_opts(&self) {
         unsafe { LLVMInitializeObjCARCOpts(self.pass_registry) }
     }
@@ -1109,6 +1115,7 @@ impl PassRegistry {
         unsafe { LLVMInitializeIPO(self.pass_registry) }
     }
 
+    #[llvm_versions(4.0..=15.0)]
     pub fn initialize_instrumentation(&self) {
         unsafe { LLVMInitializeInstrumentation(self.pass_registry) }
     }
@@ -1129,7 +1136,7 @@ impl PassRegistry {
         unsafe { LLVMInitializeTarget(self.pass_registry) }
     }
 
-    #[llvm_versions(7.0..=latest)]
+    #[llvm_versions(7.0..=15.0)]
     pub fn initialize_aggressive_inst_combiner(&self) {
         use llvm_sys::initialization::LLVMInitializeAggressiveInstCombiner;
 

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -2,6 +2,8 @@
 pub mod error_handling;
 
 use libc::c_char;
+#[llvm_versions(16.0)]
+use llvm_sys::core::LLVMGetVersion;
 use llvm_sys::core::{LLVMCreateMessage, LLVMDisposeMessage};
 use llvm_sys::error_handling::LLVMEnablePrettyStackTrace;
 use llvm_sys::support::LLVMLoadLibraryPermanently;
@@ -121,6 +123,18 @@ pub unsafe fn shutdown_llvm() {
     use llvm_sys::core::LLVMShutdown;
 
     LLVMShutdown()
+}
+
+/// Returns the major, minor, and patch version of the LLVM in use
+#[llvm_versions(16.0..=latest)]
+pub fn get_llvm_version() -> (u32, u32, u32) {
+    let mut major: u32 = 0;
+    let mut minor: u32 = 0;
+    let mut patch: u32 = 0;
+
+    unsafe { LLVMGetVersion(&mut major, &mut minor, &mut patch) };
+
+    return (major, minor, patch);
 }
 
 pub fn load_library_permanently(filename: &str) -> bool {

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -76,7 +76,19 @@ impl<'ctx> ArrayType<'ctx> {
     /// let i8_array_type = i8_type.array_type(3);
     /// let i8_array_ptr_type = i8_array_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(i8_array_ptr_type.get_element_type().into_array_type(), i8_array_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -221,7 +221,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMLabelTypeKind => panic!("FIXME: Unsupported type: Label"),
@@ -236,7 +237,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
             // FIXME: should inkwell support metadata as AnyType?
@@ -246,10 +248,13 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => panic!("FIXME: Unsupported type: AMX"),
             LLVMTypeKind::LLVMTokenTypeKind => panic!("FIXME: Unsupported type: Token"),
+            #[cfg(feature = "llvm16-0")]
+            LLVMTypeKind::LLVMTargetExtTypeKind => panic!("FIXME: Unsupported type: TargetExt"),
         }
     }
 
@@ -400,7 +405,8 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMIntegerTypeKind => BasicTypeEnum::IntType(IntType::new(type_)),
@@ -413,7 +419,8 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Unsupported basic type: Metadata"),
@@ -424,13 +431,16 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm12-0",
                 feature = "llvm13-0",
                 feature = "llvm14-0",
-                feature = "llvm15-0"
+                feature = "llvm15-0",
+                feature = "llvm16-0"
             ))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => unreachable!("Unsupported basic type: AMX"),
             LLVMTypeKind::LLVMLabelTypeKind => unreachable!("Unsupported basic type: Label"),
             LLVMTypeKind::LLVMVoidTypeKind => unreachable!("Unsupported basic type: VoidType"),
             LLVMTypeKind::LLVMFunctionTypeKind => unreachable!("Unsupported basic type: FunctionType"),
             LLVMTypeKind::LLVMTokenTypeKind => unreachable!("Unsupported basic type: Token"),
+            #[cfg(feature = "llvm16-0")]
+            LLVMTypeKind::LLVMTargetExtTypeKind => unreachable!("Unsupported basic type: TargetExt"),
         }
     }
 

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -215,7 +215,19 @@ impl<'ctx> FloatType<'ctx> {
     /// let f32_type = context.f32_type();
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(f32_ptr_type.get_element_type().into_float_type(), f32_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -45,7 +45,19 @@ impl<'ctx> FunctionType<'ctx> {
     /// let fn_type = f32_type.fn_type(&[], false);
     /// let fn_ptr_type = fn_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(fn_ptr_type.get_element_type().into_function_type(), fn_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -310,7 +310,19 @@ impl<'ctx> IntType<'ctx> {
     /// let i8_type = context.i8_type();
     /// let i8_ptr_type = i8_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(i8_ptr_type.get_element_type().into_int_type(), i8_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -79,7 +79,19 @@ impl<'ctx> PointerType<'ctx> {
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// let f32_ptr_ptr_type = f32_ptr_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(f32_ptr_ptr_type.get_element_type().into_pointer_type(), f32_ptr_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -192,7 +192,19 @@ impl<'ctx> StructType<'ctx> {
     /// let struct_type = context.struct_type(&[f32_type.into(), f32_type.into()], false);
     /// let struct_ptr_type = struct_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(struct_ptr_type.get_element_type().into_struct_type(), struct_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -181,7 +181,19 @@ impl<'ctx> VectorType<'ctx> {
     /// let f32_vec_type = f32_type.vec_type(3);
     /// let f32_vec_ptr_type = f32_vec_type.ptr_type(AddressSpace::default());
     ///
-    /// #[cfg(not(feature = "llvm15-0"))]
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
     /// assert_eq!(f32_vec_ptr_type.get_element_type().into_vector_type(), f32_vec_type);
     /// ```
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -1,5 +1,7 @@
+#[llvm_versions(4.0..=15.0)]
+use llvm_sys::core::LLVMConstFNeg;
 use llvm_sys::core::{
-    LLVMConstFCmp, LLVMConstFNeg, LLVMConstFPCast, LLVMConstFPExt, LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc,
+    LLVMConstFCmp, LLVMConstFPCast, LLVMConstFPExt, LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc,
     LLVMConstRealGetDouble,
 };
 use llvm_sys::prelude::LLVMValueRef;
@@ -60,6 +62,7 @@ impl<'ctx> FloatValue<'ctx> {
         self.float_value.as_instruction()
     }
 
+    #[llvm_versions(4.0..=15.0)]
     pub fn const_neg(self) -> Self {
         unsafe { FloatValue::new(LLVMConstFNeg(self.as_value_ref())) }
     }

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -36,6 +36,8 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 30;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 31;
 #[cfg(any(feature = "llvm15-0"))]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 36;
+#[cfg(any(feature = "llvm16-0"))]
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 39;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue<'ctx> {

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -20,10 +20,10 @@ mod struct_value;
 mod traits;
 mod vec_value;
 
-#[cfg(not(any(feature = "llvm15-0")))]
+#[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0")))]
 mod callable_value;
 
-#[cfg(not(any(feature = "llvm15-0")))]
+#[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0")))]
 pub use crate::values::callable_value::CallableValue;
 
 use crate::support::{to_c_str, LLVMString};

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -55,18 +55,42 @@ fn test_build_call() {
 
     builder.build_store(alloca, fn_ptr);
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let load = builder.build_load(alloca, "load").into_pointer_value();
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let load = builder.build_load(fn_ptr_type, alloca, "load").into_pointer_value();
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     {
         use inkwell::values::CallableValue;
         let callable_value = CallableValue::try_from(load).unwrap();
         builder.build_call(callable_value, &[], "call");
     }
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     builder.build_indirect_call(fn_type2, load, &[], "call");
     builder.build_return(None);
 
@@ -338,9 +362,21 @@ fn test_null_checked_ptr_ops() {
     let ptr_as_int = builder.build_ptr_to_int(ptr, i64_type, "ptr_as_int");
     let new_ptr_as_int = builder.build_int_add(ptr_as_int, one, "add");
     let new_ptr = builder.build_int_to_ptr(new_ptr_as_int, i8_ptr_type, "int_as_ptr");
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let index1 = builder.build_load(new_ptr, "deref");
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let index1 = builder.build_load(i8_ptr_type, new_ptr, "deref");
 
     builder.build_return(Some(&index1));
@@ -378,9 +414,21 @@ fn test_null_checked_ptr_ops() {
     let ptr_as_int = builder.build_ptr_to_int(ptr, i64_type, "ptr_as_int");
     let new_ptr_as_int = builder.build_int_add(ptr_as_int, one, "add");
     let new_ptr = builder.build_int_to_ptr(new_ptr_as_int, i8_ptr_type, "int_as_ptr");
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let index1 = builder.build_load(new_ptr, "deref");
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let index1 = builder.build_load(i8_ptr_type, new_ptr, "deref");
 
     builder.build_return(Some(&index1));
@@ -889,9 +937,21 @@ fn test_insert_value() {
     builder.position_at_end(entry);
 
     let array_alloca = builder.build_alloca(array_type, "array_alloca");
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let array = builder.build_load(array_alloca, "array_load").into_array_value();
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let array = builder
         .build_load(array_type, array_alloca, "array_load")
         .into_array_value();
@@ -921,9 +981,21 @@ fn test_insert_value() {
     assert!(builder.build_extract_value(array, 3, "extract").is_none());
 
     let struct_alloca = builder.build_alloca(struct_type, "struct_alloca");
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let struct_value = builder.build_load(struct_alloca, "struct_load").into_struct_value();
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let struct_value = builder
         .build_load(struct_type, struct_alloca, "struct_load")
         .into_struct_value();
@@ -1028,9 +1100,21 @@ fn run_memcpy_on<'ctx>(
     // Initialize the array with the values [1, 2, 3, 4]
     for index in 0..4 {
         let index_val = i32_type.const_int(index, false);
-        #[cfg(not(feature = "llvm15-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
         let elem_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
-        #[cfg(feature = "llvm15-0")]
+        #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
         let elem_ptr = unsafe { builder.build_in_bounds_gep(element_type, array_ptr, &[index_val], "index") };
         let int_val = i32_type.const_int(index + 1, false);
 
@@ -1042,9 +1126,21 @@ fn run_memcpy_on<'ctx>(
     let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
     let size_val = i64_type.const_int(bytes_to_copy as u64, false);
     let index_val = i32_type.const_int(2, false);
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let dest_ptr = unsafe { builder.build_in_bounds_gep(element_type, array_ptr, &[index_val], "index") };
 
     builder.build_memcpy(dest_ptr, alignment, array_ptr, alignment, size_val)?;
@@ -1106,9 +1202,21 @@ fn run_memmove_on<'ctx>(
     // Initialize the array with the values [1, 2, 3, 4]
     for index in 0..4 {
         let index_val = i32_type.const_int(index, false);
-        #[cfg(not(feature = "llvm15-0"))]
+        #[cfg(any(
+            feature = "llvm4-0",
+            feature = "llvm5-0",
+            feature = "llvm6-0",
+            feature = "llvm7-0",
+            feature = "llvm8-0",
+            feature = "llvm9-0",
+            feature = "llvm10-0",
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0"
+        ))]
         let elem_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
-        #[cfg(feature = "llvm15-0")]
+        #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
         let elem_ptr = unsafe { builder.build_in_bounds_gep(element_type, array_ptr, &[index_val], "index") };
         let int_val = i32_type.const_int(index + 1, false);
 
@@ -1120,9 +1228,21 @@ fn run_memmove_on<'ctx>(
     let bytes_to_copy = elems_to_copy * std::mem::size_of::<i32>();
     let size_val = i64_type.const_int(bytes_to_copy as u64, false);
     let index_val = i32_type.const_int(2, false);
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") };
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let dest_ptr = unsafe { builder.build_in_bounds_gep(element_type, array_ptr, &[index_val], "index") };
 
     builder.build_memmove(dest_ptr, alignment, array_ptr, alignment, size_val)?;
@@ -1191,9 +1311,21 @@ fn run_memset_on<'ctx>(
     // Memset the second half of the array as -1
     let val = i8_type.const_all_ones();
     let index = i32_type.const_int(2, false);
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let part_2 = unsafe { builder.build_in_bounds_gep(array_ptr, &[index], "index") };
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let part_2 = unsafe { builder.build_in_bounds_gep(element_type, array_ptr, &[index], "index") };
     builder.build_memset(part_2, alignment, val, size_val)?;
     builder.build_return(Some(&array_ptr));
@@ -1302,7 +1434,19 @@ fn test_atomicrmw() {
     let result = builder.build_atomicrmw(AtomicRMWBinOp::Add, ptr_value, zero_value, AtomicOrdering::Unordered);
     assert!(result.is_ok());
 
-    #[cfg(not(any(feature = "llvm15-0")))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     {
         let ptr_value = i64_type.ptr_type(AddressSpace::default()).get_undef();
         let zero_value = i32_type.const_zero();
@@ -1410,7 +1554,19 @@ fn test_cmpxchg() {
     );
     assert!(result.is_err());
 
-    #[cfg(not(any(feature = "llvm15-0")))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     {
         let ptr_value = i32_ptr_ptr_type.get_undef();
         let zero_value = i32_type.const_zero();
@@ -1461,7 +1617,19 @@ fn test_cmpxchg() {
     );
     assert!(result.is_ok());
 
-    #[cfg(not(any(feature = "llvm15-0")))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     {
         let ptr_value = i32_ptr_type.get_undef();
         let zero_value = i32_ptr_type.const_zero();
@@ -1497,7 +1665,19 @@ fn test_safe_struct_gep() {
     let i32_ptr = fn_value.get_first_param().unwrap().into_pointer_value();
     let struct_ptr = fn_value.get_last_param().unwrap().into_pointer_value();
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     {
         assert!(builder.build_struct_gep(i32_ptr, 0, "struct_gep").is_err());
         assert!(builder.build_struct_gep(i32_ptr, 10, "struct_gep").is_err());
@@ -1505,7 +1685,7 @@ fn test_safe_struct_gep() {
         assert!(builder.build_struct_gep(struct_ptr, 1, "struct_gep").is_ok());
         assert!(builder.build_struct_gep(struct_ptr, 2, "struct_gep").is_err());
     }
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     {
         assert!(builder.build_struct_gep(i32_ty, i32_ptr, 0, "struct_gep").is_err());
         assert!(builder.build_struct_gep(i32_ty, i32_ptr, 10, "struct_gep").is_err());

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -30,7 +30,8 @@ fn test_smoke() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -38,7 +39,8 @@ fn test_smoke() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -114,7 +116,8 @@ fn test_struct_with_placeholders() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -122,7 +125,8 @@ fn test_struct_with_placeholders() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -240,7 +244,8 @@ fn test_no_explicit_finalize() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -248,7 +253,8 @@ fn test_no_explicit_finalize() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -283,7 +289,8 @@ fn test_replacing_placeholder_with_placeholder() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -291,7 +298,8 @@ fn test_replacing_placeholder_with_placeholder() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -340,7 +348,8 @@ fn test_anonymous_basic_type() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -348,7 +357,8 @@ fn test_anonymous_basic_type() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -390,7 +400,8 @@ fn test_global_expressions() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -398,7 +409,8 @@ fn test_global_expressions() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -458,7 +470,8 @@ fn test_pointer_types() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -466,7 +479,8 @@ fn test_pointer_types() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -510,7 +524,8 @@ fn test_reference_types() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -518,7 +533,8 @@ fn test_reference_types() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );
@@ -562,7 +578,8 @@ fn test_array_type() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
         #[cfg(any(
@@ -570,7 +587,8 @@ fn test_array_type() {
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
-            feature = "llvm15-0"
+            feature = "llvm15-0",
+            feature = "llvm16-0"
         ))]
         "",
     );

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -64,7 +64,19 @@ fn test_operands() {
     assert!(free_instruction.set_operand(0, arg1));
 
     // Module is no longer valid because free takes an i8* not f32*
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     assert!(module.verify().is_err());
 
     assert!(free_instruction.set_operand(0, free_operand0));
@@ -420,9 +432,21 @@ fn test_mem_instructions() {
     let f32_val = f32_type.const_float(::std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val);
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let load = builder.build_load(arg1, "");
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let load = builder.build_load(f32_type, arg1, "");
     let load_instruction = load.as_instruction_value().unwrap();
 
@@ -486,9 +510,21 @@ fn test_atomic_ordering_mem_instructions() {
     let f32_val = f32_type.const_float(::std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val);
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     let load = builder.build_load(arg1, "");
-    #[cfg(feature = "llvm15-0")]
+    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0"))]
     let load = builder.build_load(f32_type, arg1, "");
     let load_instruction = load.as_instruction_value().unwrap();
 

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -13,7 +13,19 @@ fn test_init_all_passes_for_module() {
     let module = context.create_module("my_module");
     let pass_manager = PassManager::create(());
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     pass_manager.add_argument_promotion_pass();
     pass_manager.add_constant_merge_pass();
     #[cfg(not(any(
@@ -35,9 +47,11 @@ fn test_init_all_passes_for_module() {
         feature = "llvm12-0",
         feature = "llvm13-0",
         feature = "llvm14-0",
-        feature = "llvm15-0"
+        feature = "llvm15-0",
+        feature = "llvm16-0"
     )))]
     pass_manager.add_ip_constant_propagation_pass();
+    #[cfg(not(feature = "llvm16-0"))]
     pass_manager.add_prune_eh_pass();
     pass_manager.add_ipsccp_pass();
     pass_manager.add_internalize_pass(true);
@@ -64,7 +78,19 @@ fn test_init_all_passes_for_module() {
     pass_manager.add_loop_rotate_pass();
     pass_manager.add_loop_reroll_pass();
     pass_manager.add_loop_unroll_pass();
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     pass_manager.add_loop_unswitch_pass();
     pass_manager.add_memcpy_optimize_pass();
     pass_manager.add_partially_inline_lib_calls_pass();
@@ -81,14 +107,16 @@ fn test_init_all_passes_for_module() {
         feature = "llvm12-0",
         feature = "llvm13-0",
         feature = "llvm14-0",
-        feature = "llvm15-0"
+        feature = "llvm15-0",
+        feature = "llvm16-0"
     )))]
     pass_manager.add_constant_propagation_pass();
     #[cfg(any(
         feature = "llvm12-0",
         feature = "llvm13-0",
         feature = "llvm14-0",
-        feature = "llvm15-0"
+        feature = "llvm15-0",
+        feature = "llvm16-0"
     ))]
     pass_manager.add_instruction_simplify_pass();
     pass_manager.add_demote_memory_to_register_pass();
@@ -102,18 +130,18 @@ fn test_init_all_passes_for_module() {
     pass_manager.add_early_cse_mem_ssa_pass();
     pass_manager.add_new_gvn_pass();
 
+    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm16-0")))]
+    pass_manager.add_aggressive_inst_combiner_pass();
     #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
-    {
-        pass_manager.add_aggressive_inst_combiner_pass();
-        pass_manager.add_loop_unroll_and_jam_pass();
-    }
+    pass_manager.add_loop_unroll_and_jam_pass();
 
     #[cfg(not(any(
         feature = "llvm4-0",
         feature = "llvm5-0",
         feature = "llvm6-0",
         feature = "llvm7-0",
-        feature = "llvm15-0"
+        feature = "llvm15-0",
+        feature = "llvm16-0"
     )))]
     {
         pass_manager.add_coroutine_early_pass();
@@ -165,7 +193,19 @@ fn test_pass_manager_builder() {
 
     pass_manager_builder.populate_module_pass_manager(&module_pass_manager);
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     {
         let module2 = module.clone();
 
@@ -188,16 +228,18 @@ fn test_pass_registry() {
     pass_registry.initialize_core();
     pass_registry.initialize_transform_utils();
     pass_registry.initialize_scalar_opts();
+    #[cfg(not(feature = "llvm16-0"))]
     pass_registry.initialize_obj_carc_opts();
     pass_registry.initialize_vectorization();
     pass_registry.initialize_inst_combine();
     pass_registry.initialize_ipo();
+    #[cfg(not(feature = "llvm16-0"))]
     pass_registry.initialize_instrumentation();
     pass_registry.initialize_analysis();
     pass_registry.initialize_ipa();
     pass_registry.initialize_codegen();
     pass_registry.initialize_target();
-    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0")))]
+    #[cfg(not(any(feature = "llvm4-0", feature = "llvm5-0", feature = "llvm6-0", feature = "llvm16-0")))]
     pass_registry.initialize_aggressive_inst_combiner();
 }
 

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -314,7 +314,7 @@ fn test_const_zero() {
     );
 
     // handle opaque pointers
-    let ptr_type = if cfg!(any(feature = "llvm15-0")) {
+    let ptr_type = if cfg!(any(feature = "llvm15-0", feature = "llvm16-0")) {
         "ptr null"
     } else {
         "double* null"
@@ -355,7 +355,19 @@ fn test_ptr_type() {
 
     assert_eq!(ptr_type.get_address_space(), AddressSpace::default());
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     assert_eq!(ptr_type.get_element_type().into_int_type(), i8_type);
 
     // Fn ptr:
@@ -363,7 +375,19 @@ fn test_ptr_type() {
     let fn_type = void_type.fn_type(&[], false);
     let fn_ptr_type = fn_type.ptr_type(AddressSpace::default());
 
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(any(
+        feature = "llvm4-0",
+        feature = "llvm5-0",
+        feature = "llvm6-0",
+        feature = "llvm7-0",
+        feature = "llvm8-0",
+        feature = "llvm9-0",
+        feature = "llvm10-0",
+        feature = "llvm11-0",
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0"
+    ))]
     assert_eq!(fn_ptr_type.get_element_type().into_function_type(), fn_type);
 
     assert_eq!(fn_ptr_type.get_context(), context);


### PR DESCRIPTION
This PR updates the crate to support building and using LLVM 16. The LLVM changelog can be found [here](https://releases.llvm.org/16.0.0/docs/ReleaseNotes.html), and the llvm-sys MR is [here](https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/28). The commit messages contain a more detailed explanation of what was done in each patch, so I recommend reviewing commit-by-commit.

This closes #400.

This was tested by running the CI on the development fork. I also wrote a small test package to verify `support::get_llvm_version()`, but I don't believe it is feasible to test it using the test suite.