### PR TITLE
Added get_field_at_index and count_fields to struct values

### DIFF
--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -25,7 +25,7 @@ impl<'ctx> StructValue<'ctx> {
         }
     }
 
-    /// Gets the value of a field belonging to this `StructType`.
+    /// Gets the value of a field belonging to this `StructValue`.
     ///
     /// ```no_run
     /// use inkwell::context::Context;

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -1,4 +1,4 @@
-use llvm_sys::core::{LLVMGetNumOperands, LLVMGetOperand, LLVMIsConstant};
+use llvm_sys::core::{LLVMGetNumOperands, LLVMGetOperand};
 
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -44,9 +44,6 @@ impl<'ctx> StructValue<'ctx> {
     /// assert!(struct_val.get_field_at_index(0).unwrap().is_int_value());
     /// ```
     pub fn get_field_at_index(self, index: u32) -> Option<BasicValueEnum<'ctx>> {
-        if unsafe { LLVMIsConstant(self.as_value_ref()) } == 0 {
-            return None;
-        }
         // OoB indexing seems to be unchecked and therefore is UB
         if index >= self.count_fields() {
             return None;
@@ -122,4 +119,3 @@ impl Display for StructValue<'_> {
         write!(f, "{}", self.print_to_string())
     }
 }
-

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1184,6 +1184,34 @@ fn test_consts() {
     assert_eq!(f128_val.get_constant(), Some((7.8, false)));
     assert_eq!(ppc_f128_val.get_constant(), Some((9.0, false)));
 
+    //const struct member access
+    let struct_type = context.struct_type(&[i8_type.into(), i32_type.into()], false);
+    let struct_val = struct_type.const_named_struct(&[i8_val.into(), i32_val.into()]);
+
+    assert_eq!(struct_val.count_fields(), 2);
+    assert_eq!(struct_val.count_fields(), struct_type.count_fields());
+    assert!(struct_val.get_field_at_index(0).is_some());
+    assert!(struct_val.get_field_at_index(1).is_some());
+    assert!(struct_val.get_field_at_index(3).is_none());
+    assert!(struct_val.get_field_at_index(0).unwrap().is_int_value());
+    assert!(struct_val.get_field_at_index(1).unwrap().is_int_value());
+    assert_eq!(
+        struct_val
+            .get_field_at_index(0)
+            .unwrap()
+            .into_int_value()
+            .get_sign_extended_constant(),
+        Some(-1)
+    );
+    assert_eq!(
+        struct_val
+            .get_field_at_index(1)
+            .unwrap()
+            .into_int_value()
+            .get_sign_extended_constant(),
+        Some(-1)
+    );
+
     // Non const test
     let builder = context.create_builder();
     let module = context.create_module("fns");
@@ -1365,3 +1393,4 @@ fn test_constant_expression() {
     assert!(expr.is_const());
     assert!(!expr.is_constant_int());
 }
+


### PR DESCRIPTION
Added get_field_at_index and count_fields to StructValue.

## Description

This  mirrors the functions from StructType and allows accessing members of const structures directly.

## Related Issue

https://github.com/TheDan64/inkwell/issues/450

## How This Has Been Tested

Added a few simple assertions to the tests.
[test_values.rs](https://github.com/TimZF/inkwell/blob/00ccb05b34c906931586e174d57330425b559715/tests/all/test_values.rs#L1187)


## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
