### PR TITLE
ci: build kaleidoscope in ci and revise example docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
         run: cargo build --release --features llvm${{ matrix.llvm-version[1] }} --verbose
       - name: Run tests
         run: cargo test --release --features llvm${{ matrix.llvm-version[1] }} --verbose
+      - name: Build example
+        run: cargo build --example kaleidoscope --features llvm${{ matrix.llvm-version[1] }} --verbose
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/examples/kaleidoscope/README.md
+++ b/examples/kaleidoscope/README.md
@@ -3,7 +3,14 @@
 This example shows how one can implement the [Kaleidoscope programming language](https://llvm.org/docs/tutorial/index.html) using Inkwell.  
 It implements every feature up to the [7th chapter](https://llvm.org/docs/tutorial/LangImpl07.html).
 
-When running this example (using the `cargo run --example kaleidoscope` command), a prompt will be displayed; for example:
+The [usage](../../README.md#usage) part doesn't fit the example as it shares the same `Cargo.toml` file with the whole project.
+
+To run the example, the LLVM version is required:
+```sh
+cargo run --example kaleidoscope --features llvm$(llvm-config  --version | sed 's/\./-/;s/\.[0-9]*//')
+```
+
+When running this command, a prompt will be displayed; for example:
 
 ```
 ?> 1 + 1


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

The command provided to run example is not valid in my desktop even though I installed the llvm already:
```sh
$ uname -a
Darwin GF9534F26Q 21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:41 PST 2021; 
root:xnu-8019.61.5~1/RELEASE_ARM64_T6000 arm64

$ llvm-config  --version
16.0.6
```

A part of error log is shown below:
```
➜  inkwell git:(improve/revise-example-guides) cargo run --example kaleidoscope        
   Compiling inkwell v0.2.0 (/Users/yuchen.xie/workspace/rust/inkwell)
error: One of the LLVM feature flags must be provided: llvm4-0 llvm5-0 llvm6-0 llvm7-0 llvm8-0 llvm9-0 llvm10-0 llvm11-0 llvm12-0 llvm13-0 llvm14-0 llvm15-0 llvm16-0 llvm17-0 
   --> src/lib.rs:101:9
    |
101 |           compile_error!(concat!("One of the LLVM feature flags must be provided: ", $($all, " "),*));
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
112 | / assert_unique_used_features! {
113 | |     "llvm4-0",
114 | |     "llvm5-0",
115 | |     "llvm6-0",
...   |
126 | |     "llvm17-0"
127 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `assert_used_features` which comes from the expansion of the macro `assert_unique_used_features` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## Description

The readme should provide a command which could run the demo directly without any additional exploring. Hence, I changed the readme to cargo run with the llvm version.

Moreover, I change the ci configuration to check build example as well.


- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
