### PR TITLE
renamed bitcast to bit_cast

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1797,12 +1797,12 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.position_at_end(entry);
     ///
-    /// builder.build_bitcast(i32_arg, f32_type, "i32tof32").unwrap();
+    /// builder.build_bit_cast(i32_arg, f32_type, "i32tof32").unwrap();
     /// builder.build_return(None).unwrap();
     ///
     /// assert!(module.verify().is_ok());
     /// ```
-    pub fn build_bitcast<T, V>(&self, val: V, ty: T, name: &str) -> Result<BasicValueEnum<'ctx>, BuilderError>
+    pub fn build_bit_cast<T, V>(&self, val: V, ty: T, name: &str) -> Result<BasicValueEnum<'ctx>, BuilderError>
     where
         T: BasicType<'ctx>,
         V: BasicValue<'ctx>,

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -1530,7 +1530,7 @@ fn test_memset() {
 }
 
 #[test]
-fn test_bitcast() {
+fn test_bit_cast() {
     use inkwell::values::BasicValue;
 
     let context = Context::create();
@@ -1562,11 +1562,11 @@ fn test_bitcast() {
 
     builder.position_at_end(entry);
 
-    let cast = builder.build_bitcast(i32_arg, f32_type, "i32tof32").unwrap();
+    let cast = builder.build_bit_cast(i32_arg, f32_type, "i32tof32").unwrap();
 
-    builder.build_bitcast(f32_arg, f32_type, "f32tof32").unwrap();
-    builder.build_bitcast(i32_vec_arg, i64_type, "2xi32toi64").unwrap();
-    builder.build_bitcast(i32_ptr_arg, i64_ptr_type, "i32*toi64*").unwrap();
+    builder.build_bit_cast(f32_arg, f32_type, "f32tof32").unwrap();
+    builder.build_bit_cast(i32_vec_arg, i64_type, "2xi32toi64").unwrap();
+    builder.build_bit_cast(i32_ptr_arg, i64_ptr_type, "i32*toi64*").unwrap();
 
     builder.build_return(None).unwrap();
 
@@ -1575,7 +1575,7 @@ fn test_bitcast() {
     let first_iv = cast.as_instruction_value().unwrap();
 
     builder.position_before(&first_iv);
-    builder.build_bitcast(f64_arg, i64_type, "f64toi64").unwrap();
+    builder.build_bit_cast(f64_arg, i64_type, "f64toi64").unwrap();
 
     assert!(module.verify().is_ok());
 }

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -105,7 +105,7 @@ fn test_operands() {
     assert!(return_instruction.get_operand(2).is_none());
 
     // Test Uses
-    let bitcast_use_value = free_operand0_instruction
+    let bit_cast_use_value = free_operand0_instruction
         .get_first_use()
         .unwrap()
         .get_used_value()
@@ -113,7 +113,7 @@ fn test_operands() {
         .unwrap();
     let free_call_param = free_instruction.get_operand(0).unwrap().left().unwrap();
 
-    assert_eq!(bitcast_use_value, free_call_param);
+    assert_eq!(bit_cast_use_value, free_call_param);
 
     // These instructions/calls don't return any ir value so they aren't used anywhere
     assert!(store_instruction.get_first_use().is_none());


### PR DESCRIPTION
## Description

Renamed `bitcast` to `bit_cast`. For consistency with LLVM's `LLVMBuildBitCast` and internal `build_int_cast`,`build_float_cast`,... . 

## Related Issue

Closes #485.

## How This Has Been Tested

To be tested with github CI.

## Breaking Changes

API change from `builder.build_bitcast` to `builder.build_bit_cast`.

## Checklist

- [ x ] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
