### PR TITLE
Fix rustc and clippy warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
   DOC_LLVM_FEATURE: llvm17-0
-  DOC_LLVM_VERSION: '17.0'
+  DOC_LLVM_VERSION: "17.0"
   DOC_PATH: target/doc
 
 jobs:
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust Stable
-        run: rustup toolchain install stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Install typos
-        run: cargo install typos-cli
+        uses: taiki-e/install-action@typos
       - name: Run typos
         run: typos .
   tests:
@@ -39,22 +39,24 @@ jobs:
           - ["15.0", "15-0"]
           - ["16.0", "16-0"]
           - ["17.0", "17-0"]
-        # only use ubuntu-22.04 for llvm 16 and higher
         include:
           - os: ubuntu-20.04
+          # only use ubuntu-22.04 for llvm 16 and higher
           - os: ubuntu-22.04
             llvm-version: ["16.0", "16-0"]
           - os: ubuntu-22.04
             llvm-version: ["17.0", "17-0"]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: ${{ matrix.llvm-version[0] }}
       - name: llvm-config
         run: llvm-config --version --bindir --libdir
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --release --features llvm${{ matrix.llvm-version[1] }} --verbose
       - name: Run tests
@@ -67,19 +69,19 @@ jobs:
     needs: [typos, tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-    - uses: actions/checkout@v3
-    - uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: ${{ env.DOC_LLVM_VERSION }}
-    - name: Install Rust Nightly
-      run: rustup toolchain install nightly
-    - name: Build Documentation
-      run: cargo +nightly doc --features ${{ env.DOC_LLVM_FEATURE }},nightly --verbose
-    - name: Doc Index Page Redirection
-      run: echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > ${{ env.DOC_PATH }}/index.html
-    - name: Deploy Documentation
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ${{ env.DOC_PATH }}
-        force_orphan: true
+      - uses: actions/checkout@v4
+      - uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: ${{ env.DOC_LLVM_VERSION }}
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Build Documentation
+        run: cargo +nightly doc --features ${{ env.DOC_LLVM_FEATURE }},nightly --verbose
+      - name: Doc Index Page Redirection
+        run: echo '<meta http-equiv="refresh" content="1; url=inkwell/index.html">' > ${{ env.DOC_PATH }}/index.html
+      - name: Deploy Documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.DOC_PATH }}
+          force_orphan: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [features]
 default = ["target-all"]
+
 # Please update internal_macros::FEATURE_VERSIONS when adding a new LLVM version
 llvm4-0 = ["llvm-sys-40"]
 llvm5-0 = ["llvm-sys-50"]
@@ -29,6 +30,7 @@ llvm15-0 = ["llvm-sys-150"]
 llvm16-0 = ["llvm-sys-160"]
 llvm17-0 = ["llvm-sys-170"]
 llvm18-0 = ["llvm-sys-180"]
+
 # Don't link against LLVM libraries. This is useful if another dependency is
 # installing LLVM. See llvm-sys for more details. We can't enable a single
 # `no-llvm-linking` feature across the board of llvm versions, as it'll cause
@@ -133,9 +135,8 @@ experimental = ["static-alloc"]
 nightly = ["inkwell_internals/nightly"]
 
 [dependencies]
-either = "1.5"
 inkwell_internals = { path = "./internal_macros", version = "0.9.0" }
-libc = "0.2"
+
 llvm-sys-40 = { package = "llvm-sys", version = "40.4", optional = true }
 llvm-sys-50 = { package = "llvm-sys", version = "50.4", optional = true }
 llvm-sys-60 = { package = "llvm-sys", version = "60.6", optional = true }
@@ -151,9 +152,13 @@ llvm-sys-150 = { package = "llvm-sys", version = "150.0.3", optional = true }
 llvm-sys-160 = { package = "llvm-sys", version = "160.1.0", optional = true }
 llvm-sys-170 = { package = "llvm-sys", version = "170.0.1", optional = true }
 llvm-sys-180 = { package = "llvm-sys", version = "180.0.0", optional = true }
+
+either = "1.5"
+libc = "0.2"
 once_cell = "1.16"
-static-alloc = { version = "0.2", optional = true }
 thiserror = "1.0.48"
+
+static-alloc = { version = "0.2", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/examples/kaleidoscope/implementation_typed_pointers.rs
+++ b/examples/kaleidoscope/implementation_typed_pointers.rs
@@ -51,12 +51,10 @@ pub struct LexError {
 }
 
 impl LexError {
-    #[allow(unused)]
     pub fn new(msg: &'static str) -> LexError {
         LexError { error: msg, index: 0 }
     }
 
-    #[allow(unused)]
     pub fn with_index(msg: &'static str, index: usize) -> LexError {
         LexError { error: msg, index }
     }

--- a/examples/kaleidoscope/implementation_typed_pointers.rs
+++ b/examples/kaleidoscope/implementation_typed_pointers.rs
@@ -882,7 +882,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             } => {
                 let mut old_bindings = Vec::new();
 
-                for &(ref var_name, ref initializer) in variables {
+                for (var_name, initializer) in variables {
                     let var_name = var_name.as_str();
 
                     let initial_val = match *initializer {

--- a/examples/kaleidoscope/main.rs
+++ b/examples/kaleidoscope/main.rs
@@ -32,8 +32,7 @@ use inkwell::{
 use inkwell_internals::llvm_versions;
 
 mod implementation_typed_pointers;
-
-use crate::implementation_typed_pointers::*;
+pub use implementation_typed_pointers::*;
 
 // ======================================================================================
 // PROGRAM ==============================================================================

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -369,14 +369,10 @@ impl AttributeLoc {
         match self {
             AttributeLoc::Return => 0,
             AttributeLoc::Param(index) => {
-                assert!(
-                    index <= u32::max_value() - 2,
-                    "Param index must be <= u32::max_value() - 2"
-                );
-
+                assert!(index <= u32::MAX - 2, "Param index must be <= u32::MAX - 2");
                 index + 1
             },
-            AttributeLoc::Function => u32::max_value(),
+            AttributeLoc::Function => u32::MAX,
         }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -421,7 +421,7 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.position_at_end(basic_block);
     ///
-    /// let pi = f32_type.const_float(::std::f64::consts::PI);
+    /// let pi = f32_type.const_float(std::f64::consts::PI);
     ///
     /// builder.build_return(Some(&pi)).unwrap();
     ///
@@ -542,7 +542,7 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.position_at_end(basic_block);
     ///
-    /// let pi = f32_type.const_float(::std::f64::consts::PI);
+    /// let pi = f32_type.const_float(std::f64::consts::PI);
     ///
     /// builder.build_return(Some(&pi)).unwrap();
     ///
@@ -900,7 +900,7 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.position_at_end(basic_block);
     ///
-    /// let pi = f32_type.const_float(::std::f64::consts::PI);
+    /// let pi = f32_type.const_float(std::f64::consts::PI);
     ///
     /// builder.build_return(Some(&pi)).unwrap();
     ///
@@ -3390,7 +3390,7 @@ impl<'ctx> Builder<'ctx> {
             feature = "llvm17-0",
             feature = "llvm18-0"
         )))]
-        if ptr.get_type().get_element_type().to_basic_type_enum() != cmp.get_type() {
+        if ptr.get_type().get_element_type().as_basic_type_enum() != cmp.get_type() {
             return Err(BuilderError::PointeeTypeMismatch(
                 "The pointer does not point to an element of the value type.",
             ));

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,10 +21,11 @@ use llvm_sys::core::{
     LLVMCreateStringAttribute, LLVMDoubleTypeInContext, LLVMFP128TypeInContext, LLVMFloatTypeInContext,
     LLVMGetGlobalContext, LLVMGetMDKindIDInContext, LLVMHalfTypeInContext, LLVMInsertBasicBlockInContext,
     LLVMInt16TypeInContext, LLVMInt1TypeInContext, LLVMInt32TypeInContext, LLVMInt64TypeInContext,
-    LLVMInt8TypeInContext, LLVMIntTypeInContext, LLVMMDNodeInContext, LLVMMDStringInContext,
-    LLVMModuleCreateWithNameInContext, LLVMPPCFP128TypeInContext, LLVMStructCreateNamed, LLVMStructTypeInContext,
-    LLVMVoidTypeInContext, LLVMX86FP80TypeInContext,
+    LLVMInt8TypeInContext, LLVMIntTypeInContext, LLVMModuleCreateWithNameInContext, LLVMPPCFP128TypeInContext,
+    LLVMStructCreateNamed, LLVMStructTypeInContext, LLVMVoidTypeInContext, LLVMX86FP80TypeInContext,
 };
+#[allow(deprecated)]
+use llvm_sys::core::{LLVMMDNodeInContext, LLVMMDStringInContext};
 use llvm_sys::ir_reader::LLVMParseIRInContext;
 use llvm_sys::prelude::{LLVMContextRef, LLVMDiagnosticInfoRef, LLVMTypeRef, LLVMValueRef};
 use llvm_sys::target::{LLVMIntPtrTypeForASInContext, LLVMIntPtrTypeInContext};
@@ -328,6 +329,7 @@ impl ContextImpl {
         }
     }
 
+    #[allow(deprecated)]
     fn metadata_node<'ctx>(&self, values: &[BasicMetadataValueEnum<'ctx>]) -> MetadataValue<'ctx> {
         let mut tuple_values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
         unsafe {
@@ -339,6 +341,7 @@ impl ContextImpl {
         }
     }
 
+    #[allow(deprecated)]
     fn metadata_string<'ctx>(&self, string: &str) -> MetadataValue<'ctx> {
         let c_string = to_c_str(string);
 

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -167,6 +167,7 @@ impl<'ctx> DIScope<'ctx> {
 /// Specific scopes (i.e. `DILexicalBlock`) can be turned into a `DIScope` with the
 /// `AsDIScope::as_debug_info_scope` trait method.
 pub trait AsDIScope<'ctx> {
+    #[allow(clippy::wrong_self_convention)]
     fn as_debug_info_scope(self) -> DIScope<'ctx>;
 }
 

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -406,7 +406,7 @@ impl<'ctx> ExecutionEngine<'ctx> {
         let cstring_args: Vec<_> = args.iter().map(|&arg| to_c_str(arg)).collect();
         let raw_args: Vec<*const _> = cstring_args.iter().map(|arg| arg.as_ptr()).collect();
 
-        let environment_variables = vec![]; // TODO: Support envp. Likely needs to be null terminated
+        let environment_variables = []; // TODO: Support envp. Likely needs to be null terminated
 
         LLVMRunFunctionAsMain(
             self.execution_engine_inner(),
@@ -475,7 +475,7 @@ impl Deref for ExecEngineInner<'_> {
     type Target = LLVMExecutionEngineRef;
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! * Most functions which take a string slice as input may possibly panic in the unlikely event that a c style string cannot be created based on it. (IE if your slice already has a null byte in it)
 
 #![deny(missing_debug_implementations)]
+#![allow(clippy::missing_safety_doc, clippy::too_many_arguments, clippy::result_unit_err)]
 #![cfg_attr(feature = "nightly", feature(doc_cfg))]
 
 #[macro_use]
@@ -147,14 +148,8 @@ assert_unique_used_features! {
 ///
 /// # Remarks
 /// See also: https://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
 pub struct AddressSpace(u32);
-
-impl Default for AddressSpace {
-    fn default() -> Self {
-        AddressSpace(0)
-    }
-}
 
 impl From<u16> for AddressSpace {
     fn from(val: u16) -> Self {

--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -3,6 +3,7 @@ use llvm_sys::core::{
     LLVMCreateMemoryBufferWithMemoryRangeCopy, LLVMCreateMemoryBufferWithSTDIN, LLVMDisposeMemoryBuffer,
     LLVMGetBufferSize, LLVMGetBufferStart,
 };
+#[allow(deprecated)]
 use llvm_sys::object::LLVMCreateObjectFile;
 use llvm_sys::prelude::LLVMMemoryBufferRef;
 
@@ -123,6 +124,7 @@ impl MemoryBuffer {
     /// Convert this `MemoryBuffer` into an `ObjectFile`. LLVM does not currently
     /// provide any way to determine the cause of error if conversion fails.
     pub fn create_object_file(self) -> Result<ObjectFile, ()> {
+        #[allow(deprecated)]
         let object_file = unsafe { LLVMCreateObjectFile(self.memory_buffer) };
 
         forget(self);

--- a/src/module.rs
+++ b/src/module.rs
@@ -849,6 +849,7 @@ impl<'ctx> Module<'ctx> {
     }
 
     /// Prints the content of the `Module` to a `String`.
+    #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.print_to_string().to_string()
     }
@@ -1507,7 +1508,7 @@ impl<'ctx> Module<'ctx> {
                 machine.target_machine,
                 options.options_ref,
             );
-            if error == std::ptr::null_mut() {
+            if error.is_null() {
                 Ok(())
             } else {
                 let message = LLVMGetErrorMessage(error);

--- a/src/object_file.rs
+++ b/src/object_file.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use llvm_sys::object::{
     LLVMDisposeObjectFile, LLVMDisposeRelocationIterator, LLVMDisposeSectionIterator, LLVMDisposeSymbolIterator,
     LLVMGetRelocationOffset, LLVMGetRelocationSymbol, LLVMGetRelocationType, LLVMGetRelocationTypeName,

--- a/src/support/error_handling.rs
+++ b/src/support/error_handling.rs
@@ -42,12 +42,11 @@ impl DiagnosticInfo {
     }
 
     pub(crate) fn severity_is_error(&self) -> bool {
-        unsafe {
-            match LLVMGetDiagInfoSeverity(self.diagnostic_info) {
-                LLVMDiagnosticSeverity::LLVMDSError => true,
-                _ => false,
-            }
-        }
+        self.severity() == LLVMDiagnosticSeverity::LLVMDSError
+    }
+
+    fn severity(&self) -> LLVMDiagnosticSeverity {
+        unsafe { LLVMGetDiagInfoSeverity(self.diagnostic_info) }
     }
 }
 

--- a/src/support/error_handling.rs
+++ b/src/support/error_handling.rs
@@ -10,7 +10,7 @@ use llvm_sys::LLVMDiagnosticSeverity;
 // wrap the provided function input ptr into a &CStr somehow
 // TODOC: Can be used like this:
 // extern "C" fn print_before_exit(msg: *const i8) {
-//    let c_str = unsafe { ::std::ffi::CStr::from_ptr(msg) };
+//    let c_str = unsafe { std::ffi::CStr::from_ptr(msg) };
 //
 //    eprintln!("LLVM fatally errored: {:?}", c_str);
 // }

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -31,6 +31,7 @@ impl LLVMString {
     /// as much as possible to save memory since it is allocated by
     /// LLVM. It's essentially a `CString` with a custom LLVM
     /// deallocator
+    #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
         (*self).to_string_lossy().into_owned()
     }
@@ -135,7 +136,7 @@ pub fn get_llvm_version() -> (u32, u32, u32) {
 
     unsafe { LLVMGetVersion(&mut major, &mut minor, &mut patch) };
 
-    return (major, minor, patch);
+    (major, minor, patch)
 }
 
 /// Possible errors that can occur when loading a library
@@ -186,7 +187,7 @@ pub fn search_for_address_of_symbol(symbol: &str) -> Option<usize> {
     if address.is_null() {
         return None;
     }
-    return Some(address as usize);
+    Some(address as usize)
 }
 
 #[test]
@@ -213,7 +214,7 @@ pub fn enable_llvm_pretty_stack_trace() {
 /// A) Finds a terminating null byte in the Rust string and can reference it directly like a C string.
 ///
 /// B) Finds no null byte and allocates a new C string based on the input Rust string.
-pub(crate) fn to_c_str<'s>(mut s: &'s str) -> Cow<'s, CStr> {
+pub(crate) fn to_c_str(mut s: &str) -> Cow<'_, CStr> {
     if s.is_empty() {
         s = "\0";
     }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -8,13 +8,12 @@ use llvm_sys::target::{
 #[llvm_versions(4.0..=latest)]
 use llvm_sys::target_machine::LLVMCreateTargetDataLayout;
 use llvm_sys::target_machine::{
-    LLVMAddAnalysisPasses, LLVMCodeGenFileType, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetMachine,
-    LLVMDisposeTargetMachine, LLVMGetDefaultTargetTriple, LLVMGetFirstTarget, LLVMGetNextTarget,
-    LLVMGetTargetDescription, LLVMGetTargetFromName, LLVMGetTargetFromTriple, LLVMGetTargetMachineCPU,
-    LLVMGetTargetMachineFeatureString, LLVMGetTargetMachineTarget, LLVMGetTargetMachineTriple, LLVMGetTargetName,
-    LLVMRelocMode, LLVMSetTargetMachineAsmVerbosity, LLVMTargetHasAsmBackend, LLVMTargetHasJIT,
-    LLVMTargetHasTargetMachine, LLVMTargetMachineEmitToFile, LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineRef,
-    LLVMTargetRef,
+    LLVMAddAnalysisPasses, LLVMCodeGenFileType, LLVMCodeModel, LLVMCreateTargetMachine, LLVMDisposeTargetMachine,
+    LLVMGetDefaultTargetTriple, LLVMGetFirstTarget, LLVMGetNextTarget, LLVMGetTargetDescription, LLVMGetTargetFromName,
+    LLVMGetTargetFromTriple, LLVMGetTargetMachineCPU, LLVMGetTargetMachineFeatureString, LLVMGetTargetMachineTarget,
+    LLVMGetTargetMachineTriple, LLVMGetTargetName, LLVMRelocMode, LLVMSetTargetMachineAsmVerbosity,
+    LLVMTargetHasAsmBackend, LLVMTargetHasJIT, LLVMTargetHasTargetMachine, LLVMTargetMachineEmitToFile,
+    LLVMTargetMachineEmitToMemoryBuffer, LLVMTargetMachineRef, LLVMTargetRef,
 };
 #[llvm_versions(18.0..=latest)]
 use llvm_sys::target_machine::{

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -1,12 +1,13 @@
-use llvm_sys::core::{LLVMConstArray, LLVMGetArrayLength};
-use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
+#[allow(deprecated)]
+use llvm_sys::core::LLVMGetArrayLength;
+use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{BasicTypeEnum, FunctionType, PointerType, Type};
-use crate::values::{ArrayValue, AsValueRef, IntValue};
+use crate::values::{ArrayValue, IntValue};
 use crate::AddressSpace;
 
 use std::fmt::{self, Display};
@@ -158,7 +159,7 @@ impl<'ctx> ArrayType<'ctx> {
         self.array_type.array_type(size)
     }
 
-    /// Creates a constant `ArrayValue`.
+    /// Creates a constant `ArrayValue` of `ArrayValue`s.
     ///
     /// # Example
     /// ```no_run
@@ -173,14 +174,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// assert!(f32_array_array.is_const());
     /// ```
     pub fn const_array(self, values: &[ArrayValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-        unsafe {
-            ArrayValue::new(LLVMConstArray(
-                self.as_type_ref(),
-                values.as_mut_ptr(),
-                values.len() as u32,
-            ))
-        }
+        unsafe { ArrayValue::new_const_array(&self, values) }
     }
 
     /// Creates a constant zero value of this `ArrayType`.
@@ -213,7 +207,10 @@ impl<'ctx> ArrayType<'ctx> {
     /// assert_eq!(i8_array_type.len(), 3);
     /// ```
     pub fn len(self) -> u32 {
-        unsafe { LLVMGetArrayLength(self.as_type_ref()) }
+        #[allow(deprecated)]
+        unsafe {
+            LLVMGetArrayLength(self.as_type_ref())
+        }
     }
 
     /// Returns `true` if this `ArrayType` contains no elements.

--- a/src/types/array_type.rs
+++ b/src/types/array_type.rs
@@ -216,6 +216,11 @@ impl<'ctx> ArrayType<'ctx> {
         unsafe { LLVMGetArrayLength(self.as_type_ref()) }
     }
 
+    /// Returns `true` if this `ArrayType` contains no elements.
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
     /// Print the definition of an `ArrayType` to `LLVMString`
     pub fn print_to_string(self) -> LLVMString {
         self.array_type.print_to_string()
@@ -272,7 +277,7 @@ impl<'ctx> ArrayType<'ctx> {
     /// assert_eq!(i8_array_type.get_element_type().into_int_type(), i8_type);
     /// ```
     pub fn get_element_type(self) -> BasicTypeEnum<'ctx> {
-        self.array_type.get_element_type().to_basic_type_enum()
+        self.array_type.get_element_type().as_basic_type_enum()
     }
 }
 

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -265,7 +265,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
     }
 
     /// This will panic if type is a void or function type.
-    pub(crate) fn to_basic_type_enum(&self) -> BasicTypeEnum<'ctx> {
+    pub(crate) fn as_basic_type_enum(&self) -> BasicTypeEnum<'ctx> {
         unsafe { BasicTypeEnum::new(self.as_type_ref()) }
     }
 

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -1,13 +1,13 @@
-use llvm_sys::core::{LLVMConstArray, LLVMConstReal, LLVMConstRealOfStringAndSize};
+use llvm_sys::core::{LLVMConstReal, LLVMConstRealOfStringAndSize};
 use llvm_sys::execution_engine::LLVMCreateGenericValueOfFloat;
-use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
+use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
 use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
-use crate::values::{ArrayValue, AsValueRef, FloatValue, GenericValue, IntValue};
+use crate::values::{ArrayValue, FloatValue, GenericValue, IntValue};
 use crate::AddressSpace;
 
 use std::fmt::{self, Display};
@@ -304,14 +304,7 @@ impl<'ctx> FloatType<'ctx> {
     /// assert!(f32_array.is_const());
     /// ```
     pub fn const_array(self, values: &[FloatValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-        unsafe {
-            ArrayValue::new(LLVMConstArray(
-                self.as_type_ref(),
-                values.as_mut_ptr(),
-                values.len() as u32,
-            ))
-        }
+        unsafe { ArrayValue::new_const_array(&self, values) }
     }
 }
 

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -1,15 +1,14 @@
 use llvm_sys::core::{
-    LLVMConstAllOnes, LLVMConstArray, LLVMConstInt, LLVMConstIntOfArbitraryPrecision, LLVMConstIntOfStringAndSize,
-    LLVMGetIntTypeWidth,
+    LLVMConstAllOnes, LLVMConstInt, LLVMConstIntOfArbitraryPrecision, LLVMConstIntOfStringAndSize, LLVMGetIntTypeWidth,
 };
 use llvm_sys::execution_engine::LLVMCreateGenericValueOfInt;
-use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
+use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
-use crate::values::{ArrayValue, AsValueRef, GenericValue, IntValue};
+use crate::values::{ArrayValue, GenericValue, IntValue};
 use crate::AddressSpace;
 
 use crate::types::enums::BasicMetadataTypeEnum;
@@ -409,14 +408,7 @@ impl<'ctx> IntType<'ctx> {
     /// assert!(i8_array.is_const());
     /// ```
     pub fn const_array(self, values: &[IntValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-        unsafe {
-            ArrayValue::new(LLVMConstArray(
-                self.as_type_ref(),
-                values.as_mut_ptr(),
-                values.len() as u32,
-            ))
-        }
+        unsafe { ArrayValue::new_const_array(&self, values) }
     }
 }
 

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -58,14 +58,7 @@ impl StringRadix {
         }
 
         // and all digits must be in the radix' character set
-        let mut it = slice.chars();
-        match self {
-            StringRadix::Binary => it.all(|c| matches!(c, '0'..='1')),
-            StringRadix::Octal => it.all(|c| matches!(c, '0'..='7')),
-            StringRadix::Decimal => it.all(|c| matches!(c, '0'..='9')),
-            StringRadix::Hexadecimal => it.all(|c| matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F')),
-            StringRadix::Alphanumeric => it.all(|c| matches!(c, '0'..='9' | 'a'..='z' | 'A'..='Z')),
-        }
+        slice.chars().all(|c| c.is_digit(*self as u32))
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -38,10 +38,11 @@ pub use crate::types::void_type::VoidType;
 #[llvm_versions(12.0..=latest)]
 use llvm_sys::core::LLVMGetPoison;
 
+#[allow(deprecated)]
+use llvm_sys::core::LLVMArrayType;
 use llvm_sys::core::{
-    LLVMAlignOf, LLVMArrayType, LLVMConstNull, LLVMConstPointerNull, LLVMFunctionType, LLVMGetElementType,
-    LLVMGetTypeContext, LLVMGetTypeKind, LLVMGetUndef, LLVMPointerType, LLVMPrintTypeToString, LLVMSizeOf,
-    LLVMTypeIsSized, LLVMVectorType,
+    LLVMAlignOf, LLVMConstNull, LLVMConstPointerNull, LLVMFunctionType, LLVMGetElementType, LLVMGetTypeContext,
+    LLVMGetTypeKind, LLVMGetUndef, LLVMPointerType, LLVMPrintTypeToString, LLVMSizeOf, LLVMTypeIsSized, LLVMVectorType,
 };
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 use llvm_sys::LLVMTypeKind;
@@ -130,6 +131,7 @@ impl<'ctx> Type<'ctx> {
         }
     }
 
+    #[allow(deprecated)]
     fn array_type(self, size: u32) -> ArrayType<'ctx> {
         unsafe { ArrayType::new(LLVMArrayType(self.ty, size)) }
     }

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -1,7 +1,7 @@
+use llvm_sys::core::LLVMGetPointerAddressSpace;
 #[llvm_versions(15.0..=latest)]
 use llvm_sys::core::LLVMPointerTypeIsOpaque;
-use llvm_sys::core::{LLVMConstArray, LLVMGetPointerAddressSpace};
-use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
+use llvm_sys::prelude::LLVMTypeRef;
 
 use crate::context::ContextRef;
 use crate::support::LLVMString;
@@ -9,7 +9,7 @@ use crate::types::traits::AsTypeRef;
 #[llvm_versions(4.0..=14.0)]
 use crate::types::AnyTypeEnum;
 use crate::types::{ArrayType, FunctionType, Type, VectorType};
-use crate::values::{ArrayValue, AsValueRef, IntValue, PointerValue};
+use crate::values::{ArrayValue, IntValue, PointerValue};
 use crate::AddressSpace;
 
 use crate::types::enums::BasicMetadataTypeEnum;
@@ -368,14 +368,7 @@ impl<'ctx> PointerType<'ctx> {
     /// assert!(f32_ptr_array.is_const());
     /// ```
     pub fn const_array(self, values: &[PointerValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-        unsafe {
-            ArrayValue::new(LLVMConstArray(
-                self.as_type_ref(),
-                values.as_mut_ptr(),
-                values.len() as u32,
-            ))
-        }
+        unsafe { ArrayValue::new_const_array(&self, values) }
     }
 
     /// Determine whether this pointer is opaque.

--- a/src/types/struct_type.rs
+++ b/src/types/struct_type.rs
@@ -1,5 +1,5 @@
 use llvm_sys::core::{
-    LLVMConstArray, LLVMConstNamedStruct, LLVMCountStructElementTypes, LLVMGetStructElementTypes, LLVMGetStructName,
+    LLVMConstNamedStruct, LLVMCountStructElementTypes, LLVMGetStructElementTypes, LLVMGetStructName,
     LLVMIsOpaqueStruct, LLVMIsPackedStruct, LLVMStructGetTypeAtIndex, LLVMStructSetBody,
 };
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
@@ -452,14 +452,7 @@ impl<'ctx> StructType<'ctx> {
     /// assert!(struct_array.is_const());
     /// ```
     pub fn const_array(self, values: &[StructValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-        unsafe {
-            ArrayValue::new(LLVMConstArray(
-                self.as_type_ref(),
-                values.as_mut_ptr(),
-                values.len() as u32,
-            ))
-        }
+        unsafe { ArrayValue::new_const_array(&self, values) }
     }
 }
 

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -1,11 +1,11 @@
-use llvm_sys::core::{LLVMConstArray, LLVMConstVector, LLVMGetVectorSize};
+use llvm_sys::core::{LLVMConstVector, LLVMGetVectorSize};
 use llvm_sys::prelude::{LLVMTypeRef, LLVMValueRef};
 
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::{traits::AsTypeRef, ArrayType, BasicTypeEnum, FunctionType, PointerType, Type};
-use crate::values::{ArrayValue, AsValueRef, BasicValue, IntValue, VectorValue};
+use crate::values::{ArrayValue, BasicValue, IntValue, VectorValue};
 use crate::AddressSpace;
 
 use std::fmt::{self, Display};
@@ -283,15 +283,7 @@ impl<'ctx> VectorType<'ctx> {
     /// assert!(f32_array.is_const());
     /// ```
     pub fn const_array(self, values: &[VectorValue<'ctx>]) -> ArrayValue<'ctx> {
-        let mut values: Vec<LLVMValueRef> = values.iter().map(|val| val.as_value_ref()).collect();
-
-        unsafe {
-            ArrayValue::new(LLVMConstArray(
-                self.as_type_ref(),
-                values.as_mut_ptr(),
-                values.len() as u32,
-            ))
-        }
+        unsafe { ArrayValue::new_const_array(&self, values) }
     }
 
     /// Gets a reference to the `Context` this `VectorType` was created in.

--- a/src/types/vec_type.rs
+++ b/src/types/vec_type.rs
@@ -184,7 +184,7 @@ impl<'ctx> VectorType<'ctx> {
     /// assert_eq!(f32_vector_type.get_element_type().into_float_type(), f32_type);
     /// ```
     pub fn get_element_type(self) -> BasicTypeEnum<'ctx> {
-        self.vec_type.get_element_type().to_basic_type_enum()
+        self.vec_type.get_element_type().as_basic_type_enum()
     }
 
     /// Creates a `PointerType` with this `VectorType` for its element type.

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -52,7 +52,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -116,7 +116,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -155,7 +155,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();

--- a/src/values/float_value.rs
+++ b/src/values/float_value.rs
@@ -11,7 +11,9 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-use crate::types::{AsTypeRef, FloatType};
+#[llvm_versions(4.0..=17.0)]
+use crate::types::AsTypeRef;
+use crate::types::FloatType;
 use crate::values::traits::AsValueRef;
 use crate::values::{InstructionValue, IntValue, Value};
 use crate::FloatPredicate;

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -106,7 +106,7 @@ pub enum InstructionOpcode {
     ZExt,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct InstructionValue<'ctx> {
     instruction_value: Value<'ctx>,
 }
@@ -145,6 +145,12 @@ impl<'ctx> InstructionValue<'ctx> {
         InstructionValue {
             instruction_value: value,
         }
+    }
+
+    /// Creates a clone of this `InstructionValue`, and returns it.
+    /// The clone will have no parent, and no name.
+    pub fn explicit_clone(&self) -> Self {
+        unsafe { Self::new(LLVMInstructionClone(self.as_value_ref())) }
     }
 
     /// Get name of the `InstructionValue`.
@@ -482,7 +488,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -545,7 +551,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -649,7 +655,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -695,7 +701,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -762,7 +768,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// builder.position_at_end(basic_block);
     ///
     /// let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    /// let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    /// let f32_val = f32_type.const_float(std::f64::consts::PI);
     /// let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
@@ -838,14 +844,6 @@ impl<'ctx> InstructionValue<'ctx> {
         }
 
         Ok(())
-    }
-}
-
-impl Clone for InstructionValue<'_> {
-    /// Creates a clone of this `InstructionValue`, and returns it.
-    /// The clone will have no parent, and no name.
-    fn clone(&self) -> Self {
-        unsafe { InstructionValue::new(LLVMInstructionClone(self.as_value_ref())) }
     }
 }
 

--- a/src/values/int_value.rs
+++ b/src/values/int_value.rs
@@ -21,11 +21,11 @@ use std::fmt::{self, Display};
 use crate::types::FloatType;
 use crate::types::{AsTypeRef, IntType, PointerType};
 use crate::values::traits::AsValueRef;
-#[llvm_versions(4.0..=16.0)]
-use crate::values::BasicValueEnum;
 #[llvm_versions(4.0..=17.0)]
 use crate::values::FloatValue;
-use crate::values::{BasicValue, InstructionValue, PointerValue, Value};
+#[llvm_versions(4.0..=16.0)]
+use crate::values::{BasicValue, BasicValueEnum};
+use crate::values::{InstructionValue, PointerValue, Value};
 use crate::IntPredicate;
 
 use super::AnyValue;

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -16,30 +16,33 @@ use super::AnyValue;
 use std::ffi::CStr;
 use std::fmt::{self, Display};
 
-// FIXME: use #[doc(cfg(...))] for this rustdoc comment when it's stabilized:
-// https://github.com/rust-lang/rust/issues/43781
 /// Value returned by [`Context::get_kind_id()`](crate::context::Context::get_kind_id)
-/// for the first input string that isn't known. Each LLVM version has a different set of pre-defined metadata kinds.
-#[cfg(feature = "llvm4-0")]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 22;
-#[cfg(feature = "llvm5-0")]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 23;
-#[cfg(any(feature = "llvm6-0", feature = "llvm7-0"))]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 25;
-#[cfg(feature = "llvm8-0")]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 26;
-#[cfg(feature = "llvm9-0")]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 28;
-#[cfg(any(feature = "llvm10-0", feature = "llvm11-0"))]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 30;
-#[cfg(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0",))]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 31;
-#[cfg(any(feature = "llvm15-0"))]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 36;
-#[cfg(any(feature = "llvm16-0", feature = "llvm17-0"))]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 39;
-#[cfg(any(feature = "llvm18-0"))]
-pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = 40;
+/// for the first input string that isn't known.
+///
+/// Each LLVM version has a different set of pre-defined metadata kinds.
+pub const FIRST_CUSTOM_METADATA_KIND_ID: u32 = if cfg!(feature = "llvm4-0") {
+    22
+} else if cfg!(feature = "llvm5-0") {
+    23
+} else if cfg!(any(feature = "llvm6-0", feature = "llvm7-0")) {
+    25
+} else if cfg!(feature = "llvm8-0") {
+    26
+} else if cfg!(feature = "llvm9-0") {
+    28
+} else if cfg!(any(feature = "llvm10-0", feature = "llvm11-0")) {
+    30
+} else if cfg!(any(feature = "llvm12-0", feature = "llvm13-0", feature = "llvm14-0",)) {
+    31
+} else if cfg!(feature = "llvm15-0") {
+    36
+} else if cfg!(any(feature = "llvm16-0", feature = "llvm17-0")) {
+    39
+} else if cfg!(feature = "llvm18-0") {
+    40
+} else {
+    panic!("Unhandled LLVM version")
+};
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct MetadataValue<'ctx> {

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -225,7 +225,7 @@ impl<'ctx> Value<'ctx> {
             }
         });
 
-        let c_string = section.as_deref().map(to_c_str);
+        let c_string = section.map(to_c_str);
 
         unsafe {
             LLVMSetSection(

--- a/src/values/vec_value.rs
+++ b/src/values/vec_value.rs
@@ -1,8 +1,10 @@
 #[llvm_versions(4.0..=16.0)]
 use llvm_sys::core::LLVMConstSelect;
+#[allow(deprecated)]
+use llvm_sys::core::LLVMGetElementAsConstant;
 use llvm_sys::core::{
-    LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstShuffleVector, LLVMGetElementAsConstant,
-    LLVMIsAConstantDataVector, LLVMIsAConstantVector,
+    LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstShuffleVector, LLVMIsAConstantDataVector,
+    LLVMIsAConstantVector,
 };
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -112,6 +114,7 @@ impl<'ctx> VectorValue<'ctx> {
 
     // TODOC: Value seems to be zero initialized if index out of bounds
     // SubType: VectorValue<BV> -> BV
+    #[allow(deprecated)]
     pub fn get_element_as_constant(self, index: u32) -> BasicValueEnum<'ctx> {
         unsafe { BasicValueEnum::new(LLVMGetElementAsConstant(self.as_value_ref(), index)) }
     }

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -49,6 +49,8 @@ fn test_type_attribute() {
     let context = Context::create();
     let kind_id = Attribute::get_named_enum_kind_id("sret");
 
+    #[allow(deprecated)]
+    let ptr_type = context.i32_type().ptr_type(AddressSpace::default());
     let any_types = [
         context.i32_type().as_any_type_enum(),
         context.f32_type().as_any_type_enum(),
@@ -56,7 +58,7 @@ fn test_type_attribute() {
         context.i32_type().vec_type(1).as_any_type_enum(),
         context.i32_type().array_type(1).as_any_type_enum(),
         context.i32_type().fn_type(&[], false).as_any_type_enum(),
-        context.i32_type().ptr_type(AddressSpace::from(5u16)).as_any_type_enum(),
+        ptr_type.as_any_type_enum(),
         context
             .struct_type(&[context.i32_type().as_basic_type_enum()], false)
             .as_any_type_enum(),
@@ -76,6 +78,7 @@ fn test_type_attribute() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_attributes_on_function_values() {
     let context = Context::create();
     let builder = context.create_builder();

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -18,7 +18,7 @@ fn test_build_call() {
 
     builder.position_at_end(basic_block);
 
-    let pi = f32_type.const_float(::std::f64::consts::PI);
+    let pi = f32_type.const_float(std::f64::consts::PI);
 
     builder.build_return(Some(&pi)).unwrap();
 
@@ -138,7 +138,7 @@ fn test_build_invoke_cleanup_resume() {
 
     builder.position_at_end(basic_block);
 
-    let pi = f32_type.const_float(::std::f64::consts::PI);
+    let pi = f32_type.const_float(std::f64::consts::PI);
 
     builder.build_return(Some(&pi)).unwrap();
 
@@ -222,7 +222,7 @@ fn test_build_invoke_catch_all() {
 
     builder.position_at_end(basic_block);
 
-    let pi = f32_type.const_float(::std::f64::consts::PI);
+    let pi = f32_type.const_float(std::f64::consts::PI);
 
     builder.build_return(Some(&pi)).unwrap();
 
@@ -310,7 +310,7 @@ fn landing_pad_filter() {
 
     builder.position_at_end(basic_block);
 
-    let pi = f32_type.const_float(::std::f64::consts::PI);
+    let pi = f32_type.const_float(std::f64::consts::PI);
 
     builder.build_return(Some(&pi)).unwrap();
 
@@ -1094,7 +1094,7 @@ fn test_insert_value() {
     let const_int1 = i32_type.const_int(2, false);
     let const_int2 = i32_type.const_int(5, false);
     let const_int3 = i32_type.const_int(6, false);
-    let const_float = f32_type.const_float(3.14);
+    let const_float = f32_type.const_float(2.0);
 
     assert!(builder
         .build_insert_value(array, const_int1, 0, "insert")
@@ -1274,7 +1274,7 @@ fn test_alignment_bytes() {
         verify_alignment(alignment);
     }
 
-    verify_alignment(u32::max_value());
+    verify_alignment(u32::MAX);
 }
 
 #[llvm_versions(8.0..=latest)]

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -2,7 +2,6 @@ use inkwell::builder::BuilderError;
 use inkwell::context::Context;
 use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, OptimizationLevel};
 
-use std::convert::TryFrom;
 use std::ptr::null;
 
 #[test]
@@ -118,7 +117,7 @@ fn test_build_call() {
         feature = "llvm17-0",
         feature = "llvm18-0"
     ))]
-    builder.build_indirect_call(fn_type2, load, &[], "call");
+    builder.build_indirect_call(fn_type2, load, &[], "call").unwrap();
     builder.build_return(None).unwrap();
 
     assert!(module.verify().is_ok());
@@ -1226,6 +1225,7 @@ fn test_insert_element() {
     v = builder
         .build_insert_element(v, i8_ty.const_int(3, false), i32_ty.const_int(3, false), "v3")
         .unwrap();
+    let _ = v;
 
     builder.build_return(None).unwrap();
 
@@ -1308,7 +1308,6 @@ fn run_memcpy_on<'ctx>(
 
     let len_value = i64_type.const_int(array_len as u64, false);
     let element_type = i32_type;
-    let array_type = element_type.array_type(array_len as u32);
     let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
 
     // Initialize the array with the values [1, 2, 3, 4]
@@ -1441,7 +1440,6 @@ fn run_memmove_on<'ctx>(
 
     let len_value = i64_type.const_int(array_len as u64, false);
     let element_type = i32_type;
-    let array_type = element_type.array_type(array_len as u32);
     let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
 
     // Initialize the array with the values [1, 2, 3, 4]
@@ -1575,7 +1573,6 @@ fn run_memset_on<'ctx>(
 
     let len_value = i64_type.const_int(array_len as u64, false);
     let element_type = i32_type;
-    let array_type = element_type.array_type(array_len as u32);
     let array_ptr = builder.build_array_malloc(i32_type, len_value, "array_ptr").unwrap();
 
     let elems_to_copy = 2;

--- a/tests/all/test_debug_info.rs
+++ b/tests/all/test_debug_info.rs
@@ -177,8 +177,8 @@ fn test_struct_with_placeholders() {
         )
         .unwrap();
 
-    let member_sizes = vec![32, 64, 32, 64];
-    let member_types = vec![i32ty, i64ty, f32ty, f64ty];
+    let member_sizes = [32, 64, 32, 64];
+    let member_types = [i32ty, i64ty, f32ty, f64ty];
     let member_placeholders = member_types
         .iter()
         .map(|_ty| unsafe { dibuilder.create_placeholder_derived_type(&context) })
@@ -587,6 +587,7 @@ fn test_reference_types() {
 }
 
 #[test]
+#[allow(clippy::single_range_in_vec_init)]
 fn test_array_type() {
     let context = Context::create();
     let module = context.create_module("bin");
@@ -640,7 +641,7 @@ fn test_array_type() {
         .unwrap()
         .as_type();
 
-    //Smoke test that the array gets created
+    // Smoke test that the array gets created.
     dibuilder.create_array_type(di_type, 160, 64, &[(0..20)]);
 
     dibuilder.create_array_type(di_type, 160, 64, &[(0..20), (-1..30), (20..55)]);

--- a/tests/all/test_execution_engine.rs
+++ b/tests/all/test_execution_engine.rs
@@ -53,7 +53,6 @@ fn test_jit_execution_engine() {
     let context = Context::create();
     let module = context.create_module("main_module");
     let builder = context.create_builder();
-    let i8_type = context.i8_type();
     let i32_type = context.i32_type();
     #[cfg(not(any(
         feature = "llvm15-0",
@@ -61,7 +60,8 @@ fn test_jit_execution_engine() {
         feature = "llvm17-0",
         feature = "llvm18-0"
     )))]
-    let i8_ptr_ptr_type = i8_type
+    let i8_ptr_ptr_type = context
+        .i8_type()
         .ptr_type(AddressSpace::default())
         .ptr_type(AddressSpace::default());
     #[cfg(any(

--- a/tests/all/test_instruction_conversion.rs
+++ b/tests/all/test_instruction_conversion.rs
@@ -110,14 +110,13 @@ fn test_conversion_to_pointer_value() {
     builder.position_at_end(basic_block);
 
     // Create a PointerType instruction
-    let i64_type = context.i64_type();
     #[cfg(not(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
         feature = "llvm18-0"
     )))]
-    let i64_ptr_type = i64_type.ptr_type(AddressSpace::default());
+    let i64_ptr_type = context.i64_type().ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -1,5 +1,5 @@
 use inkwell::context::Context;
-use inkwell::types::{AnyTypeEnum, AsTypeRef, BasicType};
+use inkwell::types::{AnyTypeEnum, BasicType};
 use inkwell::values::{BasicValue, InstructionOpcode::*};
 use inkwell::{AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
 

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -33,7 +33,7 @@ fn test_operands() {
     builder.position_at_end(basic_block);
 
     let arg1 = function.get_first_param().unwrap().into_pointer_value();
-    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    let f32_val = f32_type.const_float(std::f64::consts::PI);
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     let free_instruction = builder.build_free(arg1).unwrap();
     let return_instruction = builder.build_return(None).unwrap();
@@ -240,7 +240,7 @@ fn test_get_next_use() {
     builder.position_at_end(basic_block);
 
     let arg1 = function.get_first_param().unwrap().into_float_value();
-    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    let f32_val = f32_type.const_float(std::f64::consts::PI);
     let add_pi0 = builder.build_float_add(arg1, f32_val, "add_pi").unwrap();
     let add_pi1 = builder.build_float_add(add_pi0, f32_val, "add_pi").unwrap();
 
@@ -294,7 +294,7 @@ fn test_instructions() {
     assert!(arg1.get_first_use().is_none());
     assert!(arg2.get_first_use().is_none());
 
-    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    let f32_val = f32_type.const_float(std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     let alloca_val = builder.build_alloca(i64_type, "alloca").unwrap();
@@ -351,7 +351,7 @@ fn test_instructions() {
 
     // test instruction cloning
     #[allow(clippy::redundant_clone)]
-    let instruction_clone = return_instruction.clone();
+    let instruction_clone = return_instruction.explicit_clone();
 
     assert_eq!(instruction_clone.get_opcode(), return_instruction.get_opcode());
     assert_ne!(instruction_clone, return_instruction);
@@ -417,16 +417,16 @@ fn test_volatile_atomicrmw_cmpxchg() {
         .as_instruction_value()
         .unwrap();
 
-    assert_eq!(atomicrmw.get_volatile().unwrap(), false);
-    assert_eq!(cmpxchg.get_volatile().unwrap(), false);
+    assert!(!atomicrmw.get_volatile().unwrap());
+    assert!(!cmpxchg.get_volatile().unwrap());
     atomicrmw.set_volatile(true).unwrap();
     cmpxchg.set_volatile(true).unwrap();
-    assert_eq!(atomicrmw.get_volatile().unwrap(), true);
-    assert_eq!(cmpxchg.get_volatile().unwrap(), true);
+    assert!(atomicrmw.get_volatile().unwrap());
+    assert!(cmpxchg.get_volatile().unwrap());
     atomicrmw.set_volatile(false).unwrap();
     cmpxchg.set_volatile(false).unwrap();
-    assert_eq!(atomicrmw.get_volatile().unwrap(), false);
-    assert_eq!(cmpxchg.get_volatile().unwrap(), false);
+    assert!(!atomicrmw.get_volatile().unwrap());
+    assert!(!cmpxchg.get_volatile().unwrap());
 }
 
 #[llvm_versions(4.0..=10.0)]
@@ -465,7 +465,7 @@ fn test_mem_instructions() {
     assert!(arg1.get_first_use().is_none());
     assert!(arg2.get_first_use().is_none());
 
-    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    let f32_val = f32_type.const_float(std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     let load = builder.build_load(arg1, "").unwrap();
@@ -543,7 +543,7 @@ fn test_mem_instructions() {
     assert!(arg1.get_first_use().is_none());
     assert!(arg2.get_first_use().is_none());
 
-    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    let f32_val = f32_type.const_float(std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     #[cfg(any(
@@ -569,16 +569,16 @@ fn test_mem_instructions() {
     let load = builder.build_load(f32_type, arg1, "").unwrap();
     let load_instruction = load.as_instruction_value().unwrap();
 
-    assert_eq!(store_instruction.get_volatile().unwrap(), false);
-    assert_eq!(load_instruction.get_volatile().unwrap(), false);
+    assert!(!store_instruction.get_volatile().unwrap());
+    assert!(!load_instruction.get_volatile().unwrap());
     store_instruction.set_volatile(true).unwrap();
     load_instruction.set_volatile(true).unwrap();
-    assert_eq!(store_instruction.get_volatile().unwrap(), true);
-    assert_eq!(load_instruction.get_volatile().unwrap(), true);
+    assert!(store_instruction.get_volatile().unwrap());
+    assert!(load_instruction.get_volatile().unwrap());
     store_instruction.set_volatile(false).unwrap();
     load_instruction.set_volatile(false).unwrap();
-    assert_eq!(store_instruction.get_volatile().unwrap(), false);
-    assert_eq!(load_instruction.get_volatile().unwrap(), false);
+    assert!(!store_instruction.get_volatile().unwrap());
+    assert!(!load_instruction.get_volatile().unwrap());
 
     assert_eq!(store_instruction.get_alignment().unwrap(), 4);
     assert_eq!(load_instruction.get_alignment().unwrap(), 4);
@@ -640,7 +640,7 @@ fn test_atomic_ordering_mem_instructions() {
     assert!(arg1.get_first_use().is_none());
     assert!(arg2.get_first_use().is_none());
 
-    let f32_val = f32_type.const_float(::std::f64::consts::PI);
+    let f32_val = f32_type.const_float(std::f64::consts::PI);
 
     let store_instruction = builder.build_store(arg1, f32_val).unwrap();
     #[cfg(any(
@@ -774,7 +774,7 @@ fn test_find_instruction_with_name() {
     builder.position_at_end(entry);
 
     let var = builder.build_alloca(i32_type, "some_number").unwrap();
-    builder.build_store(var, i32_type.const_int(1 as u64, false)).unwrap();
+    builder.build_store(var, i32_type.const_int(1, false)).unwrap();
     builder.build_return(None).unwrap();
 
     let block = fn_value.get_first_basic_block().unwrap();
@@ -878,7 +878,6 @@ fn test_or_disjoint_flag() {
 
     let void_type = context.void_type();
     let i32_type = context.i32_type();
-    let f32_type = context.f32_type();
     let fn_type = void_type.fn_type(&[i32_type.into(), i32_type.into()], false);
 
     let builder = context.create_builder();

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -259,12 +259,10 @@ fn test_parse_from_buffer() {
 fn test_parse_from_path() {
     let context = Context::create();
     let garbage_path = Path::new("foo/bar");
-    let module_result = Module::parse_bitcode_from_path(&garbage_path, &context);
-
+    let module_result = Module::parse_bitcode_from_path(garbage_path, &context);
     assert!(module_result.is_err(), "1");
 
-    let module_result2 = Module::parse_bitcode_from_path(&garbage_path, &context);
-
+    let module_result2 = Module::parse_bitcode_from_path(garbage_path, &context);
     assert!(module_result2.is_err(), "2");
 
     let module = context.create_module("mod");
@@ -457,7 +455,7 @@ fn test_metadata_flags() {
         assert!(module.get_flag("some_key").is_some());
 
         let f64_type = context.f64_type();
-        let f64_val = f64_type.const_float(3.14);
+        let f64_val = f64_type.const_float(std::f64::consts::PI);
 
         assert!(module.get_flag("some_key2").is_none());
 

--- a/tests/all/test_object_file.rs
+++ b/tests/all/test_object_file.rs
@@ -19,7 +19,7 @@ fn ptr_sized_int_type<'ctx>(target_machine: &TargetMachine, context: &'ctx Conte
     context.ptr_sized_int_type(&target_data, None)
 }
 #[llvm_versions(4.0..=latest)]
-fn apply_target_to_module<'ctx>(target_machine: &TargetMachine, module: &Module) {
+fn apply_target_to_module(target_machine: &TargetMachine, module: &Module) {
     module.set_triple(&target_machine.get_triple());
     module.set_data_layout(&target_machine.get_target_data().get_data_layout());
 }
@@ -54,7 +54,7 @@ fn test_section_iterator() {
     let target_machine = get_native_target_machine();
 
     let context = Context::create();
-    let mut module = context.create_module("test_section_iterator");
+    let module = context.create_module("test_section_iterator");
 
     let gv_a = module.add_global(context.i8_type(), None, "a");
     gv_a.set_initializer(&context.i8_type().const_zero().as_basic_value_enum());
@@ -91,7 +91,7 @@ fn test_section_iterator() {
     apply_target_to_module(&target_machine, &module);
 
     let memory_buffer = target_machine
-        .write_to_memory_buffer(&mut module, FileType::Object)
+        .write_to_memory_buffer(&module, FileType::Object)
         .unwrap();
     let object_file = memory_buffer.create_object_file().unwrap();
 
@@ -138,7 +138,7 @@ fn test_symbol_iterator() {
     let target_machine = get_native_target_machine();
 
     let context = Context::create();
-    let mut module = context.create_module("test_symbol_iterator");
+    let module = context.create_module("test_symbol_iterator");
     module
         .add_global(context.i8_type(), None, "a")
         .set_initializer(&context.i8_type().const_zero().as_basic_value_enum());
@@ -151,7 +151,7 @@ fn test_symbol_iterator() {
     apply_target_to_module(&target_machine, &module);
 
     let memory_buffer = target_machine
-        .write_to_memory_buffer(&mut module, FileType::Object)
+        .write_to_memory_buffer(&module, FileType::Object)
         .unwrap();
     let object_file = memory_buffer.create_object_file().unwrap();
 
@@ -193,7 +193,7 @@ fn test_reloc_iterator() {
     let context = Context::create();
     let intptr_t = ptr_sized_int_type(&target_machine, &context);
 
-    let mut module = context.create_module("test_reloc_iterator");
+    let module = context.create_module("test_reloc_iterator");
     let x_ptr = module.add_global(context.i8_type(), None, "x").as_pointer_value();
     let x_plus_4 = x_ptr.const_to_int(intptr_t).const_add(intptr_t.const_int(4, false));
     module.add_global(intptr_t, None, "a").set_initializer(&x_plus_4);
@@ -201,7 +201,7 @@ fn test_reloc_iterator() {
     apply_target_to_module(&target_machine, &module);
 
     let memory_buffer = target_machine
-        .write_to_memory_buffer(&mut module, FileType::Object)
+        .write_to_memory_buffer(&module, FileType::Object)
         .unwrap();
     let object_file = memory_buffer.create_object_file().unwrap();
 
@@ -220,7 +220,7 @@ fn test_section_contains_nul() {
     let target_machine = get_native_target_machine();
 
     let context = Context::create();
-    let mut module = context.create_module("test_section_iterator");
+    let module = context.create_module("test_section_iterator");
 
     let gv = module.add_global(context.i32_type(), None, "gv");
     gv.set_initializer(&context.i32_type().const_int(0xff0000ff, false).as_basic_value_enum());
@@ -229,7 +229,7 @@ fn test_section_contains_nul() {
     apply_target_to_module(&target_machine, &module);
 
     let memory_buffer = target_machine
-        .write_to_memory_buffer(&mut module, FileType::Object)
+        .write_to_memory_buffer(&module, FileType::Object)
         .unwrap();
     let object_file = memory_buffer.create_object_file().unwrap();
 

--- a/tests/all/test_targets.rs
+++ b/tests/all/test_targets.rs
@@ -184,7 +184,7 @@ fn test_default_triple() {
     let default_triple = default_triple.as_str().to_string_lossy();
 
     let archs = ["x86_64", "arm64"];
-    let has_known_arch = archs.iter().find(|arch| default_triple.starts_with(*arch)).is_some();
+    let has_known_arch = archs.iter().any(|arch| default_triple.starts_with(*arch));
     assert!(has_known_arch, "Target triple '{default_triple}' has unknown arch");
 
     let vendors = if cfg!(target_os = "linux") {
@@ -195,7 +195,7 @@ fn test_default_triple() {
         vec![]
     };
 
-    let has_known_vendor = vendors.iter().find(|vendor| default_triple.contains(*vendor)).is_some();
+    let has_known_vendor = vendors.iter().any(|vendor| default_triple.contains(*vendor));
     assert!(has_known_vendor, "Target triple '{default_triple}' has unknown vendor");
 
     let os = [
@@ -204,7 +204,7 @@ fn test_default_triple() {
         #[cfg(target_os = "macos")]
         "darwin",
     ];
-    let has_known_os = os.iter().find(|os| default_triple.contains(*os)).is_some();
+    let has_known_os = os.iter().any(|os| default_triple.contains(*os));
     assert!(has_known_os, "Target triple '{default_triple}' has unknown OS");
 
     // TODO: CFG for other supported major OSes
@@ -310,7 +310,7 @@ fn test_target_data() {
     assert_eq!(target_data.element_at_offset(&struct_type, 16), 2);
     assert_eq!(target_data.element_at_offset(&struct_type, 24), 3);
     assert_eq!(target_data.element_at_offset(&struct_type, 32), 3); // OoB
-    assert_eq!(target_data.element_at_offset(&struct_type, ::std::u64::MAX), 3); // OoB; Odd as it seems to cap at max element number
+    assert_eq!(target_data.element_at_offset(&struct_type, u64::MAX), 3); // OoB; Odd as it seems to cap at max element number
 
     assert_eq!(target_data.offset_of_element(&struct_type2, 0), Some(0));
     assert_eq!(target_data.offset_of_element(&struct_type2, 1), Some(4));
@@ -325,7 +325,7 @@ fn test_target_data() {
     assert_eq!(target_data.element_at_offset(&struct_type2, 8), 2);
     assert_eq!(target_data.element_at_offset(&struct_type2, 16), 3);
     assert_eq!(target_data.element_at_offset(&struct_type2, 32), 3); // OoB
-    assert_eq!(target_data.element_at_offset(&struct_type2, ::std::u64::MAX), 3); // OoB; TODOC: Odd but seems to cap at max element number
+    assert_eq!(target_data.element_at_offset(&struct_type2, u64::MAX), 3); // OoB; TODOC: Odd but seems to cap at max element number
 
     TargetData::create("e-m:e-i64:64-f80:128-n8:16:32:64-S128");
 }

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -472,7 +472,7 @@ fn test_ptr_type() {
         feature = "llvm13-0",
         feature = "llvm14-0"
     ))]
-    assert_eq!(ptr_type.get_element_type().into_int_type(), i8_type);
+    assert_eq!(ptr_type.get_element_type().into_int_type(), context.i8_type());
 
     // Fn ptr:
     let void_type = context.void_type();

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -556,7 +556,7 @@ fn test_no_vector_zero() {
 fn test_ptr_address_space() {
     let context = Context::create();
 
-    let spaces = [0u32, 1, 2, 3, 4, 5, 6, 1 << 24 - 1];
+    let spaces = [0u32, 1, 2, 3, 4, 5, 6, (1 << 24) - 1];
 
     for index in spaces {
         let address_space = AddressSpace::try_from(index).unwrap();

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -207,22 +207,30 @@ fn sized_types(global_ctx: &Context) {
     assert!(!fn_type3.is_sized());
     assert!(!fn_type4.is_sized());
 
-    assert!(bool_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(i8_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(i16_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(i32_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(i64_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(i128_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(f16_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(f32_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(f64_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(f80_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(f128_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(ppc_f128_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(struct_type.ptr_type(AddressSpace::default()).is_sized());
-    assert!(struct_type2.ptr_type(AddressSpace::default()).is_sized());
-    assert!(struct_type3.ptr_type(AddressSpace::default()).is_sized());
-    assert!(struct_type4.ptr_type(AddressSpace::default()).is_sized());
+    #[cfg(not(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    )))]
+    {
+        assert!(bool_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(i8_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(i16_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(i32_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(i64_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(i128_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(f16_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(f32_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(f64_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(f80_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(f128_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(ppc_f128_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(struct_type.ptr_type(AddressSpace::default()).is_sized());
+        assert!(struct_type2.ptr_type(AddressSpace::default()).is_sized());
+        assert!(struct_type3.ptr_type(AddressSpace::default()).is_sized());
+        assert!(struct_type4.ptr_type(AddressSpace::default()).is_sized());
+    }
 
     assert!(bool_type.array_type(42).is_sized());
     assert!(i8_type.array_type(42).is_sized());
@@ -271,8 +279,18 @@ fn sized_types(global_ctx: &Context) {
     let opaque_struct_type = global_ctx.opaque_struct_type("opaque");
 
     assert!(!opaque_struct_type.is_sized());
-    assert!(opaque_struct_type.ptr_type(AddressSpace::default()).is_sized());
     assert!(!opaque_struct_type.array_type(0).is_sized());
+
+    #[cfg(not(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    )))]
+    {
+        let opaque_struct_ptr_type = opaque_struct_type.ptr_type(AddressSpace::default());
+        assert!(opaque_struct_ptr_type.is_sized());
+    }
 }
 
 #[test]
@@ -424,14 +442,13 @@ fn test_type_copies() {
 #[test]
 fn test_ptr_type() {
     let context = Context::create();
-    let i8_type = context.i8_type();
     #[cfg(not(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
         feature = "llvm17-0",
         feature = "llvm18-0"
     )))]
-    let ptr_type = i8_type.ptr_type(AddressSpace::default());
+    let ptr_type = context.i8_type().ptr_type(AddressSpace::default());
     #[cfg(any(
         feature = "llvm15-0",
         feature = "llvm16-0",
@@ -460,6 +477,7 @@ fn test_ptr_type() {
     // Fn ptr:
     let void_type = context.void_type();
     let fn_type = void_type.fn_type(&[], false);
+    #[allow(deprecated)]
     let fn_ptr_type = fn_type.ptr_type(AddressSpace::default());
 
     #[cfg(any(
@@ -511,6 +529,12 @@ fn test_basic_type_enum() {
         &int.vec_type(1),
     ];
     for basic_type in types {
+        #[cfg(not(any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        )))]
         assert_eq!(
             basic_type.as_basic_type_enum().ptr_type(addr),
             basic_type.ptr_type(addr)
@@ -559,12 +583,13 @@ fn test_ptr_address_space() {
 
 #[llvm_versions(15.0..=latest)]
 #[test]
+#[allow(deprecated)]
 fn test_ptr_is_opaque() {
     let context = Context::create();
 
     let i32_ptr_type = context.i32_type().ptr_type(AddressSpace::default());
-    let ptr_type = context.ptr_type(AddressSpace::default());
-
     assert!(i32_ptr_type.is_opaque());
+
+    let ptr_type = context.ptr_type(AddressSpace::default());
     assert!(ptr_type.is_opaque());
 }

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -758,7 +758,7 @@ fn test_floats() {
         let f128_type = context.f128_type();
         let i64_type = context.i32_type();
 
-        let f64_pi = f64_type.const_float(::std::f64::consts::PI);
+        let f64_pi = f64_type.const_float(std::f64::consts::PI);
 
         let f32_pi = f64_pi.const_truncate(f32_type);
         let f128_pi = f64_pi.const_extend(f128_type);
@@ -1320,10 +1320,10 @@ fn test_consts() {
     assert!(vec_val.is_constant_data_vector());
 
     assert_eq!(bool_val.get_zero_extended_constant(), Some(1));
-    assert_eq!(i8_val.get_zero_extended_constant(), Some(u8::max_value() as u64));
-    assert_eq!(i16_val.get_zero_extended_constant(), Some(u16::max_value() as u64));
-    assert_eq!(i32_val.get_zero_extended_constant(), Some(u32::max_value() as u64));
-    assert_eq!(i64_val.get_zero_extended_constant(), Some(u64::max_value() as u64));
+    assert_eq!(i8_val.get_zero_extended_constant(), Some(u8::MAX as u64));
+    assert_eq!(i16_val.get_zero_extended_constant(), Some(u16::MAX as u64));
+    assert_eq!(i32_val.get_zero_extended_constant(), Some(u32::MAX as u64));
+    assert_eq!(i64_val.get_zero_extended_constant(), Some(u64::MAX));
     assert_eq!(i128_val.get_zero_extended_constant(), None);
 
     assert_eq!(bool_val.get_sign_extended_constant(), Some(-1));

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -3,8 +3,8 @@ use inkwell::attributes::AttributeLoc;
 use inkwell::comdat::ComdatSelectionKind;
 use inkwell::context::Context;
 use inkwell::module::Linkage::*;
-use inkwell::types::{AnyTypeEnum, BasicType, StringRadix, VectorType};
-use inkwell::values::{AnyValue, BasicValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
+use inkwell::types::{AnyTypeEnum, StringRadix, VectorType};
+use inkwell::values::{AnyValue, InstructionOpcode::*, FIRST_CUSTOM_METADATA_KIND_ID};
 use inkwell::{AddressSpace, DLLStorageClass, GlobalVisibility, ThreadLocalMode};
 
 #[llvm_versions(18.0..=latest)]
@@ -1478,7 +1478,9 @@ fn test_non_fn_ptr_called() {
         feature = "llvm17-0",
         feature = "llvm18-0"
     ))]
-    builder.build_indirect_call(i8_ptr_type.fn_type(&[], false), i8_ptr_param, &[], "call");
+    builder
+        .build_indirect_call(i8_ptr_type.fn_type(&[], false), i8_ptr_param, &[], "call")
+        .unwrap();
     builder.build_return(None).unwrap();
 
     assert!(module.verify().is_ok());
@@ -1562,7 +1564,9 @@ fn test_aggregate_returns() {
         feature = "llvm17-0",
         feature = "llvm18-0"
     ))]
-    builder.build_ptr_diff(i32_ptr_type, ptr_param1, ptr_param2, "diff");
+    builder
+        .build_ptr_diff(i32_ptr_type, ptr_param1, ptr_param2, "diff")
+        .unwrap();
     builder
         .build_aggregate_return(&[i32_three.into(), i32_seven.into()])
         .unwrap();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
Fix rustc and clippy warnings, mostly automated with `cargo clippy --fix`.

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
`cargo clippy --all-targets` on the latest few LLVM versions.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
