### PR TITLE
doc: amend README with git dep for LLVM 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ You'll need to point your Cargo.toml to use a single LLVM version feature flag c
 
 ```toml
 [dependencies]
-inkwell = { version = "0.4.0", features = ["llvm18-0"] }
+inkwell = { version = "0.4.0", features = ["llvm17-0"] }
+```
+
+Since support for LLVM 18 is unreleased yet, you'd have to specify the crate as git dependency in your Cargo.toml:
+
+```toml
+[dependencies]
+inkwell = { git = "https://github.com/TheDan64/inkwell", features = ["llvm18-0"] }
 ```
 
 Supported versions:


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Amend the README `Usage` section with a comment that crates targeting llvm 18 should use git dependency instead. Had to quickly dig through the PRs to discover that support for llvm 18 has not been release yet.

With that said, @TheDan64 what is the plan wrt the next release?

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
