### PR TITLE
Fix compilation on MacOS

### DIFF
--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -219,11 +219,11 @@ impl<'ctx> Value<'ctx> {
         #[cfg(target_os = "macos")]
         let section = section.map(|s| {
             if s.contains(",") {
-                format!("{}", s).as_str()
+                format!("{}", s)
             } else {
-                format!(",{}", s).as_str()
+                format!(",{}", s)
             }
-        });
+        }).as_deref();
 
         let c_string = section.map(to_c_str);
 

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -219,9 +219,9 @@ impl<'ctx> Value<'ctx> {
         #[cfg(target_os = "macos")]
         let section = section.map(|s| {
             if s.contains(",") {
-                format!("{}", s)
+                format!("{}", s).as_str()
             } else {
-                format!(",{}", s)
+                format!(",{}", s).as_str()
             }
         });
 

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -217,13 +217,15 @@ impl<'ctx> Value<'ctx> {
     /// Sets the section of the global value
     fn set_section(self, section: Option<&str>) {
         #[cfg(target_os = "macos")]
-        let section = section.map(|s| {
+        let mapped_section = section.map(|s| {
             if s.contains(",") {
                 format!("{}", s)
             } else {
                 format!(",{}", s)
             }
-        }).as_deref();
+        });
+        #[cfg(target_os = "macos")]
+        let section = mapped_section.as_deref();
 
         let c_string = section.map(to_c_str);
 


### PR DESCRIPTION
## Description

Simply fixes the conditional compilation code inside values/mod.rs to correctly use the &str type instead of String

## Related Issue
#497 

## How This Has Been Tested
Code was built on a MacOS x86_64 and MacOS Aarch64 machine (13.0 and 13.4) using github actions

On a side note, it may be wise to setup actions to automatically build the project to prevent issues like this.

There hasn't been any testing of the specific section function, but any issues after this change will have existed beforehand, all this change does it fix the compiler error.

## Checklist
- [x ] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
