### PR TITLE
WIP: Support LLVM 18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ llvm14-0 = ["llvm-sys-140"]
 llvm15-0 = ["llvm-sys-150"]
 llvm16-0 = ["llvm-sys-160"]
 llvm17-0 = ["llvm-sys-170"]
+llvm18-0 = ["llvm-sys-180"]
 # Don't link against LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
 # `no-llvm-linking` feature across the board of llvm versions, as it'll cause
@@ -47,6 +48,7 @@ llvm14-0-no-llvm-linking = ["llvm14-0", "llvm-sys-140/no-llvm-linking"]
 llvm15-0-no-llvm-linking = ["llvm15-0", "llvm-sys-150/no-llvm-linking"]
 llvm16-0-no-llvm-linking = ["llvm16-0", "llvm-sys-160/no-llvm-linking"]
 llvm17-0-no-llvm-linking = ["llvm17-0", "llvm-sys-170/no-llvm-linking"]
+llvm18-0-no-llvm-linking = ["llvm18-0", "llvm-sys-180/no-llvm-linking"]
 
 # Linking preference.
 # If none of these are enabled, it defaults to force static linking.
@@ -58,6 +60,7 @@ llvm14-0-force-dynamic = ["llvm14-0", "llvm-sys-140/force-dynamic"]
 llvm15-0-force-dynamic = ["llvm15-0", "llvm-sys-150/force-dynamic"]
 llvm16-0-force-dynamic = ["llvm16-0", "llvm-sys-160/force-dynamic"]
 llvm17-0-force-dynamic = ["llvm17-0", "llvm-sys-170/force-dynamic"]
+llvm18-0-force-dynamic = ["llvm18-0", "llvm-sys-180/force-dynamic"]
 
 # Prefer dynamic linking against LLVM libraries. See llvm-sys for more details
 llvm12-0-prefer-dynamic = ["llvm12-0", "llvm-sys-120/prefer-dynamic"]
@@ -66,6 +69,7 @@ llvm14-0-prefer-dynamic = ["llvm14-0", "llvm-sys-140/prefer-dynamic"]
 llvm15-0-prefer-dynamic = ["llvm15-0", "llvm-sys-150/prefer-dynamic"]
 llvm16-0-prefer-dynamic = ["llvm16-0", "llvm-sys-160/prefer-dynamic"]
 llvm17-0-prefer-dynamic = ["llvm17-0", "llvm-sys-170/prefer-dynamic"]
+llvm18-0-prefer-dynamic = ["llvm18-0", "llvm-sys-180/prefer-dynamic"]
 
 # Force static linking against LLVM libraries. See llvm-sys for more details
 llvm12-0-force-static = ["llvm12-0", "llvm-sys-120/force-static"]
@@ -74,6 +78,7 @@ llvm14-0-force-static = ["llvm14-0", "llvm-sys-140/force-static"]
 llvm15-0-force-static = ["llvm15-0", "llvm-sys-150/force-static"]
 llvm16-0-force-static = ["llvm16-0", "llvm-sys-160/force-static"]
 llvm17-0-force-static = ["llvm17-0", "llvm-sys-170/force-static"]
+llvm18-0-force-static = ["llvm18-0", "llvm-sys-180/force-static"]
 
 # Prefer static linking against LLVM libraries. See llvm-sys for more details
 llvm12-0-prefer-static = ["llvm12-0", "llvm-sys-120/prefer-static"]
@@ -82,6 +87,7 @@ llvm14-0-prefer-static = ["llvm14-0", "llvm-sys-140/prefer-static"]
 llvm15-0-prefer-static = ["llvm15-0", "llvm-sys-150/prefer-static"]
 llvm16-0-prefer-static = ["llvm16-0", "llvm-sys-160/prefer-static"]
 llvm17-0-prefer-static = ["llvm17-0", "llvm-sys-170/prefer-static"]
+llvm18-0-prefer-static = ["llvm18-0", "llvm-sys-180/prefer-static"]
 
 # Don't force linking to libffi on non-windows platforms. Without this feature
 # inkwell always links to libffi on non-windows platforms.
@@ -144,6 +150,7 @@ llvm-sys-140 = { package = "llvm-sys", version = "140.0.2", optional = true }
 llvm-sys-150 = { package = "llvm-sys", version = "150.0.3", optional = true }
 llvm-sys-160 = { package = "llvm-sys", version = "160.1.0", optional = true }
 llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
+llvm-sys-180 = { package = "llvm-sys", git = "https://gitlab.com/taricorp/llvm-sys.rs.git", optional = true }
 once_cell = "1.16"
 static-alloc = { version = "0.2", optional = true }
 thiserror = "1.0.48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
 once_cell = "1.16"
 static-alloc = { version = "0.2", optional = true }
 thiserror = "1.0.48"
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ llvm-sys-140 = { package = "llvm-sys", version = "140.0.2", optional = true }
 llvm-sys-150 = { package = "llvm-sys", version = "150.0.3", optional = true }
 llvm-sys-160 = { package = "llvm-sys", version = "160.1.0", optional = true }
 llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
-llvm-sys-180 = { package = "llvm-sys", git = "https://gitlab.com/taricorp/llvm-sys.rs.git", optional = true }
+llvm-sys-180 = { package = "llvm-sys", version = "180.0.0", optional = true }
 once_cell = "1.16"
 static-alloc = { version = "0.2", optional = true }
 thiserror = "1.0.48"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inkwell aims to help you pen your own programming languages by safely wrapping l
 ## Requirements
 
 * Rust 1.56+ (Stable, Beta, or Nightly)
-* One of LLVM 4-17
+* One of LLVM 4-18
 
 ## Usage
 
@@ -22,11 +22,11 @@ You'll need to point your Cargo.toml to use a single LLVM version feature flag c
 
 ```toml
 [dependencies]
-inkwell = { version = "0.4.0", features = ["llvm17-0"] }
+inkwell = { version = "0.4.0", features = ["llvm18-0"] }
 ```
 
 Supported versions:
-LLVM 4-17 mapping to a cargo feature flag `llvmM-0` where `M` corresponds to the LLVM major version.
+LLVM 4-18 mapping to a cargo feature flag `llvmM-0` where `M` corresponds to the LLVM major version.
 
 Please be aware that we may make breaking changes on master from time to time since we are
 pre-v1.0.0, in compliance with semver. Please prefer a crates.io release whenever possible!

--- a/internal_macros/src/lib.rs
+++ b/internal_macros/src/lib.rs
@@ -12,9 +12,9 @@ use syn::{parse_macro_input, parse_quote};
 use syn::{Attribute, Field, Ident, Item, LitFloat, Token, Variant};
 
 // This array should match the LLVM features in the top level Cargo manifest
-const FEATURE_VERSIONS: [&str; 14] = [
+const FEATURE_VERSIONS: [&str; 15] = [
     "llvm4-0", "llvm5-0", "llvm6-0", "llvm7-0", "llvm8-0", "llvm9-0", "llvm10-0", "llvm11-0", "llvm12-0", "llvm13-0",
-    "llvm14-0", "llvm15-0", "llvm16-0", "llvm17-0",
+    "llvm14-0", "llvm15-0", "llvm16-0", "llvm17-0", "llvm18-0",
 ];
 
 /// Gets the index of the feature version that represents `latest`

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2738,7 +2738,7 @@ impl<'ctx> Builder<'ctx> {
     ///     feature = "llvm14-0"
     /// ))]
     /// let array = builder.build_load(array_alloca, "array_load").unwrap().into_array_value();
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
     /// let array = builder.build_load(i32_type, array_alloca, "array_load").unwrap().into_array_value();
     ///
     /// let const_int1 = i32_type.const_int(2, false);
@@ -2821,7 +2821,7 @@ impl<'ctx> Builder<'ctx> {
     ///     feature = "llvm14-0"
     /// ))]
     /// let array = builder.build_load(array_alloca, "array_load").unwrap().into_array_value();
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
     /// let array = builder.build_load(i32_type, array_alloca, "array_load").unwrap().into_array_value();
     ///
     /// let const_int1 = i32_type.const_int(2, false);
@@ -3256,7 +3256,12 @@ impl<'ctx> Builder<'ctx> {
             ));
         }
 
-        #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0")))]
+        #[cfg(not(any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        )))]
         if ptr.get_type().get_element_type() != value.get_type().into() {
             return Err(BuilderError::PointeeTypeMismatch(
                 "Pointer's pointee type must match the value's type.",
@@ -3334,7 +3339,12 @@ impl<'ctx> Builder<'ctx> {
             ));
         }
 
-        #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0")))]
+        #[cfg(not(any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        )))]
         if ptr.get_type().get_element_type().to_basic_type_enum() != cmp.get_type() {
             return Err(BuilderError::PointeeTypeMismatch(
                 "The pointer does not point to an element of the value type.",

--- a/src/context.rs
+++ b/src/context.rs
@@ -569,7 +569,7 @@ impl Context {
     ///     builder.build_call(callable_value, params, "exit").unwrap();
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit").unwrap();
     ///
     /// builder.build_return(None).unwrap();
@@ -1417,7 +1417,7 @@ impl<'ctx> ContextRef<'ctx> {
     ///     builder.build_call(callable_value, params, "exit").unwrap();
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit").unwrap();
     ///
     /// builder.build_return(None).unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -1417,7 +1417,7 @@ impl<'ctx> ContextRef<'ctx> {
     ///     builder.build_call(callable_value, params, "exit").unwrap();
     /// }
     ///
-    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-1"))]
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
     /// builder.build_indirect_call(asm_fn, asm, params, "exit").unwrap();
     ///
     /// builder.build_return(None).unwrap();

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -193,7 +193,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -203,7 +204,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         sdk: &str,
     ) -> (Self, DICompileUnit<'ctx>) {
@@ -241,7 +243,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             sysroot,
             #[cfg(any(
@@ -251,7 +254,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             sdk,
         );
@@ -297,7 +301,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -307,7 +312,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         sdk: &str,
     ) -> DICompileUnit<'ctx> {
@@ -348,7 +354,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             {
                 LLVMDIBuilderCreateCompileUnit(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub extern crate llvm_sys_80 as llvm_sys;
 #[cfg(feature = "llvm9-0")]
 pub extern crate llvm_sys_90 as llvm_sys;
 
+use llvm_sys::target_machine::LLVMCodeGenOptLevel;
 use llvm_sys::{
     LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMDLLStorageClass, LLVMIntPredicate, LLVMRealPredicate,
     LLVMThreadLocalMode, LLVMVisibility,
@@ -400,6 +401,17 @@ impl Default for OptimizationLevel {
     /// Returns the default value for `OptimizationLevel`, namely `OptimizationLevel::Default`.
     fn default() -> Self {
         OptimizationLevel::Default
+    }
+}
+
+impl From<OptimizationLevel> for LLVMCodeGenOptLevel {
+    fn from(value: OptimizationLevel) -> Self {
+        match value {
+            OptimizationLevel::None => LLVMCodeGenOptLevel::LLVMCodeGenLevelNone,
+            OptimizationLevel::Less => LLVMCodeGenOptLevel::LLVMCodeGenLevelLess,
+            OptimizationLevel::Default => LLVMCodeGenOptLevel::LLVMCodeGenLevelDefault,
+            OptimizationLevel::Aggressive => LLVMCodeGenOptLevel::LLVMCodeGenLevelAggressive,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ pub extern crate llvm_sys_150 as llvm_sys;
 pub extern crate llvm_sys_160 as llvm_sys;
 #[cfg(feature = "llvm17-0")]
 pub extern crate llvm_sys_170 as llvm_sys;
+#[cfg(feature = "llvm18-0")]
+pub extern crate llvm_sys_180 as llvm_sys;
 #[cfg(feature = "llvm4-0")]
 pub extern crate llvm_sys_40 as llvm_sys;
 #[cfg(feature = "llvm5-0")]
@@ -125,7 +127,8 @@ assert_unique_used_features! {
     "llvm14-0",
     "llvm15-0",
     "llvm16-0",
-    "llvm17-0"
+    "llvm17-0",
+    "llvm18-0"
 }
 
 /// Defines the address space in which a global will be inserted.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ use llvm_sys::{
 #[llvm_versions(7.0..=latest)]
 use llvm_sys::LLVMInlineAsmDialect;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 // Thanks to kennytm for coming up with assert_unique_features!
@@ -383,6 +385,7 @@ pub enum AtomicRMWBinOp {
 /// See also: https://llvm.org/doxygen/CodeGen_8h_source.html
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OptimizationLevel {
     None = 0,
     Less = 1,
@@ -399,6 +402,7 @@ impl Default for OptimizationLevel {
 
 #[llvm_enum(LLVMVisibility)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GlobalVisibility {
     #[llvm_variant(LLVMDefaultVisibility)]
     Default,
@@ -416,6 +420,7 @@ impl Default for GlobalVisibility {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ThreadLocalMode {
     GeneralDynamicTLSModel,
     LocalDynamicTLSModel,
@@ -447,6 +452,7 @@ impl ThreadLocalMode {
 
 #[llvm_enum(LLVMDLLStorageClass)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DLLStorageClass {
     #[llvm_variant(LLVMDefaultStorageClass)]
     Default,
@@ -466,6 +472,7 @@ impl Default for DLLStorageClass {
 #[llvm_versions(7.0..=latest)]
 #[llvm_enum(LLVMInlineAsmDialect)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum InlineAsmDialect {
     #[llvm_variant(LLVMInlineAsmDialectATT)]
     ATT,

--- a/src/module.rs
+++ b/src/module.rs
@@ -1431,7 +1431,8 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         sysroot: &str,
         #[cfg(any(
@@ -1441,7 +1442,8 @@ impl<'ctx> Module<'ctx> {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         sdk: &str,
     ) -> (DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>) {
@@ -1467,7 +1469,8 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             sysroot,
             #[cfg(any(
@@ -1477,7 +1480,8 @@ impl<'ctx> Module<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             sdk,
         )

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -223,7 +223,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => AnyTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMLabelTypeKind => panic!("FIXME: Unsupported type: Label"),
@@ -240,7 +241,8 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
             // FIXME: should inkwell support metadata as AnyType?
@@ -252,11 +254,12 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => panic!("FIXME: Unsupported type: AMX"),
             LLVMTypeKind::LLVMTokenTypeKind => panic!("FIXME: Unsupported type: Token"),
-            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0"))]
+            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
             LLVMTypeKind::LLVMTargetExtTypeKind => panic!("FIXME: Unsupported type: TargetExt"),
         }
     }
@@ -410,7 +413,8 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             LLVMTypeKind::LLVMBFloatTypeKind => BasicTypeEnum::FloatType(FloatType::new(type_)),
             LLVMTypeKind::LLVMIntegerTypeKind => BasicTypeEnum::IntType(IntType::new(type_)),
@@ -425,7 +429,8 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Unsupported basic type: Metadata"),
@@ -438,14 +443,15 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm14-0",
                 feature = "llvm15-0",
                 feature = "llvm16-0",
-                feature = "llvm17-0"
+                feature = "llvm17-0",
+                feature = "llvm18-0"
             ))]
             LLVMTypeKind::LLVMX86_AMXTypeKind => unreachable!("Unsupported basic type: AMX"),
             LLVMTypeKind::LLVMLabelTypeKind => unreachable!("Unsupported basic type: Label"),
             LLVMTypeKind::LLVMVoidTypeKind => unreachable!("Unsupported basic type: VoidType"),
             LLVMTypeKind::LLVMFunctionTypeKind => unreachable!("Unsupported basic type: FunctionType"),
             LLVMTypeKind::LLVMTokenTypeKind => unreachable!("Unsupported basic type: Token"),
-            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0"))]
+            #[cfg(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
             LLVMTypeKind::LLVMTargetExtTypeKind => unreachable!("Unsupported basic type: TargetExt"),
         }
     }

--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -8,8 +8,6 @@ use llvm_sys::core::{
 #[llvm_versions(18.0..=latest)]
 use llvm_sys::core::{LLVMGetTailCallKind, LLVMSetTailCallKind};
 use llvm_sys::prelude::LLVMValueRef;
-#[llvm_versions(18.0..=latest)]
-use llvm_sys::LLVMTailCallKind;
 use llvm_sys::LLVMTypeKind;
 
 use crate::attributes::{Attribute, AttributeLoc};
@@ -90,6 +88,8 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// # Example
     ///
     /// ```no_run
+    /// use inkwell::values::LLVMTailCallKind::*;
+    ///
     /// let context = inkwell::context::Context::create();
     /// let builder = context.create_builder();
     /// let module = context.create_module("my_mod");
@@ -102,10 +102,10 @@ impl<'ctx> CallSiteValue<'ctx> {
     ///
     /// let call_site = builder.build_call(fn_value, &[], "my_fn").unwrap();
     ///
-    /// assert_eq!(call_site.get_tail_call_kind(), llvm_sys::LLVMTailCallKind::LLVMTailCallKindNone);
+    /// assert_eq!(call_site.get_tail_call_kind(), LLVMTailCallKindNone);
     /// ```
     #[llvm_versions(18.0..=latest)]
-    pub fn get_tail_call_kind(self) -> LLVMTailCallKind {
+    pub fn get_tail_call_kind(self) -> super::LLVMTailCallKind {
         unsafe { LLVMGetTailCallKind(self.as_value_ref()) }
     }
 
@@ -114,6 +114,8 @@ impl<'ctx> CallSiteValue<'ctx> {
     /// # Example
     ///
     /// ```no_run
+    /// use inkwell::values::LLVMTailCallKind::*;
+    ///
     /// let context = inkwell::context::Context::create();
     /// let builder = context.create_builder();
     /// let module = context.create_module("my_mod");
@@ -126,11 +128,11 @@ impl<'ctx> CallSiteValue<'ctx> {
     ///
     /// let call_site = builder.build_call(fn_value, &[], "my_fn").unwrap();
     ///
-    /// call_site.set_tail_call_kind(llvm_sys::LLVMTailCallKind::LLVMTailCallKindTail);
-    /// assert_eq!(call_site.get_tail_call_kind(), llvm_sys::LLVMTailCallKind::LLVMTailCallKindTail);
+    /// call_site.set_tail_call_kind(LLVMTailCallKindTail);
+    /// assert_eq!(call_site.get_tail_call_kind(), LLVMTailCallKindTail);
     /// ```
     #[llvm_versions(18.0..=latest)]
-    pub fn set_tail_call_kind(self, kind: LLVMTailCallKind) {
+    pub fn set_tail_call_kind(self, kind: super::LLVMTailCallKind) {
         unsafe { LLVMSetTailCallKind(self.as_value_ref(), kind) };
     }
 

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -1,16 +1,17 @@
+#[llvm_versions(4.0..=17.0)]
+use crate::types::IntType;
 #[llvm_versions(4.0..=15.0)]
 use llvm_sys::core::LLVMConstFNeg;
-use llvm_sys::core::{
-    LLVMConstFCmp, LLVMConstFPCast, LLVMConstFPExt, LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc,
-    LLVMConstRealGetDouble,
-};
+use llvm_sys::core::{LLVMConstFCmp, LLVMConstRealGetDouble};
+#[llvm_versions(4.0..=17.0)]
+use llvm_sys::core::{LLVMConstFPCast, LLVMConstFPExt, LLVMConstFPToSI, LLVMConstFPToUI, LLVMConstFPTrunc};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::types::{AsTypeRef, FloatType, IntType};
+use crate::types::{AsTypeRef, FloatType};
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value};
 use crate::FloatPredicate;
@@ -107,22 +108,27 @@ impl<'ctx> FloatValue<'ctx> {
         unsafe { FloatValue::new(LLVMConstFRem(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_cast(self, float_type: FloatType<'ctx>) -> Self {
         unsafe { FloatValue::new(LLVMConstFPCast(self.as_value_ref(), float_type.as_type_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_to_unsigned_int(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstFPToUI(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_to_signed_int(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstFPToSI(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_truncate(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe { FloatValue::new(LLVMConstFPTrunc(self.as_value_ref(), float_type.as_type_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_extend(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe { FloatValue::new(LLVMConstFPExt(self.as_value_ref(), float_type.as_type_ref())) }
     }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -261,6 +261,37 @@ impl<'ctx> InstructionValue<'ctx> {
         }
     }
 
+    /// Check whether this instructions supports [fast math flags][0].
+    ///
+    /// [0]: https://llvm.org/docs/LangRef.html#fast-math-flags
+    #[llvm_versions(18.0..=latest)]
+    pub fn can_use_fast_math_flags(self) -> bool {
+        unsafe { llvm_sys::core::LLVMCanValueUseFastMathFlags(self.as_value_ref()) == 1 }
+    }
+
+    /// Get [fast math flags][0] of supported instructions.
+    ///
+    /// Calling this on unsupported instructions is safe and returns `None`.
+    ///
+    /// [0]: https://llvm.org/docs/LangRef.html#fast-math-flags
+    #[llvm_versions(18.0..=latest)]
+    pub fn get_fast_math_flags(self) -> Option<u32> {
+        self.can_use_fast_math_flags()
+            .then(|| unsafe { llvm_sys::core::LLVMGetFastMathFlags(self.as_value_ref()) } as u32)
+    }
+
+    /// Set [fast math flags][0] on supported instructions.
+    ///
+    /// Calling this on unsupported instructions is safe and results in a no-op.
+    ///
+    /// [0]: https://llvm.org/docs/LangRef.html#fast-math-flags
+    #[llvm_versions(18.0..=latest)]
+    pub fn set_fast_math_flags(self, flags: u32) {
+        if self.can_use_fast_math_flags() {
+            unsafe { llvm_sys::core::LLVMSetFastMathFlags(self.as_value_ref(), flags) };
+        }
+    }
+
     pub fn replace_all_uses_with(self, other: &InstructionValue<'ctx>) {
         self.instruction_value.replace_all_uses_with(other.as_value_ref())
     }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -252,6 +252,15 @@ impl<'ctx> InstructionValue<'ctx> {
         }
     }
 
+    #[llvm_versions(18.0..=latest)]
+    pub fn get_tail_call_kind(self) -> Option<super::LLVMTailCallKind> {
+        if self.get_opcode() == InstructionOpcode::Call {
+            unsafe { llvm_sys::core::LLVMGetTailCallKind(self.as_value_ref()) }.into()
+        } else {
+            None
+        }
+    }
+
     pub fn replace_all_uses_with(self, other: &InstructionValue<'ctx>) {
         self.instruction_value.replace_all_uses_with(other.as_value_ref())
     }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -295,7 +295,7 @@ impl<'ctx> InstructionValue<'ctx> {
         }
     }
 
-    /// Check if a zext instruction has the non-negative flag set.
+    /// Check if a `zext` instruction has the non-negative flag set.
     ///
     /// Calling this function on other instructions is safe and returns `None`.
     #[llvm_versions(18.0..=latest)]
@@ -304,13 +304,32 @@ impl<'ctx> InstructionValue<'ctx> {
             .then(|| unsafe { llvm_sys::core::LLVMGetNNeg(self.as_value_ref()) == 1 })
     }
 
-    /// Set the non-negative flag on zext instructions.
+    /// Set the non-negative flag on `zext` instructions.
     ///
     /// Calling this function on other instructions is safe and results in a no-op.
     #[llvm_versions(18.0..=latest)]
     pub fn set_non_negative_flag(self, flag: bool) {
         if self.get_opcode() == InstructionOpcode::ZExt {
             unsafe { llvm_sys::core::LLVMSetNNeg(self.as_value_ref(), flag as i32) };
+        }
+    }
+
+    /// Checks if an `or` instruction has the `disjoint` flag set.
+    ///
+    /// Calling this function on other instructions is safe and returns `None`.
+    #[llvm_versions(18.0..=latest)]
+    pub fn get_disjoint_flag(self) -> Option<bool> {
+        (self.get_opcode() == InstructionOpcode::Or)
+            .then(|| unsafe { llvm_sys::core::LLVMGetIsDisjoint(self.as_value_ref()) == 1 })
+    }
+
+    /// Set the `disjoint` flag on `or` instructions.
+    ///
+    /// Calling this function on other instructions is safe and results in a no-op.
+    #[llvm_versions(18.0..=latest)]
+    pub fn set_disjoint_flag(self, flag: bool) {
+        if self.get_opcode() == InstructionOpcode::Or {
+            unsafe { llvm_sys::core::LLVMSetIsDisjoint(self.as_value_ref(), flag as i32) };
         }
     }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -252,6 +252,9 @@ impl<'ctx> InstructionValue<'ctx> {
         }
     }
 
+    /// Returns the tail call kind on call instructions.
+    ///
+    /// Other instructions return `None`.
     #[llvm_versions(18.0..=latest)]
     pub fn get_tail_call_kind(self) -> Option<super::LLVMTailCallKind> {
         if self.get_opcode() == InstructionOpcode::Call {
@@ -289,6 +292,25 @@ impl<'ctx> InstructionValue<'ctx> {
     pub fn set_fast_math_flags(self, flags: u32) {
         if self.can_use_fast_math_flags() {
             unsafe { llvm_sys::core::LLVMSetFastMathFlags(self.as_value_ref(), flags) };
+        }
+    }
+
+    /// Check if a zext instruction has the non-negative flag set.
+    ///
+    /// Calling this function on other instructions is safe and returns `None`.
+    #[llvm_versions(18.0..=latest)]
+    pub fn get_non_negative_flag(self) -> Option<bool> {
+        (self.get_opcode() == InstructionOpcode::ZExt)
+            .then(|| unsafe { llvm_sys::core::LLVMGetNNeg(self.as_value_ref()) == 1 })
+    }
+
+    /// Set the non-negative flag on zext instructions.
+    ///
+    /// Calling this function on other instructions is safe and results in a no-op.
+    #[llvm_versions(18.0..=latest)]
+    pub fn set_non_negative_flag(self, flag: bool) {
+        if self.get_opcode() == InstructionOpcode::ZExt {
+            unsafe { llvm_sys::core::LLVMSetNNeg(self.as_value_ref(), flag as i32) };
         }
     }
 

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -1,12 +1,15 @@
 #[llvm_versions(4.0..=16.0)]
 use llvm_sys::core::LLVMConstSelect;
+#[llvm_versions(4.0..=17.0)]
 use llvm_sys::core::{
-    LLVMConstAShr, LLVMConstAdd, LLVMConstAnd, LLVMConstBitCast, LLVMConstICmp, LLVMConstIntCast,
-    LLVMConstIntGetSExtValue, LLVMConstIntGetZExtValue, LLVMConstIntToPtr, LLVMConstLShr, LLVMConstMul,
-    LLVMConstNSWAdd, LLVMConstNSWMul, LLVMConstNSWNeg, LLVMConstNSWSub, LLVMConstNUWAdd, LLVMConstNUWMul,
-    LLVMConstNUWNeg, LLVMConstNUWSub, LLVMConstNeg, LLVMConstNot, LLVMConstOr, LLVMConstSExt, LLVMConstSExtOrBitCast,
-    LLVMConstSIToFP, LLVMConstShl, LLVMConstSub, LLVMConstTrunc, LLVMConstTruncOrBitCast, LLVMConstUIToFP,
-    LLVMConstXor, LLVMConstZExt, LLVMConstZExtOrBitCast, LLVMIsAConstantInt,
+    LLVMConstAShr, LLVMConstAnd, LLVMConstIntCast, LLVMConstLShr, LLVMConstOr, LLVMConstSExt, LLVMConstSExtOrBitCast,
+    LLVMConstSIToFP, LLVMConstUIToFP, LLVMConstZExt, LLVMConstZExtOrBitCast,
+};
+use llvm_sys::core::{
+    LLVMConstAdd, LLVMConstBitCast, LLVMConstICmp, LLVMConstIntGetSExtValue, LLVMConstIntGetZExtValue,
+    LLVMConstIntToPtr, LLVMConstMul, LLVMConstNSWAdd, LLVMConstNSWMul, LLVMConstNSWNeg, LLVMConstNSWSub,
+    LLVMConstNUWAdd, LLVMConstNUWMul, LLVMConstNUWNeg, LLVMConstNUWSub, LLVMConstNeg, LLVMConstNot, LLVMConstShl,
+    LLVMConstSub, LLVMConstTrunc, LLVMConstTruncOrBitCast, LLVMConstXor, LLVMIsAConstantInt,
 };
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -14,11 +17,15 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::types::{AsTypeRef, FloatType, IntType, PointerType};
+#[llvm_versions(4.0..=17.0)]
+use crate::types::FloatType;
+use crate::types::{AsTypeRef, IntType, PointerType};
 use crate::values::traits::AsValueRef;
 #[llvm_versions(4.0..=16.0)]
 use crate::values::BasicValueEnum;
-use crate::values::{BasicValue, FloatValue, InstructionValue, PointerValue, Value};
+#[llvm_versions(4.0..=17.0)]
+use crate::values::FloatValue;
+use crate::values::{BasicValue, InstructionValue, PointerValue, Value};
 use crate::IntPredicate;
 
 use super::AnyValue;
@@ -168,10 +175,12 @@ impl<'ctx> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstSRem(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_and(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstAnd(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_or(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstOr(self.as_value_ref(), rhs.as_value_ref())) }
     }
@@ -181,6 +190,7 @@ impl<'ctx> IntValue<'ctx> {
     }
 
     // TODO: Could infer is_signed from type (one day)?
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_cast(self, int_type: IntType<'ctx>, is_signed: bool) -> Self {
         unsafe {
             IntValue::new(LLVMConstIntCast(
@@ -196,20 +206,24 @@ impl<'ctx> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstShl(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_rshr(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstLShr(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_ashr(self, rhs: IntValue<'ctx>) -> Self {
         unsafe { IntValue::new(LLVMConstAShr(self.as_value_ref(), rhs.as_value_ref())) }
     }
 
     // SubType: const_to_float impl only for unsigned types
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_unsigned_to_float(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe { FloatValue::new(LLVMConstUIToFP(self.as_value_ref(), float_type.as_type_ref())) }
     }
 
     // SubType: const_to_float impl only for signed types
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_signed_to_float(self, float_type: FloatType<'ctx>) -> FloatValue<'ctx> {
         unsafe { FloatValue::new(LLVMConstSIToFP(self.as_value_ref(), float_type.as_type_ref())) }
     }
@@ -223,11 +237,13 @@ impl<'ctx> IntValue<'ctx> {
     }
 
     // TODO: More descriptive name
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_s_extend(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstSExt(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     // TODO: More descriptive name
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_z_ext(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstZExt(self.as_value_ref(), int_type.as_type_ref())) }
     }
@@ -237,11 +253,13 @@ impl<'ctx> IntValue<'ctx> {
     }
 
     // TODO: More descriptive name
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_s_extend_or_bit_cast(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstSExtOrBitCast(self.as_value_ref(), int_type.as_type_ref())) }
     }
 
     // TODO: More descriptive name
+    #[llvm_versions(4.0..=17.0)]
     pub fn const_z_ext_or_bit_cast(self, int_type: IntType<'ctx>) -> IntValue<'ctx> {
         unsafe { IntValue::new(LLVMConstZExtOrBitCast(self.as_value_ref(), int_type.as_type_ref())) }
     }

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -38,6 +38,8 @@ pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 31;
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 36;
 #[cfg(any(feature = "llvm16-0", feature = "llvm17-0"))]
 pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 39;
+#[cfg(any(feature = "llvm18-0"))]
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 40;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue<'ctx> {

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -20,10 +20,20 @@ mod struct_value;
 mod traits;
 mod vec_value;
 
-#[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0")))]
+#[cfg(not(any(
+    feature = "llvm15-0",
+    feature = "llvm16-0",
+    feature = "llvm17-0",
+    feature = "llvm18-0"
+)))]
 mod callable_value;
 
-#[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0")))]
+#[cfg(not(any(
+    feature = "llvm15-0",
+    feature = "llvm16-0",
+    feature = "llvm17-0",
+    feature = "llvm18-0"
+)))]
 pub use crate::values::callable_value::CallableValue;
 
 use crate::support::{to_c_str, LLVMString};

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -59,6 +59,9 @@ pub use crate::values::traits::AsValueRef;
 pub use crate::values::traits::{AggregateValue, AnyValue, BasicValue, FloatMathValue, IntMathValue, PointerMathValue};
 pub use crate::values::vec_value::VectorValue;
 
+#[llvm_versions(18.0..=latest)]
+pub use llvm_sys::LLVMTailCallKind;
+
 use llvm_sys::core::{
     LLVMDumpValue, LLVMGetFirstUse, LLVMGetSection, LLVMIsAInstruction, LLVMIsConstant, LLVMIsNull, LLVMIsUndef,
     LLVMPrintTypeToString, LLVMPrintValueToString, LLVMReplaceAllUsesWith, LLVMSetSection, LLVMTypeOf,

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -15,7 +15,7 @@ mod test_instruction_values;
 mod test_intrinsics;
 mod test_module;
 mod test_object_file;
-#[cfg(not(any(feature = "llvm17-0")))]
+#[cfg(not(any(feature = "llvm17-0", feature = "llvm18-0")))]
 mod test_passes;
 mod test_targets;
 mod test_tari_example;

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -70,7 +70,12 @@ fn test_build_call() {
         feature = "llvm14-0"
     ))]
     let load = builder.build_load(alloca, "load").unwrap().into_pointer_value();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let load = builder
         .build_load(fn_ptr_type, alloca, "load")
         .unwrap()
@@ -94,7 +99,12 @@ fn test_build_call() {
         let callable_value = CallableValue::try_from(load).unwrap();
         builder.build_call(callable_value, &[], "call").unwrap();
     }
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     builder.build_indirect_call(fn_type2, load, &[], "call");
     builder.build_return(None).unwrap();
 
@@ -394,7 +404,12 @@ fn test_null_checked_ptr_ops() {
         feature = "llvm14-0"
     ))]
     let index1 = builder.build_load(new_ptr, "deref").unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let index1 = builder.build_load(i8_ptr_type, new_ptr, "deref").unwrap();
 
     builder.build_return(Some(&index1)).unwrap();
@@ -448,7 +463,12 @@ fn test_null_checked_ptr_ops() {
         feature = "llvm14-0"
     ))]
     let index1 = builder.build_load(new_ptr, "deref").unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let index1 = builder.build_load(i8_ptr_type, new_ptr, "deref").unwrap();
 
     builder.build_return(Some(&index1)).unwrap();
@@ -984,7 +1004,12 @@ fn test_insert_value() {
         .build_load(array_alloca, "array_load")
         .unwrap()
         .into_array_value();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let array = builder
         .build_load(array_type, array_alloca, "array_load")
         .unwrap()
@@ -1038,7 +1063,12 @@ fn test_insert_value() {
         .build_load(struct_alloca, "struct_load")
         .unwrap()
         .into_struct_value();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let struct_value = builder
         .build_load(struct_type, struct_alloca, "struct_load")
         .unwrap()
@@ -1207,7 +1237,12 @@ fn run_memcpy_on<'ctx>(
             feature = "llvm14-0"
         ))]
         let elem_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") }.unwrap();
-        #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+        #[cfg(any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ))]
         let elem_ptr = unsafe {
             builder
                 .build_in_bounds_gep(element_type, array_ptr, &[index_val], "index")
@@ -1237,7 +1272,12 @@ fn run_memcpy_on<'ctx>(
         feature = "llvm14-0"
     ))]
     let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") }.unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let dest_ptr = unsafe {
         builder
             .build_in_bounds_gep(element_type, array_ptr, &[index_val], "index")
@@ -1317,7 +1357,12 @@ fn run_memmove_on<'ctx>(
             feature = "llvm14-0"
         ))]
         let elem_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") }.unwrap();
-        #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+        #[cfg(any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ))]
         let elem_ptr = unsafe {
             builder
                 .build_in_bounds_gep(element_type, array_ptr, &[index_val], "index")
@@ -1347,7 +1392,12 @@ fn run_memmove_on<'ctx>(
         feature = "llvm14-0"
     ))]
     let dest_ptr = unsafe { builder.build_in_bounds_gep(array_ptr, &[index_val], "index") }.unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let dest_ptr = unsafe {
         builder
             .build_in_bounds_gep(element_type, array_ptr, &[index_val], "index")
@@ -1434,7 +1484,12 @@ fn run_memset_on<'ctx>(
         feature = "llvm14-0"
     ))]
     let part_2 = unsafe { builder.build_in_bounds_gep(array_ptr, &[index], "index") }.unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let part_2 = unsafe {
         builder
             .build_in_bounds_gep(element_type, array_ptr, &[index], "index")
@@ -1798,7 +1853,12 @@ fn test_safe_struct_gep() {
         assert!(builder.build_struct_gep(struct_ptr, 1, "struct_gep").is_ok());
         assert!(builder.build_struct_gep(struct_ptr, 2, "struct_gep").is_err());
     }
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     {
         assert!(builder.build_struct_gep(i32_ty, i32_ptr, 0, "struct_gep").is_err());
         assert!(builder.build_struct_gep(i32_ty, i32_ptr, 10, "struct_gep").is_err());

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -32,7 +32,8 @@ fn test_smoke() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -42,7 +43,8 @@ fn test_smoke() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -120,7 +122,8 @@ fn test_struct_with_placeholders() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -130,7 +133,8 @@ fn test_struct_with_placeholders() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -250,7 +254,8 @@ fn test_no_explicit_finalize() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -260,7 +265,8 @@ fn test_no_explicit_finalize() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -297,7 +303,8 @@ fn test_replacing_placeholder_with_placeholder() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -307,7 +314,8 @@ fn test_replacing_placeholder_with_placeholder() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -358,7 +366,8 @@ fn test_anonymous_basic_type() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -368,7 +377,8 @@ fn test_anonymous_basic_type() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -412,7 +422,8 @@ fn test_global_expressions() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -422,7 +433,8 @@ fn test_global_expressions() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -484,7 +496,8 @@ fn test_pointer_types() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -494,7 +507,8 @@ fn test_pointer_types() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -540,7 +554,8 @@ fn test_reference_types() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -550,7 +565,8 @@ fn test_reference_types() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );
@@ -596,7 +612,8 @@ fn test_array_type() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
         #[cfg(any(
@@ -606,7 +623,8 @@ fn test_array_type() {
             feature = "llvm14-0",
             feature = "llvm15-0",
             feature = "llvm16-0",
-            feature = "llvm17-0"
+            feature = "llvm17-0",
+            feature = "llvm18-0"
         ))]
         "",
     );

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -495,7 +495,12 @@ fn test_mem_instructions() {
         feature = "llvm14-0"
     ))]
     let load = builder.build_load(arg1, "").unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let load = builder.build_load(f32_type, arg1, "").unwrap();
     let load_instruction = load.as_instruction_value().unwrap();
 
@@ -574,7 +579,12 @@ fn test_atomic_ordering_mem_instructions() {
         feature = "llvm14-0"
     ))]
     let load = builder.build_load(arg1, "").unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     let load = builder.build_load(f32_type, arg1, "").unwrap();
     let load_instruction = load.as_instruction_value().unwrap();
 

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -342,7 +342,12 @@ fn test_const_zero() {
     );
 
     // handle opaque pointers
-    let ptr_type = if cfg!(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0")) {
+    let ptr_type = if cfg!(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    )) {
         "ptr null"
     } else {
         "double* null"

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -86,6 +86,10 @@ fn test_call_site_tail_call_attributes() {
 
     assert!(!call_site.is_tail_call());
     assert_eq!(call_site.get_tail_call_kind(), LLVMTailCallKindNone);
+    assert_eq!(
+        call_site.try_as_basic_value().right().unwrap().get_tail_call_kind(),
+        Some(LLVMTailCallKindNone)
+    );
 
     call_site.set_tail_call_kind(LLVMTailCallKindTail);
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -7,8 +7,8 @@ use inkwell::types::{BasicType, StringRadix, VectorType};
 use inkwell::values::{AnyValue, BasicValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
 use inkwell::{AddressSpace, DLLStorageClass, GlobalVisibility, ThreadLocalMode};
 
-#[llvm_versions(7.0..=latest)]
-use llvm_sys::LLVMTailCallKind::*;
+#[llvm_versions(18.0..=latest)]
+pub use llvm_sys::LLVMTailCallKind::*;
 #[cfg(feature = "llvm18-0")]
 use llvm_sys_180 as llvm_sys;
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -609,7 +609,7 @@ fn test_metadata() {
 
 #[test]
 fn test_floats() {
-    #[cfg(not(feature = "llvm15-0"))]
+    #[cfg(not(any(feature = "llvm15-0", feature = "llvm18-0")))]
     {
         use inkwell::FloatPredicate;
 
@@ -644,7 +644,7 @@ fn test_floats() {
 
         let f64_one = f64_type.const_float(1.);
         let f64_two = f64_type.const_float(2.);
-        #[cfg(not(any(feature = "llvm16-0", feature = "llvm17-0")))]
+        #[cfg(not(any(feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
         {
             let neg_two = f64_two.const_neg();
 
@@ -1023,7 +1023,12 @@ fn test_allocations() {
     builder.position_at_end(entry_block);
 
     // handle opaque pointers
-    let ptr_type = if cfg!(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0")) {
+    let ptr_type = if cfg!(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    )) {
         "ptr"
     } else {
         "i32*"
@@ -1314,7 +1319,12 @@ fn test_non_fn_ptr_called() {
         let callable_value = CallableValue::try_from(i8_ptr_param).unwrap();
         builder.build_call(callable_value, &[], "call").unwrap();
     }
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     builder.build_indirect_call(i8_ptr_type.fn_type(&[], false), i8_ptr_param, &[], "call");
     builder.build_return(None).unwrap();
 
@@ -1380,7 +1390,12 @@ fn test_aggregate_returns() {
         feature = "llvm14-0"
     ))]
     builder.build_ptr_diff(ptr_param1, ptr_param2, "diff").unwrap();
-    #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0"))]
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
     builder.build_ptr_diff(i32_ptr_type, ptr_param1, ptr_param2, "diff");
     builder
         .build_aggregate_return(&[i32_three.into(), i32_seven.into()])


### PR DESCRIPTION
## Description

Support [LLVM 18](https://releases.llvm.org/18.1.0/docs/ReleaseNotes.html#id26).



## Related Issue

#482

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

- [x] Introduce feature flags 
- [ ] Wait out
  - [x] next `llvm-sys` release supporting LLVM 18
  - [ ] LLVM 18 binary releases to run tests on CI
- [x] Guard removed API methods and make test suite pass
- [ ] Implement added functionality
  - [x] Getting and setting tail, musttail, and notail attributes on call instructions
  - [x] Implmented a safe wrapper around LLVMCreateTargetMachineWithOptions
  - [x] New flags: LLVMGetNNeg, LLVMSetNNeg, LLVMGetIsDisjoint, LLVMSetIsDisjoint, LLVMGetFastMathFlags, LLVMSetFastMathFlags, LLVMCanValueUseFastMathFlags
  - [ ] ~~Operand Bundles~~ We don't need this right now, can I leave this open for a future PR?

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
