### PR TITLE
Add serde derives for some config datastructures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
 once_cell = "1.16"
 static-alloc = { version = "0.2", optional = true }
 thiserror = "1.0.48"
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ use llvm_sys::{
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMInlineAsmDialect;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 // Thanks to kennytm for coming up with assert_unique_features!
@@ -383,6 +385,7 @@ pub enum AtomicRMWBinOp {
 /// See also: https://llvm.org/doxygen/CodeGen_8h_source.html
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OptimizationLevel {
     None = 0,
     Less = 1,
@@ -399,6 +402,7 @@ impl Default for OptimizationLevel {
 
 #[llvm_enum(LLVMVisibility)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GlobalVisibility {
     #[llvm_variant(LLVMDefaultVisibility)]
     Default,
@@ -416,6 +420,7 @@ impl Default for GlobalVisibility {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ThreadLocalMode {
     GeneralDynamicTLSModel,
     LocalDynamicTLSModel,
@@ -447,6 +452,7 @@ impl ThreadLocalMode {
 
 #[llvm_enum(LLVMDLLStorageClass)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DLLStorageClass {
     #[llvm_variant(LLVMDefaultStorageClass)]
     Default,
@@ -466,6 +472,7 @@ impl Default for DLLStorageClass {
 #[llvm_versions(7.0..=latest)]
 #[llvm_enum(LLVMInlineAsmDialect)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum InlineAsmDialect {
     #[llvm_variant(LLVMInlineAsmDialectATT)]
     ATT,


### PR DESCRIPTION
## Description

Add serde derives for some config datastructures. Otherwise they can not be reused when deriving the compilers configuration (or it has to be implemented manually).

Hidden behind `serde` feature flag so it should be pretty non-invasive.

## Related Issue

## How This Has Been Tested

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
