### PR TITLE
expose functions for working with LLVMContextRef for interoperability with other libraries

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -419,11 +419,9 @@ unsafe impl Send for Context {}
 impl Context {
     /// Get raw [`LLVMContextRef`].
     ///
-    /// # Safety
-    ///
     /// This function is exposed only for interoperability with other LLVM IR libraries.
-    /// It's not intended to be used by most users, hence marked as unsafe.
-    pub unsafe fn raw(&self) -> LLVMContextRef {
+    /// It's not intended to be used by most users.
+    pub fn raw(&self) -> LLVMContextRef {
         self.context.0
     }
 
@@ -1340,11 +1338,9 @@ pub struct ContextRef<'ctx> {
 impl<'ctx> ContextRef<'ctx> {
     /// Get raw [`LLVMContextRef`].
     ///
-    /// # Safety
-    ///
     /// This function is exposed only for interoperability with other LLVM IR libraries.
-    /// It's not intended to be used by most users, hence marked as unsafe.
-    pub unsafe fn raw(&self) -> LLVMContextRef {
+    /// It's not intended to be used by most users.
+    pub fn raw(&self) -> LLVMContextRef {
         self.context.0
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -417,7 +417,24 @@ pub struct Context {
 unsafe impl Send for Context {}
 
 impl Context {
-    pub(crate) unsafe fn new(context: LLVMContextRef) -> Self {
+    /// Get raw [`LLVMContextRef`].
+    ///
+    /// # Safety
+    ///
+    /// This function is exposed only for interoperability with other LLVM IR libraries.
+    /// It's not intended to be used by most users, hence marked as unsafe.
+    pub unsafe fn raw(&self) -> LLVMContextRef {
+        self.context.0
+    }
+
+    /// Creates a new `Context` from [`LLVMContextRef`].
+    ///
+    /// # Safety
+    ///
+    /// This function is exposed only for interoperability with other LLVM IR libraries.
+    /// It's not intended to be used by most users, hence marked as unsafe.
+    /// Use [`Context::create`] instead.
+    pub unsafe fn new(context: LLVMContextRef) -> Self {
         Context {
             context: ContextImpl::new(context),
         }
@@ -1321,7 +1338,23 @@ pub struct ContextRef<'ctx> {
 }
 
 impl<'ctx> ContextRef<'ctx> {
-    pub(crate) unsafe fn new(context: LLVMContextRef) -> Self {
+    /// Get raw [`LLVMContextRef`].
+    ///
+    /// # Safety
+    ///
+    /// This function is exposed only for interoperability with other LLVM IR libraries.
+    /// It's not intended to be used by most users, hence marked as unsafe.
+    pub unsafe fn raw(&self) -> LLVMContextRef {
+        self.context.0
+    }
+
+    /// Creates a new `ContextRef` from [`LLVMContextRef`].
+    ///
+    /// # Safety
+    ///
+    /// This function is exposed only for interoperability with other LLVM IR libraries.
+    /// It's not intended to be used by most users, hence marked as unsafe.
+    pub unsafe fn new(context: LLVMContextRef) -> Self {
         ContextRef {
             context: ContextImpl::new(context),
             _marker: PhantomData,


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

This makes some functions in Context and ContextRef `pub` instead of `pub(crate)`. 
Also adds getter for raw LLVMContextRef

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tested with llvm18-0 in my code that uses `melior`, `mlir-sys` and `inkwell` together.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
