### PR TITLE
Marked const_float_from_string as unsafe. Fixes #513

### DIFF
--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -871,26 +871,24 @@ fn test_value_from_string() {
 
     // Floats
     let f64_type = context.f64_type();
-    let f64_val = f64_type.const_float_from_string("3.6");
+    let f64_val = unsafe { f64_type.const_float_from_string("3.6") };
 
     assert_eq!(f64_val.print_to_string().to_string(), "double 3.600000e+00");
 
-    let f64_val = f64_type.const_float_from_string("3.");
+    let f64_val = unsafe { f64_type.const_float_from_string("3.") };
 
     assert_eq!(f64_val.print_to_string().to_string(), "double 3.000000e+00");
 
-    let f64_val = f64_type.const_float_from_string("3");
+    let f64_val = unsafe { f64_type.const_float_from_string("3") };
 
     assert_eq!(f64_val.print_to_string().to_string(), "double 3.000000e+00");
 
-    let f64_val = f64_type.const_float_from_string("");
-
-    assert_eq!(f64_val.print_to_string().to_string(), "double 0.000000e+00");
-
-    // TODO: We should return a Result that returns Err here.
-    //let f64_val = f64_type.const_float_from_string("3.asd");
+    // TODO: We should return a Result that returns Err here. This would require
+    // us to implement manual validation of the input to assert it matched LLVM's
+    // expected format.
+    // let f64_val = f64_type.const_float_from_string("3.asd");
     //
-    //assert_eq!(f64_val.print_to_string().to_string(), "double 0x7FF0000000000000");
+    // assert_eq!(f64_val.print_to_string().to_string(), "double 0x7FF0000000000000");
 }
 
 #[test]


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Marks the const_float_from_string method as unsafe and adds an assertion that the string isn't empty

## Related Issue

#513 

## How This Has Been Tested

Locally w/ LLVM 17

## Option\<Breaking Changes\>

The method is now unsafe, an assertion triggers on empty string rather than UB.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
