### PR TITLE
module: make write_bitcode_to_path accept more general path representations

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -648,16 +648,16 @@ impl<'ctx> Module<'ctx> {
         unsafe { GlobalValue::new(value) }
     }
 
-    /// Writes a `Module` to a `Path`.
+    /// Writes a `Module` to a file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - path to write the module's bitcode to. Must be valid Unicode.
     ///
     /// # Example
     ///
     /// ```no_run
     /// use inkwell::context::Context;
-    ///
-    /// use std::path::Path;
-    ///
-    /// let mut path = Path::new("module.bc");
     ///
     /// let context = Context::create();
     /// let module = context.create_module("my_module");
@@ -665,10 +665,13 @@ impl<'ctx> Module<'ctx> {
     /// let fn_type = void_type.fn_type(&[], false);
     ///
     /// module.add_function("my_fn", fn_type, None);
-    /// module.write_bitcode_to_path(&path);
+    /// module.write_bitcode_to_path("module.bc");
     /// ```
-    pub fn write_bitcode_to_path(&self, path: &Path) -> bool {
-        let path_str = path.to_str().expect("Did not find a valid Unicode path string");
+    pub fn write_bitcode_to_path(&self, path: impl AsRef<Path>) -> bool {
+        let path_str = path
+            .as_ref()
+            .to_str()
+            .expect("Did not find a valid Unicode path string");
         let c_string = to_c_str(path_str);
 
         unsafe { LLVMWriteBitcodeToFile(self.module.get(), c_string.as_ptr()) == 0 }

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -6,8 +6,7 @@ use inkwell::values::AnyValue;
 use inkwell::OptimizationLevel;
 
 use std::env::temp_dir;
-use std::fs::{remove_file, File};
-use std::io::Read;
+use std::fs::{self, remove_file};
 use std::path::Path;
 
 #[test]
@@ -24,11 +23,7 @@ fn test_write_bitcode_to_path() {
     module.add_function("my_fn", fn_type, None);
     module.write_bitcode_to_path(&path);
 
-    let mut contents = Vec::new();
-    let mut file = File::open(&path).expect("Could not open temp file");
-
-    file.read_to_end(&mut contents).expect("Unable to verify written file");
-
+    let contents = fs::read(&path).expect("Could not read back written file.");
     assert!(!contents.is_empty());
 
     remove_file(&path).unwrap();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Change the function `Module::write_bitcode_to_path` to accept a `AsRef<Path>` argument instead of `&Path`. This allows passing e.g. string slices instead of explicitly building the `Path` instance, and matches functions in `std::fs`.

Since `&Path` is `AsRef<Path>`, the change is backwards compatible.

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

- Adapted the example in the docstring
- The tests checks passing an explicit `Path`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
