### PR TITLE
Fix null-terminated strings in LLVMSetValueName2 and LLVMMDStringInContext

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -481,7 +481,7 @@ impl<'ctx> BasicBlock<'ctx> {
         {
             use llvm_sys::core::LLVMSetValueName2;
 
-            unsafe { LLVMSetValueName2(LLVMBasicBlockAsValue(self.basic_block), c_string.as_ptr(), name.len()) };
+            unsafe { LLVMSetValueName2(LLVMBasicBlockAsValue(self.basic_block), c_string.as_ptr(), c_string.to_bytes().len()) };
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -345,7 +345,7 @@ impl ContextImpl {
     fn metadata_string<'ctx>(&self, string: &str) -> MetadataValue<'ctx> {
         let c_string = to_c_str(string);
 
-        unsafe { MetadataValue::new(LLVMMDStringInContext(self.0, c_string.as_ptr(), string.len() as u32)) }
+        unsafe { MetadataValue::new(LLVMMDStringInContext(self.0, c_string.as_ptr(), c_string.to_bytes().len() as u32)) }
     }
 
     fn get_kind_id(&self, key: &str) -> u32 {

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -132,7 +132,7 @@ impl<'ctx> Value<'ctx> {
         {
             use llvm_sys::core::LLVMSetValueName2;
 
-            unsafe { LLVMSetValueName2(self.value, c_string.as_ptr(), name.len()) }
+            unsafe { LLVMSetValueName2(self.value, c_string.as_ptr(), c_string.to_bytes().len()) }
         }
     }
 


### PR DESCRIPTION

## Description

Omit terminating NULL when passing strings to LLVMSetValueName2(...) and LLVMMDStringInContext(...)

## Related Issue

https://github.com/TheDan64/inkwell/issues/533

## How This Has Been Tested

I tried the PR in my codebase


## Checklist

- [ x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
