### PR TITLE
add test for inlinealways function attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         llvm-version:
           - ["4.0", "4-0"]
           - ["5.0", "5-0"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         llvm-version:
           - ["4.0", "4-0"]
           - ["5.0", "5-0"]
@@ -29,6 +28,11 @@ jobs:
           - ["14.0", "14-0"]
           - ["15.0", "15-0"]
           - ["16.0", "16-0"]
+        # only use ubuntu-22.04 for llvm 16 and higher
+        include:
+          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            llvm-version: ["16.0", "16-0"]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: ${{ matrix.llvm-version[0] }}
+      - name: llvm-config
+        run: llvm-config --version --bindir --libdir
       - name: Build
         run: cargo build --release --features llvm${{ matrix.llvm-version[1] }} --verbose
       - name: Run tests


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Improve test for attributes on functions. Attributes on the `Function` location were not tested at all. The `alignstack` attribute was applied to the return type, but this attribute is not actually valid in that position. A `verify()` on the module called this issue out. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
