### PR TITLE
wrapper for LLVMBuildBinOp

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,7 @@ use llvm_sys::core::LLVMBuildCallWithOperandBundles;
 use llvm_sys::core::{
     LLVMAddCase, LLVMAddClause, LLVMAddDestination, LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast,
     LLVMBuildAggregateRet, LLVMBuildAlloca, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildArrayMalloc,
-    LLVMBuildAtomicCmpXchg, LLVMBuildAtomicRMW, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCast, LLVMBuildCondBr,
+    LLVMBuildAtomicCmpXchg, LLVMBuildAtomicRMW, LLVMBuildBinOp, LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCast, LLVMBuildCondBr,
     LLVMBuildExactSDiv, LLVMBuildExtractElement, LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv,
     LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFPCast, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc,
     LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFence, LLVMBuildFree, LLVMBuildGlobalString, LLVMBuildGlobalStringPtr,
@@ -2620,6 +2620,16 @@ impl<'ctx> Builder<'ctx> {
         let value = unsafe { LLVMBuildFMul(self.builder, lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr()) };
 
         unsafe { Ok(T::new(value)) }
+    }
+
+    pub fn build_binop<T: BasicValue<'ctx>>(&self, op: InstructionOpcode, lhs: T, rhs: T, name: &str) -> Result<BasicValueEnum, BuilderError> {
+        if self.positioned.get() != PositionState::Set {
+            return Err(BuilderError::UnsetPosition);
+        }
+        let c_string = to_c_str(name);
+        let value = unsafe { LLVMBuildBinOp(self.builder, op.into(), lhs.as_value_ref(), rhs.as_value_ref(), c_string.as_ptr()) };
+
+        unsafe { Ok(BasicValueEnum::new(value)) }
     }
 
     pub fn build_cast<T: BasicType<'ctx>, V: BasicValue<'ctx>>(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2622,7 +2622,7 @@ impl<'ctx> Builder<'ctx> {
         unsafe { Ok(T::new(value)) }
     }
 
-    pub fn build_binop<T: BasicValue<'ctx>>(&self, op: InstructionOpcode, lhs: T, rhs: T, name: &str) -> Result<BasicValueEnum, BuilderError> {
+    pub fn build_binop<T: BasicValue<'ctx>>(&self, op: InstructionOpcode, lhs: T, rhs: T, name: &str) -> Result<BasicValueEnum<'ctx>, BuilderError> {
         if self.positioned.get() != PositionState::Set {
             return Err(BuilderError::UnsetPosition);
         }


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description
creates a wrapper for `LLVMBuildBinOp`
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/TheDan64/inkwell/issues/538

## How This Has Been Tested
Locally with llvm18, it should exist in all llvm versions
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
