### PR TITLE
Add `typos` to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   typos:
-    name: Documentation
+    name: Typos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
       - name: Install typos
         run: cargo install typos-cli
       - name: Run typos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,20 @@ env:
   DOC_PATH: target/doc
 
 jobs:
+  typos:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Install typos
+        run: cargo install typos-cli
+      - name: Run typos
+        run: typos .
   tests:
     name: "LLVM ${{ matrix.llvm-version[0] }}: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    needs: typos
     strategy:
       matrix:
         llvm-version:

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,9 @@
+[default]
+extend-ignore-identifiers-re = [
+    "OLT",
+    "toi",
+    "isplay",
+    "BVE",
+    "olt",
+    "TRE",
+]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -66,8 +66,6 @@ enum PositionState {
 pub enum BuilderError {
     #[error("Builder position is not set")]
     UnsetPosition,
-    #[error("GEP error: does not point to a struct or index is out of bounds")]
-    GEPError,
     #[error("Alignment error")]
     AlignmentError(&'static str),
     #[error("Aggregate extract index out of range")]
@@ -1104,13 +1102,13 @@ impl<'ctx> Builder<'ctx> {
         let pointee_ty = ptr_ty.get_element_type();
 
         if !pointee_ty.is_struct_type() {
-            return Err(BuilderError::GEPError);
+            return Err(BuilderError::GEPPointee);
         }
 
         let struct_ty = pointee_ty.into_struct_type();
 
         if index >= struct_ty.count_fields() {
-            return Err(BuilderError::GEPError);
+            return Err(BuilderError::GEPIndex);
         }
 
         let c_string = to_c_str(name);


### PR DESCRIPTION
I added the `typos` utility to CI, and simplified the enum variants in the `BuilderError` from #436 .

## Description

I added the `typos` utility to CI (and an exclude file).

I also removed the `GEPError` as it did not make sense and the 2 others `GEPPointee` and `GEPIndex` fit better. The 2 lines which used `GEPError` have been replaced to use more the descriptive variants.

## Related Issue

This is related to #438.

It also resolves what @marcospb19 raised in #436.

## How This Has Been Tested

CI, including my new addition to it, is passing.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
