### PR TITLE
Expose some LLVMValueRef constructors

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -173,7 +173,12 @@ pub struct Module<'ctx> {
 }
 
 impl<'ctx> Module<'ctx> {
-    pub(crate) unsafe fn new(module: LLVMModuleRef) -> Self {
+    /// Get a module from an [LLVMModuleRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid.
+    pub unsafe fn new(module: LLVMModuleRef) -> Self {
         debug_assert!(!module.is_null());
 
         Module {

--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -15,7 +15,12 @@ pub struct ArrayValue<'ctx> {
 }
 
 impl<'ctx> ArrayValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type array.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         ArrayValue {

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -15,7 +15,12 @@ use crate::values::{AnyValueEnum, BasicValueEnum};
 pub struct BasicValueUse<'ctx>(LLVMUseRef, PhantomData<&'ctx ()>);
 
 impl<'ctx> BasicValueUse<'ctx> {
-    pub(crate) unsafe fn new(use_: LLVMUseRef) -> Self {
+    /// Get a value from an [LLVMUseRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type basic value.
+    pub unsafe fn new(use_: LLVMUseRef) -> Self {
         debug_assert!(!use_.is_null());
 
         BasicValueUse(use_, PhantomData)

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -20,7 +20,12 @@ use super::AnyValue;
 pub struct CallSiteValue<'ctx>(Value<'ctx>);
 
 impl<'ctx> CallSiteValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type call site.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         CallSiteValue(Value::new(value))
     }
 

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -23,7 +23,12 @@ pub struct FloatValue<'ctx> {
 }
 
 impl<'ctx> FloatValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type float.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         FloatValue {

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -35,7 +35,12 @@ pub struct FunctionValue<'ctx> {
 }
 
 impl<'ctx> FunctionValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Option<Self> {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type function.
+    pub unsafe fn new(value: LLVMValueRef) -> Option<Self> {
         if value.is_null() {
             return None;
         }

--- a/src/values/global_value.rs
+++ b/src/values/global_value.rs
@@ -47,7 +47,12 @@ pub struct GlobalValue<'ctx> {
 }
 
 impl<'ctx> GlobalValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type global.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         GlobalValue {

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -130,7 +130,12 @@ impl<'ctx> InstructionValue<'ctx> {
         !unsafe { LLVMIsAAtomicCmpXchgInst(self.as_value_ref()) }.is_null()
     }
 
-    pub(crate) unsafe fn new(instruction_value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type instruction.
+    pub unsafe fn new(instruction_value: LLVMValueRef) -> Self {
         debug_assert!(!instruction_value.is_null());
 
         let value = Value::new(instruction_value);

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -29,7 +29,12 @@ pub struct IntValue<'ctx> {
 }
 
 impl<'ctx> IntValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type int.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         IntValue {

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -45,7 +45,12 @@ pub struct MetadataValue<'ctx> {
 }
 
 impl<'ctx> MetadataValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type metadata.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
         assert!(!LLVMIsAMDNode(value).is_null() || !LLVMIsAMDString(value).is_null());
 

--- a/src/values/phi_value.rs
+++ b/src/values/phi_value.rs
@@ -20,7 +20,12 @@ pub struct PhiValue<'ctx> {
 }
 
 impl<'ctx> PhiValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type phi.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         PhiValue {

--- a/src/values/ptr_value.rs
+++ b/src/values/ptr_value.rs
@@ -21,7 +21,12 @@ pub struct PointerValue<'ctx> {
 }
 
 impl<'ctx> PointerValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type pointer.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         PointerValue {

--- a/src/values/struct_value.rs
+++ b/src/values/struct_value.rs
@@ -17,7 +17,12 @@ pub struct StructValue<'ctx> {
 }
 
 impl<'ctx> StructValue<'ctx> {
-    pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type struct.
+    pub unsafe fn new(value: LLVMValueRef) -> Self {
         assert!(!value.is_null());
 
         StructValue {

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -21,7 +21,12 @@ pub struct VectorValue<'ctx> {
 }
 
 impl<'ctx> VectorValue<'ctx> {
-    pub(crate) unsafe fn new(vector_value: LLVMValueRef) -> Self {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type vector.
+    pub unsafe fn new(vector_value: LLVMValueRef) -> Self {
         assert!(!vector_value.is_null());
 
         VectorValue {


### PR DESCRIPTION
I only did some of them so llvm-plugin can move off its fork. Example use:
https://github.com/jamesmth/llvm-plugin-rs/blob/7fe29ca68b70538321ba63afc0dd5fc856809488/llvm-plugin/src/analysis.rs#L116