### PR TITLE
Adding get_allocated_type, is_terminator and is_conditional to InstructionValue

### DIFF
--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -227,6 +227,16 @@ impl<'ctx> InstructionValue<'ctx> {
         unsafe { !LLVMIsATerminatorInst(self.as_value_ref()).is_null() }
     }
 
+    // SubTypes: Only apply to terminators
+    /// Returns whether a terminator is conditional or not
+    pub fn is_conditional(self) -> bool {
+        if self.is_terminator() {
+            unsafe { LLVMIsConditional(self.as_value_ref()) == 1 }
+        } else {
+            false
+        }
+    }
+
     pub fn is_tail_call(self) -> bool {
         // LLVMIsTailCall has UB if the value is not an llvm::CallInst*.
         if self.get_opcode() == InstructionOpcode::Call {

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -7,8 +7,8 @@ use llvm_sys::core::{
     LLVMGetInstructionParent, LLVMGetMetadata, LLVMGetNextInstruction, LLVMGetNumOperands, LLVMGetOperand,
     LLVMGetOperandUse, LLVMGetPreviousInstruction, LLVMGetVolatile, LLVMHasMetadata, LLVMInstructionClone,
     LLVMInstructionEraseFromParent, LLVMInstructionRemoveFromParent, LLVMIsAAllocaInst, LLVMIsABasicBlock,
-    LLVMIsALoadInst, LLVMIsAStoreInst, LLVMIsTailCall, LLVMSetAlignment, LLVMSetMetadata, LLVMSetOperand,
-    LLVMSetVolatile, LLVMValueAsBasicBlock,
+    LLVMIsALoadInst, LLVMIsAStoreInst, LLVMIsATerminatorInst, LLVMIsConditional, LLVMIsTailCall, LLVMSetAlignment,
+    LLVMSetMetadata, LLVMSetOperand, LLVMSetVolatile, LLVMValueAsBasicBlock,
 };
 use llvm_sys::core::{LLVMGetOrdering, LLVMSetOrdering};
 #[llvm_versions(10.0..=latest)]
@@ -221,6 +221,10 @@ impl<'ctx> InstructionValue<'ctx> {
     // parent?
     pub fn get_parent(self) -> Option<BasicBlock<'ctx>> {
         unsafe { BasicBlock::new(LLVMGetInstructionParent(self.as_value_ref())) }
+    }
+
+    pub fn is_terminator(self) -> bool {
+        unsafe { !LLVMIsATerminatorInst(self.as_value_ref()).is_null() }
     }
 
     pub fn is_tail_call(self) -> bool {

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -283,15 +283,6 @@ impl<'ctx> InstructionValue<'ctx> {
         Ok(())
     }
 
-    // SubTypes: Only apply to memory access and alloca instructions
-    /// Returns alignment on a memory access instruction or alloca.
-    pub fn get_alignment(self) -> Result<u32, &'static str> {
-        if !self.is_a_alloca_inst() && !self.is_a_load_inst() && !self.is_a_store_inst() {
-            return Err("Value is not an alloca, load or store.");
-        }
-        Ok(unsafe { LLVMGetAlignment(self.as_value_ref()) })
-    }
-
     // SubTypes: Only apply to alloca instruction
     /// Returns the type that is allocated by the alloca instruction.
     pub fn get_allocated_type(self) -> Result<AnyTypeEnum<'ctx>, &'static str> {
@@ -299,6 +290,15 @@ impl<'ctx> InstructionValue<'ctx> {
             return Err("Value is not an alloca.");
         }
         Ok(unsafe { AnyTypeEnum::new(LLVMGetAllocatedType(self.as_value_ref())) })
+    }
+
+    // SubTypes: Only apply to memory access and alloca instructions
+    /// Returns alignment on a memory access instruction or alloca.
+    pub fn get_alignment(self) -> Result<u32, &'static str> {
+        if !self.is_a_alloca_inst() && !self.is_a_load_inst() && !self.is_a_store_inst() {
+            return Err("Value is not an alloca, load or store.");
+        }
+        Ok(unsafe { LLVMGetAlignment(self.as_value_ref()) })
     }
 
     // SubTypes: Only apply to memory access and alloca instructions

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -223,12 +223,13 @@ impl<'ctx> InstructionValue<'ctx> {
         unsafe { BasicBlock::new(LLVMGetInstructionParent(self.as_value_ref())) }
     }
 
+    /// Returns if the instruction is a terminator
     pub fn is_terminator(self) -> bool {
         unsafe { !LLVMIsATerminatorInst(self.as_value_ref()).is_null() }
     }
 
     // SubTypes: Only apply to terminators
-    /// Returns whether a terminator is conditional or not
+    /// Returns if a terminator is conditional or not
     pub fn is_conditional(self) -> bool {
         if self.is_terminator() {
             unsafe { LLVMIsConditional(self.as_value_ref()) == 1 }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -3,11 +3,12 @@ use either::{
     Either::{Left, Right},
 };
 use llvm_sys::core::{
-    LLVMGetAlignment, LLVMGetFCmpPredicate, LLVMGetICmpPredicate, LLVMGetInstructionOpcode, LLVMGetInstructionParent,
-    LLVMGetMetadata, LLVMGetNextInstruction, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse,
-    LLVMGetPreviousInstruction, LLVMGetVolatile, LLVMHasMetadata, LLVMInstructionClone, LLVMInstructionEraseFromParent,
-    LLVMInstructionRemoveFromParent, LLVMIsAAllocaInst, LLVMIsABasicBlock, LLVMIsALoadInst, LLVMIsAStoreInst,
-    LLVMIsTailCall, LLVMSetAlignment, LLVMSetMetadata, LLVMSetOperand, LLVMSetVolatile, LLVMValueAsBasicBlock,
+    LLVMGetAlignment, LLVMGetAllocatedType, LLVMGetFCmpPredicate, LLVMGetICmpPredicate, LLVMGetInstructionOpcode,
+    LLVMGetInstructionParent, LLVMGetMetadata, LLVMGetNextInstruction, LLVMGetNumOperands, LLVMGetOperand,
+    LLVMGetOperandUse, LLVMGetPreviousInstruction, LLVMGetVolatile, LLVMHasMetadata, LLVMInstructionClone,
+    LLVMInstructionEraseFromParent, LLVMInstructionRemoveFromParent, LLVMIsAAllocaInst, LLVMIsABasicBlock,
+    LLVMIsALoadInst, LLVMIsAStoreInst, LLVMIsTailCall, LLVMSetAlignment, LLVMSetMetadata, LLVMSetOperand,
+    LLVMSetVolatile, LLVMValueAsBasicBlock,
 };
 use llvm_sys::core::{LLVMGetOrdering, LLVMSetOrdering};
 #[llvm_versions(10.0..=latest)]
@@ -289,6 +290,15 @@ impl<'ctx> InstructionValue<'ctx> {
             return Err("Value is not an alloca, load or store.");
         }
         Ok(unsafe { LLVMGetAlignment(self.as_value_ref()) })
+    }
+
+    // SubTypes: Only apply to alloca instruction
+    /// Returns the type that is allocated by the alloca instruction.
+    pub fn get_allocated_type(self) -> Result<AnyTypeEnum<'ctx>, &'static str> {
+        if !self.is_a_alloca_inst() {
+            return Err("Value is not an alloca.");
+        }
+        Ok(unsafe { AnyTypeEnum::new(LLVMGetAllocatedType(self.as_value_ref())) })
     }
 
     // SubTypes: Only apply to memory access and alloca instructions

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -18,9 +18,9 @@ use llvm_sys::LLVMOpcode;
 
 use std::{ffi::CStr, fmt, fmt::Display};
 
-use crate::values::traits::AsValueRef;
 use crate::values::{BasicValue, BasicValueEnum, BasicValueUse, MetadataValue, Value};
 use crate::{basic_block::BasicBlock, types::AnyTypeEnum};
+use crate::{types::BasicTypeEnum, values::traits::AsValueRef};
 use crate::{AtomicOrdering, FloatPredicate, IntPredicate};
 
 use super::AnyValue;
@@ -300,11 +300,11 @@ impl<'ctx> InstructionValue<'ctx> {
 
     // SubTypes: Only apply to alloca instruction
     /// Returns the type that is allocated by the alloca instruction.
-    pub fn get_allocated_type(self) -> Result<AnyTypeEnum<'ctx>, &'static str> {
+    pub fn get_allocated_type(self) -> Result<BasicTypeEnum<'ctx>, &'static str> {
         if !self.is_a_alloca_inst() {
             return Err("Value is not an alloca.");
         }
-        Ok(unsafe { AnyTypeEnum::new(LLVMGetAllocatedType(self.as_value_ref())) })
+        Ok(unsafe { BasicTypeEnum::new(LLVMGetAllocatedType(self.as_value_ref())) })
     }
 
     // SubTypes: Only apply to memory access and alloca instructions

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -1,5 +1,5 @@
 use inkwell::context::Context;
-use inkwell::types::AnyTypeEnum;
+use inkwell::types::{AnyType, AnyTypeEnum, AsTypeRef};
 use inkwell::values::{BasicValue, InstructionOpcode::*};
 use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
 
@@ -239,6 +239,7 @@ fn test_instructions() {
     let f32_val = f32_type.const_float(::std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
+    let alloca_instruction = builder.build_alloca(i64_type, "alloca").unwrap();
     let ptr_val = builder.build_ptr_to_int(arg1, i64_type, "ptr_val").unwrap();
     let ptr = builder.build_int_to_ptr(ptr_val, f32_ptr_type, "ptr").unwrap();
     let icmp = builder.build_int_compare(IntPredicate::EQ, arg1, arg1, "icmp").unwrap();
@@ -249,6 +250,11 @@ fn test_instructions() {
     let free_instruction = builder.build_free(arg1).unwrap();
     let return_instruction = builder.build_return(None).unwrap();
 
+    assert_eq!(
+        alloca_instruction.as_instruction().unwrap().get_allocated_type(),
+        Ok(i64_type.as_any_type_enum())
+    );
+    assert!(store_instruction.get_allocated_type().is_err());
     assert_eq!(store_instruction.get_opcode(), Store);
     assert_eq!(ptr_val.as_instruction().unwrap().get_opcode(), PtrToInt);
     assert_eq!(ptr.as_instruction().unwrap().get_opcode(), IntToPtr);

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -249,6 +249,9 @@ fn test_instructions() {
         .unwrap();
     let free_instruction = builder.build_free(arg1).unwrap();
     let return_instruction = builder.build_return(None).unwrap();
+    let cond_br_instruction = builder
+        .build_conditional_branch(i64_type.const_zero(), basic_block, basic_block)
+        .unwrap();
 
     assert_eq!(
         alloca_val.as_instruction().unwrap().get_allocated_type(),
@@ -257,6 +260,9 @@ fn test_instructions() {
     assert!(store_instruction.get_allocated_type().is_err());
     assert!(!store_instruction.is_terminator());
     assert!(return_instruction.is_terminator());
+    assert!(!store_instruction.is_conditional());
+    assert!(!return_instruction.is_conditional());
+    assert!(cond_br_instruction.is_conditional());
     assert_eq!(store_instruction.get_opcode(), Store);
     assert_eq!(ptr_val.as_instruction().unwrap().get_opcode(), PtrToInt);
     assert_eq!(ptr.as_instruction().unwrap().get_opcode(), IntToPtr);

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -239,7 +239,7 @@ fn test_instructions() {
     let f32_val = f32_type.const_float(::std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
-    let alloca_instruction = builder.build_alloca(i64_type, "alloca").unwrap();
+    let alloca_val = builder.build_alloca(i64_type, "alloca").unwrap();
     let ptr_val = builder.build_ptr_to_int(arg1, i64_type, "ptr_val").unwrap();
     let ptr = builder.build_int_to_ptr(ptr_val, f32_ptr_type, "ptr").unwrap();
     let icmp = builder.build_int_compare(IntPredicate::EQ, arg1, arg1, "icmp").unwrap();
@@ -251,7 +251,7 @@ fn test_instructions() {
     let return_instruction = builder.build_return(None).unwrap();
 
     assert_eq!(
-        alloca_instruction.as_instruction().unwrap().get_allocated_type(),
+        alloca_val.as_instruction().unwrap().get_allocated_type(),
         Ok(i64_type.as_any_type_enum())
     );
     assert!(store_instruction.get_allocated_type().is_err());

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -1,5 +1,5 @@
 use inkwell::context::Context;
-use inkwell::types::{AnyType, AnyTypeEnum, AsTypeRef};
+use inkwell::types::{AnyTypeEnum, AsTypeRef, BasicType};
 use inkwell::values::{BasicValue, InstructionOpcode::*};
 use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
 
@@ -255,7 +255,7 @@ fn test_instructions() {
 
     assert_eq!(
         alloca_val.as_instruction().unwrap().get_allocated_type(),
-        Ok(i64_type.as_any_type_enum())
+        Ok(i64_type.as_basic_type_enum())
     );
     assert!(store_instruction.get_allocated_type().is_err());
     assert!(!store_instruction.is_terminator());

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -255,6 +255,8 @@ fn test_instructions() {
         Ok(i64_type.as_any_type_enum())
     );
     assert!(store_instruction.get_allocated_type().is_err());
+    assert!(!store_instruction.is_terminator());
+    assert!(return_instruction.is_terminator());
     assert_eq!(store_instruction.get_opcode(), Store);
     assert_eq!(ptr_val.as_instruction().unwrap().get_opcode(), PtrToInt);
     assert_eq!(ptr.as_instruction().unwrap().get_opcode(), IntToPtr);


### PR DESCRIPTION
Adding the 3 Functions and the corresponding tests.

## Description
-

## Related Issue

https://github.com/TheDan64/inkwell/issues/454

## How This Has Been Tested

Only tested on LLVM-16 

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
