### PR TITLE
Add scalable vector

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -51,7 +51,7 @@ use crate::values::CallableValue;
 use crate::values::{
     AggregateValue, AggregateValueEnum, AsValueRef, BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallSiteValue,
     FloatMathValue, FunctionValue, GlobalValue, InstructionOpcode, InstructionValue, IntMathValue, IntValue, PhiValue,
-    PointerMathValue, PointerValue, StructValue, VectorValue,
+    PointerMathValue, PointerValue, StructValue, VectorBaseValue,
 };
 
 use crate::{AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate};
@@ -3054,9 +3054,9 @@ impl<'ctx> Builder<'ctx> {
     ///
     /// builder.build_return(Some(&extracted)).unwrap();
     /// ```
-    pub fn build_extract_element(
+    pub fn build_extract_element<V: VectorBaseValue<'ctx>>(
         &self,
-        vector: VectorValue<'ctx>,
+        vector: V,
         index: IntValue<'ctx>,
         name: &str,
     ) -> Result<BasicValueEnum<'ctx>, BuilderError> {
@@ -3102,13 +3102,13 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_insert_element(vector_param, i32_seven, i32_zero, "insert").unwrap();
     /// builder.build_return(None).unwrap();
     /// ```
-    pub fn build_insert_element<V: BasicValue<'ctx>>(
+    pub fn build_insert_element<V: BasicValue<'ctx>, W: VectorBaseValue<'ctx>>(
         &self,
-        vector: VectorValue<'ctx>,
+        vector: W,
         element: V,
         index: IntValue<'ctx>,
         name: &str,
-    ) -> Result<VectorValue<'ctx>, BuilderError> {
+    ) -> Result<W, BuilderError> {
         if self.positioned.get() != PositionState::Set {
             return Err(BuilderError::UnsetPosition);
         }
@@ -3124,7 +3124,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        unsafe { Ok(VectorValue::new(value)) }
+        unsafe { Ok(W::new(value)) }
     }
 
     pub fn build_unreachable(&self) -> Result<InstructionValue<'ctx>, BuilderError> {
@@ -3319,13 +3319,13 @@ impl<'ctx> Builder<'ctx> {
     }
 
     // REVIEW: Do we need to constrain types here? subtypes?
-    pub fn build_shuffle_vector(
+    pub fn build_shuffle_vector<V: VectorBaseValue<'ctx>>(
         &self,
-        left: VectorValue<'ctx>,
-        right: VectorValue<'ctx>,
-        mask: VectorValue<'ctx>,
+        left: V,
+        right: V,
+        mask: V,
         name: &str,
-    ) -> Result<VectorValue<'ctx>, BuilderError> {
+    ) -> Result<V, BuilderError> {
         if self.positioned.get() != PositionState::Set {
             return Err(BuilderError::UnsetPosition);
         }
@@ -3340,7 +3340,7 @@ impl<'ctx> Builder<'ctx> {
             )
         };
 
-        unsafe { Ok(VectorValue::new(value)) }
+        unsafe { Ok(V::new(value)) }
     }
 
     // REVIEW: Is return type correct?

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -462,7 +462,9 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm17-0",
                 feature = "llvm18-0"
             ))]
-            LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::ScalableVectorType(ScalableVectorType::new(type_)),
+            LLVMTypeKind::LLVMScalableVectorTypeKind => {
+                BasicTypeEnum::ScalableVectorType(ScalableVectorType::new(type_))
+            },
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Unsupported basic type: Metadata"),
             // see https://llvm.org/docs/LangRef.html#x86-mmx-type
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("Unsupported basic type: MMX"),
@@ -533,7 +535,7 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             panic!("Found {:?} but expected the VectorType variant", self);
         }
     }
-    
+
     pub fn into_scalable_vector_type(self) -> ScalableVectorType<'ctx> {
         if let BasicTypeEnum::ScalableVectorType(t) = self {
             t

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -5,7 +5,9 @@ use llvm_sys::LLVMTypeKind;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 use crate::types::MetadataType;
-use crate::types::{ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, VectorType, VoidType};
+use crate::types::{
+    ArrayType, FloatType, FunctionType, IntType, PointerType, ScalableVectorType, StructType, VectorType, VoidType,
+};
 use crate::values::{BasicValue, BasicValueEnum, IntValue};
 
 use std::convert::TryFrom;
@@ -70,6 +72,8 @@ enum_type_set! {
         StructType,
         /// A contiguous homogeneous "SIMD" container type.
         VectorType,
+        /// A contiguous homogenous scalable "SIMD" container type.
+        ScalableVectorType,
         /// A valueless type.
         VoidType,
     }
@@ -89,6 +93,8 @@ enum_type_set! {
         StructType,
         /// A contiguous homogeneous "SIMD" container type.
         VectorType,
+        /// A contiguous homogenous scalable "SIMD" container type.
+        ScalableVectorType,
     }
 }
 enum_type_set! {
@@ -99,6 +105,7 @@ enum_type_set! {
         PointerType,
         StructType,
         VectorType,
+        ScalableVectorType,
         MetadataType,
     }
 }
@@ -152,6 +159,14 @@ impl<'ctx> BasicMetadataTypeEnum<'ctx> {
         }
     }
 
+    pub fn into_scalable_vector_type(self) -> ScalableVectorType<'ctx> {
+        if let BasicMetadataTypeEnum::ScalableVectorType(t) = self {
+            t
+        } else {
+            panic!("Found {:?} but expected another variant", self);
+        }
+    }
+
     pub fn into_metadata_type(self) -> MetadataType<'ctx> {
         if let BasicMetadataTypeEnum::MetadataType(t) = self {
             t
@@ -188,6 +203,10 @@ impl<'ctx> BasicMetadataTypeEnum<'ctx> {
         matches!(self, BasicMetadataTypeEnum::VectorType(_))
     }
 
+    pub fn is_scalable_vector_type(self) -> bool {
+        matches!(self, BasicMetadataTypeEnum::ScalableVectorType(_))
+    }
+
     /// Print the definition of a `BasicMetadataTypeEnum` to `LLVMString`.
     pub fn print_to_string(self) -> LLVMString {
         match self {
@@ -197,6 +216,7 @@ impl<'ctx> BasicMetadataTypeEnum<'ctx> {
             BasicMetadataTypeEnum::PointerType(t) => t.print_to_string(),
             BasicMetadataTypeEnum::StructType(t) => t.print_to_string(),
             BasicMetadataTypeEnum::VectorType(t) => t.print_to_string(),
+            BasicMetadataTypeEnum::ScalableVectorType(t) => t.print_to_string(),
             BasicMetadataTypeEnum::MetadataType(t) => t.print_to_string(),
         }
     }
@@ -244,7 +264,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
                 feature = "llvm17-0",
                 feature = "llvm18-0"
             ))]
-            LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::VectorType(VectorType::new(type_)),
+            LLVMTypeKind::LLVMScalableVectorTypeKind => AnyTypeEnum::ScalableVectorType(ScalableVectorType::new(type_)),
             // FIXME: should inkwell support metadata as AnyType?
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Metadata type is not supported as AnyType."),
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("FIXME: Unsupported type: MMX"),
@@ -325,6 +345,14 @@ impl<'ctx> AnyTypeEnum<'ctx> {
         }
     }
 
+    pub fn into_scalable_vector_type(self) -> ScalableVectorType<'ctx> {
+        if let AnyTypeEnum::ScalableVectorType(t) = self {
+            t
+        } else {
+            panic!("Found {:?} but expected the ScalableVectorType variant", self);
+        }
+    }
+
     pub fn into_void_type(self) -> VoidType<'ctx> {
         if let AnyTypeEnum::VoidType(t) = self {
             t
@@ -373,6 +401,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             AnyTypeEnum::PointerType(t) => Some(t.size_of()),
             AnyTypeEnum::StructType(t) => t.size_of(),
             AnyTypeEnum::VectorType(t) => t.size_of(),
+            AnyTypeEnum::ScalableVectorType(t) => t.size_of(),
             AnyTypeEnum::VoidType(_) => None,
             AnyTypeEnum::FunctionType(_) => None,
         }
@@ -387,6 +416,7 @@ impl<'ctx> AnyTypeEnum<'ctx> {
             AnyTypeEnum::PointerType(t) => t.print_to_string(),
             AnyTypeEnum::StructType(t) => t.print_to_string(),
             AnyTypeEnum::VectorType(t) => t.print_to_string(),
+            AnyTypeEnum::ScalableVectorType(t) => t.print_to_string(),
             AnyTypeEnum::VoidType(t) => t.print_to_string(),
             AnyTypeEnum::FunctionType(t) => t.print_to_string(),
         }
@@ -432,7 +462,7 @@ impl<'ctx> BasicTypeEnum<'ctx> {
                 feature = "llvm17-0",
                 feature = "llvm18-0"
             ))]
-            LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::VectorType(VectorType::new(type_)),
+            LLVMTypeKind::LLVMScalableVectorTypeKind => BasicTypeEnum::ScalableVectorType(ScalableVectorType::new(type_)),
             LLVMTypeKind::LLVMMetadataTypeKind => panic!("Unsupported basic type: Metadata"),
             // see https://llvm.org/docs/LangRef.html#x86-mmx-type
             LLVMTypeKind::LLVMX86_MMXTypeKind => panic!("Unsupported basic type: MMX"),
@@ -503,6 +533,14 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             panic!("Found {:?} but expected the VectorType variant", self);
         }
     }
+    
+    pub fn into_scalable_vector_type(self) -> ScalableVectorType<'ctx> {
+        if let BasicTypeEnum::ScalableVectorType(t) = self {
+            t
+        } else {
+            panic!("Found {:?} but expected the ScalableVectorType variant", self);
+        }
+    }
 
     pub fn is_array_type(self) -> bool {
         matches!(self, BasicTypeEnum::ArrayType(_))
@@ -528,6 +566,10 @@ impl<'ctx> BasicTypeEnum<'ctx> {
         matches!(self, BasicTypeEnum::VectorType(_))
     }
 
+    pub fn is_scalable_vector_type(self) -> bool {
+        matches!(self, BasicTypeEnum::ScalableVectorType(_))
+    }
+
     /// Creates a constant `BasicValueZero`.
     ///
     /// # Example
@@ -547,6 +589,7 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             BasicTypeEnum::PointerType(ty) => ty.const_zero().as_basic_value_enum(),
             BasicTypeEnum::StructType(ty) => ty.const_zero().as_basic_value_enum(),
             BasicTypeEnum::VectorType(ty) => ty.const_zero().as_basic_value_enum(),
+            BasicTypeEnum::ScalableVectorType(ty) => ty.const_zero().as_basic_value_enum(),
         }
     }
 
@@ -559,6 +602,7 @@ impl<'ctx> BasicTypeEnum<'ctx> {
             BasicTypeEnum::PointerType(t) => t.print_to_string(),
             BasicTypeEnum::StructType(t) => t.print_to_string(),
             BasicTypeEnum::VectorType(t) => t.print_to_string(),
+            BasicTypeEnum::ScalableVectorType(t) => t.print_to_string(),
         }
     }
 }
@@ -575,6 +619,7 @@ impl<'ctx> TryFrom<AnyTypeEnum<'ctx>> for BasicTypeEnum<'ctx> {
             PointerType(pt) => pt.into(),
             StructType(st) => st.into(),
             VectorType(vt) => vt.into(),
+            ScalableVectorType(vt) => vt.into(),
             VoidType(_) | FunctionType(_) => return Err(()),
         })
     }
@@ -592,6 +637,7 @@ impl<'ctx> TryFrom<AnyTypeEnum<'ctx>> for BasicMetadataTypeEnum<'ctx> {
             PointerType(pt) => pt.into(),
             StructType(st) => st.into(),
             VectorType(vt) => vt.into(),
+            ScalableVectorType(vt) => vt.into(),
             VoidType(_) | FunctionType(_) => return Err(()),
         })
     }
@@ -609,6 +655,7 @@ impl<'ctx> TryFrom<BasicMetadataTypeEnum<'ctx>> for BasicTypeEnum<'ctx> {
             PointerType(pt) => pt.into(),
             StructType(st) => st.into(),
             VectorType(vt) => vt.into(),
+            ScalableVectorType(vt) => vt.into(),
             MetadataType(_) => return Err(()),
         })
     }
@@ -624,6 +671,7 @@ impl<'ctx> From<BasicTypeEnum<'ctx>> for BasicMetadataTypeEnum<'ctx> {
             PointerType(pt) => pt.into(),
             StructType(st) => st.into(),
             VectorType(vt) => vt.into(),
+            ScalableVectorType(vt) => vt.into(),
         }
     }
 }

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -6,7 +6,7 @@ use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
+use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType, ScalableVectorType};
 use crate::values::{ArrayValue, FloatValue, GenericValue, IntValue};
 use crate::AddressSpace;
 
@@ -96,8 +96,8 @@ impl<'ctx> FloatType<'ctx> {
     /// assert_eq!(f32_vector_type.get_size(), 3);
     /// assert_eq!(f32_vector_type.get_element_type().into_float_type(), f32_type);
     /// ```
-    #[llvm_versions(11..)]
-    pub fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+    #[llvm_versions(12..)]
+    pub fn scalable_vec_type(self, size: u32) -> ScalableVectorType<'ctx> {
         self.float_type.scalable_vec_type(size)
     }
 

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -82,6 +82,25 @@ impl<'ctx> FloatType<'ctx> {
         self.float_type.vec_type(size)
     }
 
+    /// Creates a scalable `VectorType` with this `FloatType` for its element type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_vector_type = f32_type.scalable_vec_type(3);
+    ///
+    /// assert_eq!(f32_vector_type.get_size(), 3);
+    /// assert_eq!(f32_vector_type.get_element_type().into_float_type(), f32_type);
+    /// ```
+    #[llvm_versions(11..)]
+    pub fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+        self.float_type.scalable_vec_type(size)
+    }
+
     /// Creates a `FloatValue` representing a constant value of this `FloatType`.
     /// It will be automatically assigned this `FloatType`'s `Context`.
     ///

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -6,7 +6,7 @@ use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::enums::BasicMetadataTypeEnum;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType, ScalableVectorType};
+use crate::types::{ArrayType, FunctionType, PointerType, ScalableVectorType, Type, VectorType};
 use crate::values::{ArrayValue, FloatValue, GenericValue, IntValue};
 use crate::AddressSpace;
 
@@ -64,7 +64,7 @@ impl<'ctx> FloatType<'ctx> {
         self.float_type.array_type(size)
     }
 
-    /// Creates a `VectorType` with this `FloatType` for its element type.
+    /// Creates a `ScalableVectorType` with this `FloatType` for its element type.
     ///
     /// # Example
     ///
@@ -73,10 +73,10 @@ impl<'ctx> FloatType<'ctx> {
     ///
     /// let context = Context::create();
     /// let f32_type = context.f32_type();
-    /// let f32_vector_type = f32_type.vec_type(3);
+    /// let f32_scalable_vector_type = f32_type.vec_type(3);
     ///
-    /// assert_eq!(f32_vector_type.get_size(), 3);
-    /// assert_eq!(f32_vector_type.get_element_type().into_float_type(), f32_type);
+    /// assert_eq!(f32_scalable_vector_type.get_size(), 3);
+    /// assert_eq!(f32_scalable_vector_type.get_element_type().into_float_type(), f32_type);
     /// ```
     pub fn vec_type(self, size: u32) -> VectorType<'ctx> {
         self.float_type.vec_type(size)
@@ -147,9 +147,9 @@ impl<'ctx> FloatType<'ctx> {
     /// assert_eq!(f64_val.print_to_string().to_string(), "double 0x7FF0000000000000");
     /// ```
     pub unsafe fn const_float_from_string(self, slice: &str) -> FloatValue<'ctx> {
-    	assert!(!slice.is_empty());
+        assert!(!slice.is_empty());
 
-    	unsafe {
+        unsafe {
             FloatValue::new(LLVMConstRealOfStringAndSize(
                 self.as_type_ref(),
                 slice.as_ptr() as *const ::libc::c_char,

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -244,7 +244,7 @@ impl<'ctx> IntType<'ctx> {
         self.int_type.vec_type(size)
     }
 
-    /// Creates a scalable `VectorType` with this `IntType` for its element type.
+    /// Creates a `ScalableVectorType` with this `IntType` for its element type.
     ///
     /// # Example
     ///
@@ -253,10 +253,10 @@ impl<'ctx> IntType<'ctx> {
     ///
     /// let context = Context::create();
     /// let i8_type = context.i8_type();
-    /// let i8_vector_type = i8_type.scalable_vec_type(3);
+    /// let i8_scalable_vector_type = i8_type.scalable_vec_type(3);
     ///
-    /// assert_eq!(i8_vector_type.get_size(), 3);
-    /// assert_eq!(i8_vector_type.get_element_type().into_int_type(), i8_type);
+    /// assert_eq!(i8_scalable_vector_type.get_size(), 3);
+    /// assert_eq!(i8_scalable_vector_type.get_element_type().into_int_type(), i8_type);
     /// ```
     #[llvm_versions(12..)]
     pub fn scalable_vec_type(self, size: u32) -> ScalableVectorType<'ctx> {

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -7,7 +7,7 @@ use llvm_sys::prelude::LLVMTypeRef;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{ArrayType, FunctionType, PointerType, Type, VectorType};
+use crate::types::{ArrayType, FunctionType, PointerType, ScalableVectorType, Type, VectorType};
 use crate::values::{ArrayValue, GenericValue, IntValue};
 use crate::AddressSpace;
 
@@ -258,8 +258,8 @@ impl<'ctx> IntType<'ctx> {
     /// assert_eq!(i8_vector_type.get_size(), 3);
     /// assert_eq!(i8_vector_type.get_element_type().into_int_type(), i8_type);
     /// ```
-    #[llvm_versions(11..)]
-    pub fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+    #[llvm_versions(12..)]
+    pub fn scalable_vec_type(self, size: u32) -> ScalableVectorType<'ctx> {
         self.int_type.scalable_vec_type(size)
     }
 

--- a/src/types/int_type.rs
+++ b/src/types/int_type.rs
@@ -244,6 +244,25 @@ impl<'ctx> IntType<'ctx> {
         self.int_type.vec_type(size)
     }
 
+    /// Creates a scalable `VectorType` with this `IntType` for its element type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let i8_type = context.i8_type();
+    /// let i8_vector_type = i8_type.scalable_vec_type(3);
+    ///
+    /// assert_eq!(i8_vector_type.get_size(), 3);
+    /// assert_eq!(i8_vector_type.get_element_type().into_int_type(), i8_type);
+    /// ```
+    #[llvm_versions(11..)]
+    pub fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+        self.int_type.scalable_vec_type(size)
+    }
+
     /// Gets a reference to the `Context` this `IntType` was created in.
     ///
     /// # Example

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -35,6 +35,9 @@ pub use crate::types::traits::{AnyType, AsTypeRef, BasicType, FloatMathType, Int
 pub use crate::types::vec_type::VectorType;
 pub use crate::types::void_type::VoidType;
 
+#[llvm_versions(11..)]
+use llvm_sys::core::LLVMScalableVectorType;
+
 #[llvm_versions(12..)]
 use llvm_sys::core::LLVMGetPoison;
 
@@ -93,6 +96,14 @@ impl<'ctx> Type<'ctx> {
         // -- https://llvm.org/docs/LangRef.html#vector-type
 
         unsafe { VectorType::new(LLVMVectorType(self.ty, size)) }
+    }
+
+    #[llvm_versions(11..)]
+    fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+        assert!(size != 0, "Vectors of size zero are not allowed.");
+        // -- https://llvm.org/docs/LangRef.html#vector-type
+
+        unsafe { VectorType::new(LLVMScalableVectorType(self.ty, size)) }
     }
 
     #[cfg(not(feature = "experimental"))]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -14,13 +14,13 @@ mod metadata_type;
 #[deny(missing_docs)]
 mod ptr_type;
 #[deny(missing_docs)]
+mod scalable_vec_type;
+#[deny(missing_docs)]
 mod struct_type;
 #[deny(missing_docs)]
 mod traits;
 #[deny(missing_docs)]
 mod vec_type;
-#[deny(missing_docs)]
-mod scalable_vec_type;
 #[deny(missing_docs)]
 mod void_type;
 
@@ -31,11 +31,11 @@ pub use crate::types::fn_type::FunctionType;
 pub use crate::types::int_type::{IntType, StringRadix};
 pub use crate::types::metadata_type::MetadataType;
 pub use crate::types::ptr_type::PointerType;
+pub use crate::types::scalable_vec_type::ScalableVectorType;
 pub use crate::types::struct_type::FieldTypesIter;
 pub use crate::types::struct_type::StructType;
 pub use crate::types::traits::{AnyType, AsTypeRef, BasicType, FloatMathType, IntMathType, PointerMathType};
 pub use crate::types::vec_type::VectorType;
-pub use crate::types::scalable_vec_type::ScalableVectorType;
 pub use crate::types::void_type::VoidType;
 
 #[llvm_versions(12..)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -20,6 +20,8 @@ mod traits;
 #[deny(missing_docs)]
 mod vec_type;
 #[deny(missing_docs)]
+mod scalable_vec_type;
+#[deny(missing_docs)]
 mod void_type;
 
 pub use crate::types::array_type::ArrayType;
@@ -33,9 +35,10 @@ pub use crate::types::struct_type::FieldTypesIter;
 pub use crate::types::struct_type::StructType;
 pub use crate::types::traits::{AnyType, AsTypeRef, BasicType, FloatMathType, IntMathType, PointerMathType};
 pub use crate::types::vec_type::VectorType;
+pub use crate::types::scalable_vec_type::ScalableVectorType;
 pub use crate::types::void_type::VoidType;
 
-#[llvm_versions(11..)]
+#[llvm_versions(12..)]
 use llvm_sys::core::LLVMScalableVectorType;
 
 #[llvm_versions(12..)]
@@ -98,12 +101,12 @@ impl<'ctx> Type<'ctx> {
         unsafe { VectorType::new(LLVMVectorType(self.ty, size)) }
     }
 
-    #[llvm_versions(11..)]
-    fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+    #[llvm_versions(12..)]
+    fn scalable_vec_type(self, size: u32) -> ScalableVectorType<'ctx> {
         assert!(size != 0, "Vectors of size zero are not allowed.");
         // -- https://llvm.org/docs/LangRef.html#vector-type
 
-        unsafe { VectorType::new(LLVMScalableVectorType(self.ty, size)) }
+        unsafe { ScalableVectorType::new(LLVMScalableVectorType(self.ty, size)) }
     }
 
     #[cfg(not(feature = "experimental"))]

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -326,6 +326,30 @@ impl<'ctx> PointerType<'ctx> {
         self.ptr_type.vec_type(size)
     }
 
+    /// Creates a scalable `VectorType` with this `PointerType` for its element type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// #[cfg(not(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0")))]
+    /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
+    /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
+    /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
+    /// let f32_ptr_vec_type = f32_ptr_type.scalable_vec_type(3);
+    ///
+    /// assert_eq!(f32_ptr_vec_type.get_size(), 3);
+    /// assert_eq!(f32_ptr_vec_type.get_element_type().into_pointer_type(), f32_ptr_type);
+    /// ```
+    #[llvm_versions(11..)]
+    pub fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+        self.ptr_type.scalable_vec_type(size)
+    }
+
     // SubType: PointerrType<BT> -> BT?
     /// Gets the element type of this `PointerType`.
     ///

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -8,7 +8,7 @@ use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 #[llvm_versions(..=14)]
 use crate::types::AnyTypeEnum;
-use crate::types::{ArrayType, FunctionType, Type, VectorType, ScalableVectorType};
+use crate::types::{ArrayType, FunctionType, ScalableVectorType, Type, VectorType};
 use crate::values::{ArrayValue, IntValue, PointerValue};
 use crate::AddressSpace;
 
@@ -326,7 +326,7 @@ impl<'ctx> PointerType<'ctx> {
         self.ptr_type.vec_type(size)
     }
 
-    /// Creates a scalable `VectorType` with this `PointerType` for its element type.
+    /// Creates a `ScalableVectorType` with this `PointerType` for its element type.
     ///
     /// # Example
     ///
@@ -340,10 +340,10 @@ impl<'ctx> PointerType<'ctx> {
     /// let f32_ptr_type = f32_type.ptr_type(AddressSpace::default());
     /// #[cfg(any(feature = "llvm15-0", feature = "llvm16-0", feature = "llvm17-0", feature = "llvm18-0"))]
     /// let f32_ptr_type = context.ptr_type(AddressSpace::default());
-    /// let f32_ptr_vec_type = f32_ptr_type.scalable_vec_type(3);
+    /// let f32_ptr_scalable_vec_type = f32_ptr_type.scalable_vec_type(3);
     ///
-    /// assert_eq!(f32_ptr_vec_type.get_size(), 3);
-    /// assert_eq!(f32_ptr_vec_type.get_element_type().into_pointer_type(), f32_ptr_type);
+    /// assert_eq!(f32_ptr_scalable_vec_type.get_size(), 3);
+    /// assert_eq!(f32_ptr_scalable_vec_type.get_element_type().into_pointer_type(), f32_ptr_type);
     /// ```
     #[llvm_versions(12..)]
     pub fn scalable_vec_type(self, size: u32) -> ScalableVectorType<'ctx> {

--- a/src/types/ptr_type.rs
+++ b/src/types/ptr_type.rs
@@ -8,7 +8,7 @@ use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
 #[llvm_versions(..=14)]
 use crate::types::AnyTypeEnum;
-use crate::types::{ArrayType, FunctionType, Type, VectorType};
+use crate::types::{ArrayType, FunctionType, Type, VectorType, ScalableVectorType};
 use crate::values::{ArrayValue, IntValue, PointerValue};
 use crate::AddressSpace;
 
@@ -345,8 +345,8 @@ impl<'ctx> PointerType<'ctx> {
     /// assert_eq!(f32_ptr_vec_type.get_size(), 3);
     /// assert_eq!(f32_ptr_vec_type.get_element_type().into_pointer_type(), f32_ptr_type);
     /// ```
-    #[llvm_versions(11..)]
-    pub fn scalable_vec_type(self, size: u32) -> VectorType<'ctx> {
+    #[llvm_versions(12..)]
+    pub fn scalable_vec_type(self, size: u32) -> ScalableVectorType<'ctx> {
         self.ptr_type.scalable_vec_type(size)
     }
 

--- a/src/types/scalable_vec_type.rs
+++ b/src/types/scalable_vec_type.rs
@@ -1,0 +1,289 @@
+use llvm_sys::core::LLVMGetVectorSize;
+use llvm_sys::prelude::LLVMTypeRef;
+
+use crate::context::ContextRef;
+use crate::support::LLVMString;
+use crate::types::enums::BasicMetadataTypeEnum;
+use crate::types::{traits::AsTypeRef, ArrayType, BasicTypeEnum, FunctionType, PointerType, Type};
+use crate::values::{ArrayValue, IntValue, ScalableVectorValue};
+use crate::AddressSpace;
+
+use std::fmt::{self, Display};
+
+/// A `ScalableVectorType` is the type of a scalable multiple value SIMD constant or variable.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct ScalableVectorType<'ctx> {
+    scalable_vec_type: Type<'ctx>,
+}
+
+impl<'ctx> ScalableVectorType<'ctx> {
+    /// Create `ScalableVectorType` from [`LLVMTypeRef`]
+    ///
+    /// # Safety
+    /// Undefined behavior, if referenced type isn't scalable vector type
+    pub unsafe fn new(scalable_vector_type: LLVMTypeRef) -> Self {
+        assert!(!scalable_vector_type.is_null());
+
+        ScalableVectorType {
+            scalable_vec_type: Type::new(scalable_vector_type),
+        }
+    }
+
+    // TODO: impl only for ScalableVectorType<!StructType<Opaque>>
+    // REVIEW: What about Opaque struct hiding in deeper levels
+    // like ScalableVectorType<ArrayType<StructType<Opaque>>>?
+    /// Gets the size of this `ScalableVectorType`. Value may vary depending on the target architecture.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(3);
+    /// let f32_scalable_vec_type_size = f32_scalable_vec_type.size_of();
+    /// ```
+    pub fn size_of(self) -> Option<IntValue<'ctx>> {
+        self.scalable_vec_type.size_of()
+    }
+
+    /// Gets the alignment of this `ScalableVectorType`. Value may vary depending on the target architecture.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(7);
+    /// let f32_type_alignment = f32_scalable_vec_type.get_alignment();
+    /// ```
+    pub fn get_alignment(self) -> IntValue<'ctx> {
+        self.scalable_vec_type.get_alignment()
+    }
+
+    /// Gets the size of this `ScalableVectorType`.
+    /// 
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vector_type = f32_type.scalable_vec_type(3);
+    ///
+    /// assert_eq!(f32_scalable_vector_type.get_size(), 3);
+    /// assert_eq!(f32_scalable_vector_type.get_element_type().into_float_type(), f32_type);
+    /// ```
+    pub fn get_size(self) -> u32 {
+        unsafe { LLVMGetVectorSize(self.as_type_ref()) }
+    }
+
+    /// Creates a constant zero value of this `ScalableVectorType`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(7);
+    /// let f32_scalable_vec_zero = f32_scalable_vec_type.const_zero();
+    /// ```
+    pub fn const_zero(self) -> ScalableVectorValue<'ctx> {
+        unsafe { ScalableVectorValue::new(self.scalable_vec_type.const_zero()) }
+    }
+
+    /// Print the definition of a `ScalableVectorType` to `LLVMString`.
+    pub fn print_to_string(self) -> LLVMString {
+        self.scalable_vec_type.print_to_string()
+    }
+
+    /// Creates an undefined instance of a `ScalableVectorType`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(3);
+    /// let f32_scalable_vec_undef = f32_scalable_vec_type.get_undef();
+    ///
+    /// assert!(f32_scalable_vec_undef.is_undef());
+    /// ```
+    pub fn get_undef(self) -> ScalableVectorValue<'ctx> {
+        unsafe { ScalableVectorValue::new(self.scalable_vec_type.get_undef()) }
+    }
+
+    /// Creates a poison instance of a `ScalableVectorType`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(3);
+    /// let f32_scalable_vec_poison = f32_scalable_vec_type.get_undef();
+    ///
+    /// assert!(f32_scalable_vec_poison.is_undef());
+    /// ```
+    #[llvm_versions(12..)]
+    pub fn get_poison(self) -> ScalableVectorValue<'ctx> {
+        unsafe { ScalableVectorValue::new(self.scalable_vec_type.get_poison()) }
+    }
+
+    // SubType: ScalableVectorType<BT> -> BT?
+    /// Gets the element type of this `ScalableVectorType`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vector_type = f32_type.scalable_vec_type(3);
+    ///
+    /// assert_eq!(f32_scalable_vector_type.get_size(), 3);
+    /// assert_eq!(f32_scalable_vector_type.get_element_type().into_float_type(), f32_type);
+    /// ```
+    pub fn get_element_type(self) -> BasicTypeEnum<'ctx> {
+        self.scalable_vec_type.get_element_type().as_basic_type_enum()
+    }
+
+    /// Creates a `PointerType` with this `ScalableVectorType` for its element type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::AddressSpace;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(3);
+    /// let f32_scalable_vec_ptr_type = f32_scalable_vec_type.ptr_type(AddressSpace::default());
+    ///
+    /// #[cfg(any(
+    ///     feature = "llvm4-0",
+    ///     feature = "llvm5-0",
+    ///     feature = "llvm6-0",
+    ///     feature = "llvm7-0",
+    ///     feature = "llvm8-0",
+    ///     feature = "llvm9-0",
+    ///     feature = "llvm10-0",
+    ///     feature = "llvm11-0",
+    ///     feature = "llvm12-0",
+    ///     feature = "llvm13-0",
+    ///     feature = "llvm14-0"
+    /// ))]
+    /// assert_eq!(f32_scalable_vec_ptr_type.get_element_type().into_scalable_vector_type(), f32_scalable_vec_type);
+    /// ```
+    #[cfg_attr(
+        any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ),
+        deprecated(
+            note = "Starting from version 15.0, LLVM doesn't differentiate between pointer types. Use Context::ptr_type instead."
+        )
+    )]
+    pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {
+        self.scalable_vec_type.ptr_type(address_space)
+    }
+
+    /// Creates a `FunctionType` with this `ScalableVectorType` for its return type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(3);
+    /// let fn_type = f32_scalable_vec_type.fn_type(&[], false);
+    /// ```
+    pub fn fn_type(self, param_types: &[BasicMetadataTypeEnum<'ctx>], is_var_args: bool) -> FunctionType<'ctx> {
+        self.scalable_vec_type.fn_type(param_types, is_var_args)
+    }
+
+    /// Creates an `ArrayType` with this `ScalableVectorType` for its element type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(3);
+    /// let f32_scalable_vec_array_type = f32_scalable_vec_type.array_type(3);
+    ///
+    /// assert_eq!(f32_scalable_vec_array_type.len(), 3);
+    /// assert_eq!(f32_scalable_vec_array_type.get_element_type().into_scalable_vector_type(), f32_scalable_vec_type);
+    /// ```
+    pub fn array_type(self, size: u32) -> ArrayType<'ctx> {
+        self.scalable_vec_type.array_type(size)
+    }
+
+    /// Creates a constant `ArrayValue`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use inkwell::types::ScalableVectorType;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_val = f32_type.const_float(0.);
+    /// let f32_val2 = f32_type.const_float(2.);
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(2);
+    /// let f32_scalable_vec_val = f32_scalable_vec_type.const_zero();
+    /// let f32_array = f32_scalable_vec_type.const_array(&[f32_scalable_vec_val, f32_scalable_vec_val]);
+    ///
+    /// assert!(f32_array.is_const());
+    /// ```
+    pub fn const_array(self, values: &[ScalableVectorValue<'ctx>]) -> ArrayValue<'ctx> {
+        unsafe { ArrayValue::new_const_array(&self, values) }
+    }
+
+    /// Gets a reference to the `Context` this `ScalableVectorType` was created in.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f32_type = context.f32_type();
+    /// let f32_scalable_vec_type = f32_type.scalable_vec_type(7);
+    ///
+    /// assert_eq!(f32_scalable_vec_type.get_context(), context);
+    /// ```
+    pub fn get_context(self) -> ContextRef<'ctx> {
+        self.scalable_vec_type.get_context()
+    }
+}
+
+unsafe impl AsTypeRef for ScalableVectorType<'_> {
+    fn as_type_ref(&self) -> LLVMTypeRef {
+        self.scalable_vec_type.ty
+    }
+}
+
+impl Display for ScalableVectorType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}

--- a/src/types/scalable_vec_type.rs
+++ b/src/types/scalable_vec_type.rs
@@ -36,7 +36,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -52,7 +52,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -65,10 +65,10 @@ impl<'ctx> ScalableVectorType<'ctx> {
     }
 
     /// Gets the size of this `ScalableVectorType`.
-    /// 
+    ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -86,7 +86,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -106,7 +106,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     /// Creates an undefined instance of a `ScalableVectorType`.
     ///
     /// # Example
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     /// use inkwell::AddressSpace;
     ///
@@ -124,7 +124,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     /// Creates a poison instance of a `ScalableVectorType`.
     ///
     /// # Example
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     /// use inkwell::AddressSpace;
     ///
@@ -145,7 +145,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -163,7 +163,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     /// use inkwell::AddressSpace;
     ///
@@ -206,7 +206,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -222,7 +222,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -240,7 +240,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     /// Creates a constant `ArrayValue`.
     ///
     /// # Example
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     /// use inkwell::types::ScalableVectorType;
     ///
@@ -262,7 +262,7 @@ impl<'ctx> ScalableVectorType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -4,8 +4,14 @@ use std::fmt::Debug;
 
 use crate::support::LLVMString;
 use crate::types::enums::{AnyTypeEnum, BasicMetadataTypeEnum, BasicTypeEnum};
-use crate::types::{ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, Type, VectorType, ScalableVectorType, VoidType};
-use crate::values::{FloatMathValue, FloatValue, IntMathValue, IntValue, PointerMathValue, PointerValue, VectorValue, ScalableVectorValue};
+use crate::types::{
+    ArrayType, FloatType, FunctionType, IntType, PointerType, ScalableVectorType, StructType, Type, VectorType,
+    VoidType,
+};
+use crate::values::{
+    FloatMathValue, FloatValue, IntMathValue, IntValue, PointerMathValue, PointerValue, ScalableVectorValue,
+    VectorValue,
+};
 use crate::AddressSpace;
 
 /// Accessor to the inner LLVM type reference

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 
 use crate::support::LLVMString;
 use crate::types::enums::{AnyTypeEnum, BasicMetadataTypeEnum, BasicTypeEnum};
-use crate::types::{ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, Type, VectorType, VoidType};
-use crate::values::{FloatMathValue, FloatValue, IntMathValue, IntValue, PointerMathValue, PointerValue, VectorValue};
+use crate::types::{ArrayType, FloatType, FunctionType, IntType, PointerType, StructType, Type, VectorType, ScalableVectorType, VoidType};
+use crate::values::{FloatMathValue, FloatValue, IntMathValue, IntValue, PointerMathValue, PointerValue, VectorValue, ScalableVectorValue};
 use crate::AddressSpace;
 
 /// Accessor to the inner LLVM type reference
@@ -168,8 +168,8 @@ pub unsafe trait PointerMathType<'ctx>: BasicType<'ctx> {
     type PtrConvType: IntMathType<'ctx>;
 }
 
-trait_type_set! {AnyType: AnyTypeEnum, BasicTypeEnum, IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VoidType, VectorType}
-trait_type_set! {BasicType: BasicTypeEnum, IntType, FloatType, PointerType, StructType, ArrayType, VectorType}
+trait_type_set! {AnyType: AnyTypeEnum, BasicTypeEnum, IntType, FunctionType, FloatType, PointerType, StructType, ArrayType, VoidType, VectorType, ScalableVectorType}
+trait_type_set! {BasicType: BasicTypeEnum, IntType, FloatType, PointerType, StructType, ArrayType, VectorType, ScalableVectorType}
 
 unsafe impl<'ctx> IntMathType<'ctx> for IntType<'ctx> {
     type ValueType = IntValue<'ctx>;
@@ -183,6 +183,12 @@ unsafe impl<'ctx> IntMathType<'ctx> for VectorType<'ctx> {
     type PtrConvType = VectorType<'ctx>;
 }
 
+unsafe impl<'ctx> IntMathType<'ctx> for ScalableVectorType<'ctx> {
+    type ValueType = ScalableVectorValue<'ctx>;
+    type MathConvType = ScalableVectorType<'ctx>;
+    type PtrConvType = ScalableVectorType<'ctx>;
+}
+
 unsafe impl<'ctx> FloatMathType<'ctx> for FloatType<'ctx> {
     type ValueType = FloatValue<'ctx>;
     type MathConvType = IntType<'ctx>;
@@ -193,6 +199,11 @@ unsafe impl<'ctx> FloatMathType<'ctx> for VectorType<'ctx> {
     type MathConvType = VectorType<'ctx>;
 }
 
+unsafe impl<'ctx> FloatMathType<'ctx> for ScalableVectorType<'ctx> {
+    type ValueType = ScalableVectorValue<'ctx>;
+    type MathConvType = ScalableVectorType<'ctx>;
+}
+
 unsafe impl<'ctx> PointerMathType<'ctx> for PointerType<'ctx> {
     type ValueType = PointerValue<'ctx>;
     type PtrConvType = IntType<'ctx>;
@@ -201,4 +212,9 @@ unsafe impl<'ctx> PointerMathType<'ctx> for PointerType<'ctx> {
 unsafe impl<'ctx> PointerMathType<'ctx> for VectorType<'ctx> {
     type ValueType = VectorValue<'ctx>;
     type PtrConvType = VectorType<'ctx>;
+}
+
+unsafe impl<'ctx> PointerMathType<'ctx> for ScalableVectorType<'ctx> {
+    type ValueType = ScalableVectorValue<'ctx>;
+    type PtrConvType = ScalableVectorType<'ctx>;
 }

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -94,6 +94,16 @@ impl<'ctx> AnyValueEnum<'ctx> {
             },
             LLVMTypeKind::LLVMArrayTypeKind => AnyValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => AnyValueEnum::VectorValue(VectorValue::new(value)),
+            #[cfg(any(
+                feature = "llvm11-0",
+                feature = "llvm12-0",
+                feature = "llvm13-0",
+                feature = "llvm14-0",
+                feature = "llvm15-0",
+                feature = "llvm16-0",
+                feature = "llvm17-0",
+                feature = "llvm18-0"
+            ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => {
                 AnyValueEnum::ScalableVectorValue(ScalableVectorValue::new(value))
             },
@@ -253,6 +263,16 @@ impl<'ctx> BasicValueEnum<'ctx> {
             LLVMTypeKind::LLVMPointerTypeKind => BasicValueEnum::PointerValue(PointerValue::new(value)),
             LLVMTypeKind::LLVMArrayTypeKind => BasicValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => BasicValueEnum::VectorValue(VectorValue::new(value)),
+            #[cfg(any(
+                feature = "llvm11-0",
+                feature = "llvm12-0",
+                feature = "llvm13-0",
+                feature = "llvm14-0",
+                feature = "llvm15-0",
+                feature = "llvm16-0",
+                feature = "llvm17-0",
+                feature = "llvm18-0"
+            ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => {
                 BasicValueEnum::ScalableVectorValue(ScalableVectorValue::new(value))
             },
@@ -428,6 +448,16 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
             LLVMTypeKind::LLVMPointerTypeKind => BasicMetadataValueEnum::PointerValue(PointerValue::new(value)),
             LLVMTypeKind::LLVMArrayTypeKind => BasicMetadataValueEnum::ArrayValue(ArrayValue::new(value)),
             LLVMTypeKind::LLVMVectorTypeKind => BasicMetadataValueEnum::VectorValue(VectorValue::new(value)),
+            #[cfg(any(
+                feature = "llvm11-0",
+                feature = "llvm12-0",
+                feature = "llvm13-0",
+                feature = "llvm14-0",
+                feature = "llvm15-0",
+                feature = "llvm16-0",
+                feature = "llvm17-0",
+                feature = "llvm18-0"
+            ))]
             LLVMTypeKind::LLVMScalableVectorTypeKind => {
                 BasicMetadataValueEnum::ScalableVectorValue(ScalableVectorValue::new(value))
             },

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -16,6 +16,7 @@ mod int_value;
 mod metadata_value;
 mod phi_value;
 mod ptr_value;
+mod scalable_vec_value;
 mod struct_value;
 mod traits;
 mod vec_value;
@@ -59,10 +60,13 @@ pub use crate::values::metadata_value::{MetadataValue, FIRST_CUSTOM_METADATA_KIN
 pub use crate::values::phi_value::IncomingIter;
 pub use crate::values::phi_value::PhiValue;
 pub use crate::values::ptr_value::PointerValue;
+pub use crate::values::scalable_vec_value::ScalableVectorValue;
 pub use crate::values::struct_value::FieldValueIter;
 pub use crate::values::struct_value::StructValue;
 pub use crate::values::traits::AsValueRef;
-pub use crate::values::traits::{AggregateValue, AnyValue, BasicValue, FloatMathValue, IntMathValue, PointerMathValue};
+pub use crate::values::traits::{
+    AggregateValue, AnyValue, BasicValue, FloatMathValue, IntMathValue, PointerMathValue, VectorBaseValue,
+};
 pub use crate::values::vec_value::VectorValue;
 
 #[llvm_versions(18..)]

--- a/src/values/scalable_vec_value.rs
+++ b/src/values/scalable_vec_value.rs
@@ -1,0 +1,156 @@
+#[llvm_versions(..=16)]
+use llvm_sys::core::LLVMConstSelect;
+#[allow(deprecated)]
+use llvm_sys::core::LLVMGetElementAsConstant;
+use llvm_sys::core::{
+    LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstShuffleVector, LLVMIsAConstantDataVector,
+    LLVMIsAConstantVector,
+};
+use llvm_sys::prelude::LLVMValueRef;
+
+use std::ffi::CStr;
+use std::fmt::{self, Display};
+
+use crate::types::ScalableVectorType;
+use crate::values::traits::AsValueRef;
+use crate::values::{BasicValue, BasicValueEnum, InstructionValue, IntValue, Value};
+
+use super::AnyValue;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct ScalableVectorValue<'ctx> {
+    scalable_vec_value: Value<'ctx>,
+}
+
+impl<'ctx> ScalableVectorValue<'ctx> {
+    /// Get a value from an [LLVMValueRef].
+    ///
+    /// # Safety
+    ///
+    /// The ref must be valid and of type scalable vector.
+    pub unsafe fn new(scalable_vector_value: LLVMValueRef) -> Self {
+        assert!(!scalable_vector_value.is_null());
+
+        ScalableVectorValue {
+            scalable_vec_value: Value::new(scalable_vector_value),
+        }
+    }
+
+    /// Determines whether or not a `ScalableVectorValue` is a constant.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let i8_type = context.i8_type();
+    /// let i8_scalable_vec_type = i8_type.scalable_vec_type(3);
+    /// let i8_scalable_vec_zero = i8_scalable_vec_type.const_zero();
+    ///
+    /// assert!(i8_scalable_vec_zero.is_const());
+    /// ```
+    pub fn is_const(self) -> bool {
+        self.scalable_vec_value.is_const()
+    }
+
+    pub fn is_constant_vector(self) -> bool {
+        unsafe { !LLVMIsAConstantVector(self.as_value_ref()).is_null() }
+    }
+
+    pub fn is_constant_data_vector(self) -> bool {
+        unsafe { !LLVMIsAConstantDataVector(self.as_value_ref()).is_null() }
+    }
+
+    pub fn print_to_stderr(self) {
+        self.scalable_vec_value.print_to_stderr()
+    }
+
+    /// Gets the name of a `ScalableVectorValue`. If the value is a constant, this will
+    /// return an empty string.
+    pub fn get_name(&self) -> &CStr {
+        self.scalable_vec_value.get_name()
+    }
+
+    /// Set name of the `ScalableVectorValue`.
+    pub fn set_name(&self, name: &str) {
+        self.scalable_vec_value.set_name(name)
+    }
+
+    pub fn get_type(self) -> ScalableVectorType<'ctx> {
+        unsafe { ScalableVectorType::new(self.scalable_vec_value.get_type()) }
+    }
+
+    pub fn is_null(self) -> bool {
+        self.scalable_vec_value.is_null()
+    }
+
+    pub fn is_undef(self) -> bool {
+        self.scalable_vec_value.is_undef()
+    }
+
+    pub fn as_instruction(self) -> Option<InstructionValue<'ctx>> {
+        self.scalable_vec_value.as_instruction()
+    }
+
+    pub fn const_extract_element(self, index: IntValue<'ctx>) -> BasicValueEnum<'ctx> {
+        unsafe { BasicValueEnum::new(LLVMConstExtractElement(self.as_value_ref(), index.as_value_ref())) }
+    }
+
+    // SubTypes: value should really be T in self: ScalableVectorValue<T> I think
+    pub fn const_insert_element<BV: BasicValue<'ctx>>(self, index: IntValue<'ctx>, value: BV) -> BasicValueEnum<'ctx> {
+        unsafe {
+            BasicValueEnum::new(LLVMConstInsertElement(
+                self.as_value_ref(),
+                value.as_value_ref(),
+                index.as_value_ref(),
+            ))
+        }
+    }
+
+    pub fn replace_all_uses_with(self, other: ScalableVectorValue<'ctx>) {
+        self.scalable_vec_value.replace_all_uses_with(other.as_value_ref())
+    }
+
+    // TODOC: Value seems to be zero initialized if index out of bounds
+    // SubType: ScalableVectorValue<BV> -> BV
+    #[allow(deprecated)]
+    pub fn get_element_as_constant(self, index: u32) -> BasicValueEnum<'ctx> {
+        unsafe { BasicValueEnum::new(LLVMGetElementAsConstant(self.as_value_ref(), index)) }
+    }
+
+    // SubTypes: self can only be ScalableVectoValue<IntValue<bool>>
+    #[llvm_versions(..=16)]
+    pub fn const_select<BV: BasicValue<'ctx>>(self, then: BV, else_: BV) -> BasicValueEnum<'ctx> {
+        unsafe {
+            BasicValueEnum::new(LLVMConstSelect(
+                self.as_value_ref(),
+                then.as_value_ref(),
+                else_.as_value_ref(),
+            ))
+        }
+    }
+
+    // SubTypes: <V: ScalableVectorValue<T, Const>> self: V, right: V, mask: V -> V
+    pub fn const_shuffle_vector(self, right: ScalableVectorValue<'ctx>, mask: ScalableVectorValue<'ctx>) -> ScalableVectorValue<'ctx> {
+        unsafe {
+            ScalableVectorValue::new(LLVMConstShuffleVector(
+                self.as_value_ref(),
+                right.as_value_ref(),
+                mask.as_value_ref(),
+            ))
+        }
+    }
+}
+
+unsafe impl AsValueRef for ScalableVectorValue<'_> {
+    fn as_value_ref(&self) -> LLVMValueRef {
+        self.scalable_vec_value.value
+    }
+}
+
+impl Display for ScalableVectorValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_to_string())
+    }
+}

--- a/src/values/scalable_vec_value.rs
+++ b/src/values/scalable_vec_value.rs
@@ -2,10 +2,7 @@
 use llvm_sys::core::LLVMConstSelect;
 #[allow(deprecated)]
 use llvm_sys::core::LLVMGetElementAsConstant;
-use llvm_sys::core::{
-    LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstShuffleVector, LLVMIsAConstantDataVector,
-    LLVMIsAConstantVector,
-};
+use llvm_sys::core::{LLVMConstExtractElement, LLVMConstInsertElement, LLVMConstShuffleVector};
 use llvm_sys::prelude::LLVMValueRef;
 
 use std::ffi::CStr;
@@ -40,7 +37,7 @@ impl<'ctx> ScalableVectorValue<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -52,14 +49,6 @@ impl<'ctx> ScalableVectorValue<'ctx> {
     /// ```
     pub fn is_const(self) -> bool {
         self.scalable_vec_value.is_const()
-    }
-
-    pub fn is_constant_vector(self) -> bool {
-        unsafe { !LLVMIsAConstantVector(self.as_value_ref()).is_null() }
-    }
-
-    pub fn is_constant_data_vector(self) -> bool {
-        unsafe { !LLVMIsAConstantDataVector(self.as_value_ref()).is_null() }
     }
 
     pub fn print_to_stderr(self) {
@@ -132,7 +121,11 @@ impl<'ctx> ScalableVectorValue<'ctx> {
     }
 
     // SubTypes: <V: ScalableVectorValue<T, Const>> self: V, right: V, mask: V -> V
-    pub fn const_shuffle_vector(self, right: ScalableVectorValue<'ctx>, mask: ScalableVectorValue<'ctx>) -> ScalableVectorValue<'ctx> {
+    pub fn const_shuffle_vector(
+        self,
+        right: ScalableVectorValue<'ctx>,
+        mask: ScalableVectorValue<'ctx>,
+    ) -> ScalableVectorValue<'ctx> {
         unsafe {
             ScalableVectorValue::new(LLVMConstShuffleVector(
                 self.as_value_ref(),

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -926,7 +926,7 @@ fn test_scalable_vector_convert_ops() {
     let float32_vec_type = context.f32_type().scalable_vec_type(3);
     let float16_vec_type = context.f16_type().scalable_vec_type(3);
 
-    // Here we're building a function that takes in a <vscale x 3 x i8> and returns it casted to 
+    // Here we're building a function that takes in a <vscale x 3 x i8> and returns it casted to
     // and from a <vscale x 3 x i32>
     // Casting to and from means we can ensure the cast build functions return a vector when one is provided.
     let fn_type = int32_vec_type.fn_type(&[int8_vec_type.into()], false);
@@ -1003,7 +1003,7 @@ fn test_scalable_vector_convert_ops_respect_target_signedness() {
     let module = context.create_module("test");
     let int8_vec_type = context.i8_type().scalable_vec_type(3);
 
-    // Here we're building a function that takes in a <vscale x 3 x i8> (signed) and returns it 
+    // Here we're building a function that takes in a <vscale x 3 x i8> (signed) and returns it
     // casted to and from a <vscale x 3 x i8> (unsigned)
     let fn_type = int8_vec_type.fn_type(&[int8_vec_type.into()], false);
     let fn_value = module.add_function("test_int_vec_cast", fn_type, None);
@@ -1101,7 +1101,7 @@ fn test_scalable_vector_binary_ops() {
     let float32_vec_type = context.f32_type().scalable_vec_type(2);
     let bool_vec_type = context.bool_type().scalable_vec_type(2);
 
-    // Here we're building a function that takes in three <vscale x 2 x i32>s and returns them 
+    // Here we're building a function that takes in three <vscale x 2 x i32>s and returns them
     // added together as a <vscale x 2 x i32>
     let fn_type = int32_vec_type.fn_type(
         &[int32_vec_type.into(), int32_vec_type.into(), int32_vec_type.into()],
@@ -1981,8 +1981,20 @@ fn test_bit_cast() {
     {
         let i64_scalable_vec_type = i64_type.scalable_vec_type(1);
         let f32_scalable_vec_type = f32_type.scalable_vec_type(2);
-        builder.build_bit_cast(i32_scalable_vec_arg, i64_scalable_vec_type, "vscalex2xi32tovscalex1xi64").unwrap();
-        builder.build_bit_cast(i32_scalable_vec_arg, f32_scalable_vec_type, "vscalex2xi32tovscalex2xf32").unwrap();
+        builder
+            .build_bit_cast(
+                i32_scalable_vec_arg,
+                i64_scalable_vec_type,
+                "vscalex2xi32tovscalex1xi64",
+            )
+            .unwrap();
+        builder
+            .build_bit_cast(
+                i32_scalable_vec_arg,
+                f32_scalable_vec_type,
+                "vscalex2xi32tovscalex2xf32",
+            )
+            .unwrap();
     }
     builder.build_bit_cast(i32_ptr_arg, i64_ptr_type, "i32*toi64*").unwrap();
 

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -916,6 +916,62 @@ fn test_vector_convert_ops() {
     assert!(fn_value.verify(true));
 }
 
+#[llvm_versions(12..)]
+#[test]
+fn test_scalable_vector_convert_ops() {
+    let context = Context::create();
+    let module = context.create_module("test");
+    let int8_vec_type = context.i8_type().scalable_vec_type(3);
+    let int32_vec_type = context.i32_type().scalable_vec_type(3);
+    let float32_vec_type = context.f32_type().scalable_vec_type(3);
+    let float16_vec_type = context.f16_type().scalable_vec_type(3);
+
+    // Here we're building a function that takes in a <vscale x 3 x i8> and returns it casted to 
+    // and from a <vscale x 3 x i32>
+    // Casting to and from means we can ensure the cast build functions return a vector when one is provided.
+    let fn_type = int32_vec_type.fn_type(&[int8_vec_type.into()], false);
+    let fn_value = module.add_function("test_int_vec_cast", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+    let casted_vec = builder.build_int_cast(in_vec, int32_vec_type, "casted_vec").unwrap();
+    let _uncasted_vec = builder.build_int_cast(casted_vec, int8_vec_type, "uncasted_vec");
+    builder.build_return(Some(&casted_vec)).unwrap();
+    assert!(fn_value.verify(true));
+
+    // Here we're building a function that takes in a <vscale x 3 x f32> and returns it casted to and from a <vscale x 3 x f16>
+    let fn_type = float16_vec_type.fn_type(&[float32_vec_type.into()], false);
+    let fn_value = module.add_function("test_float_vec_cast", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+    let casted_vec = builder
+        .build_float_cast(in_vec, float16_vec_type, "casted_vec")
+        .unwrap();
+    let _uncasted_vec = builder.build_float_cast(casted_vec, float32_vec_type, "uncasted_vec");
+    builder.build_return(Some(&casted_vec)).unwrap();
+    assert!(fn_value.verify(true));
+
+    // Here we're building a function that takes in a <vscale x 3 x f32> and returns it casted to and from a <vscale x 3 x i32>
+    let fn_type = int32_vec_type.fn_type(&[float32_vec_type.into()], false);
+    let fn_value = module.add_function("test_float_to_int_vec_cast", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+    let casted_vec = builder
+        .build_float_to_signed_int(in_vec, int32_vec_type, "casted_vec")
+        .unwrap();
+    let _uncasted_vec = builder.build_signed_int_to_float(casted_vec, float32_vec_type, "uncasted_vec");
+    builder.build_return(Some(&casted_vec)).unwrap();
+    assert!(fn_value.verify(true));
+}
+
 #[llvm_versions(8..)]
 #[test]
 fn test_vector_convert_ops_respect_target_signedness() {
@@ -931,6 +987,31 @@ fn test_vector_convert_ops_respect_target_signedness() {
 
     builder.position_at_end(entry);
     let in_vec = fn_value.get_first_param().unwrap().into_vector_value();
+    let casted_vec = builder
+        .build_int_cast_sign_flag(in_vec, int8_vec_type, true, "casted_vec")
+        .unwrap();
+    let _uncasted_vec = builder.build_int_cast_sign_flag(casted_vec, int8_vec_type, true, "uncasted_vec");
+    builder.build_return(Some(&casted_vec)).unwrap();
+
+    assert!(fn_value.verify(true));
+}
+
+#[llvm_versions(12..)]
+#[test]
+fn test_scalable_vector_convert_ops_respect_target_signedness() {
+    let context = Context::create();
+    let module = context.create_module("test");
+    let int8_vec_type = context.i8_type().scalable_vec_type(3);
+
+    // Here we're building a function that takes in a <vscale x 3 x i8> (signed) and returns it 
+    // casted to and from a <vscale x 3 x i8> (unsigned)
+    let fn_type = int8_vec_type.fn_type(&[int8_vec_type.into()], false);
+    let fn_value = module.add_function("test_int_vec_cast", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
     let casted_vec = builder
         .build_int_cast_sign_flag(in_vec, int8_vec_type, true, "casted_vec")
         .unwrap();
@@ -1011,6 +1092,79 @@ fn test_vector_binary_ops() {
     assert!(fn_value.verify(true));
 }
 
+#[llvm_versions(12..)]
+#[test]
+fn test_scalable_vector_binary_ops() {
+    let context = Context::create();
+    let module = context.create_module("test");
+    let int32_vec_type = context.i32_type().scalable_vec_type(2);
+    let float32_vec_type = context.f32_type().scalable_vec_type(2);
+    let bool_vec_type = context.bool_type().scalable_vec_type(2);
+
+    // Here we're building a function that takes in three <vscale x 2 x i32>s and returns them 
+    // added together as a <vscale x 2 x i32>
+    let fn_type = int32_vec_type.fn_type(
+        &[int32_vec_type.into(), int32_vec_type.into(), int32_vec_type.into()],
+        false,
+    );
+    let fn_value = module.add_function("test_int_vec_add", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let p1_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+    let p2_vec = fn_value.get_nth_param(1).unwrap().into_scalable_vector_value();
+    let p3_vec = fn_value.get_nth_param(2).unwrap().into_scalable_vector_value();
+    let added_vec = builder.build_int_add(p1_vec, p2_vec, "added_vec").unwrap();
+    let added_vec = builder.build_int_add(added_vec, p3_vec, "added_vec").unwrap();
+    builder.build_return(Some(&added_vec)).unwrap();
+    assert!(fn_value.verify(true));
+
+    // Here we're building a function that takes in three <vscale x 2 x f32>s and returns x * y / z as an
+    // <vscale x 2 x f32>
+    let fn_type = float32_vec_type.fn_type(
+        &[
+            float32_vec_type.into(),
+            float32_vec_type.into(),
+            float32_vec_type.into(),
+        ],
+        false,
+    );
+    let fn_value = module.add_function("test_float_vec_mul", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let p1_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+    let p2_vec = fn_value.get_nth_param(1).unwrap().into_scalable_vector_value();
+    let p3_vec = fn_value.get_nth_param(2).unwrap().into_scalable_vector_value();
+    let multiplied_vec = builder.build_float_mul(p1_vec, p2_vec, "multiplied_vec").unwrap();
+    let divided_vec = builder.build_float_div(multiplied_vec, p3_vec, "divided_vec").unwrap();
+    builder.build_return(Some(&divided_vec)).unwrap();
+    assert!(fn_value.verify(true));
+
+    // Here we're building a function that takes two <vscale x 2 x f32>s and a <vscale x 2 x bool> and returns (x < y) * z
+    // as a <vscale x 2 x bool>
+    let fn_type = bool_vec_type.fn_type(
+        &[float32_vec_type.into(), float32_vec_type.into(), bool_vec_type.into()],
+        false,
+    );
+    let fn_value = module.add_function("test_float_vec_compare", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let p1_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+    let p2_vec = fn_value.get_nth_param(1).unwrap().into_scalable_vector_value();
+    let p3_vec = fn_value.get_nth_param(2).unwrap().into_scalable_vector_value();
+    let compared_vec = builder
+        .build_float_compare(inkwell::FloatPredicate::OLT, p1_vec, p2_vec, "compared_vec")
+        .unwrap();
+    let multiplied_vec = builder.build_int_mul(compared_vec, p3_vec, "multiplied_vec").unwrap();
+    builder.build_return(Some(&multiplied_vec)).unwrap();
+    assert!(fn_value.verify(true));
+}
+
 #[test]
 fn test_vector_pointer_ops() {
     let context = Context::create();
@@ -1041,6 +1195,43 @@ fn test_vector_pointer_ops() {
 
     builder.position_at_end(entry);
     let in_vec = fn_value.get_first_param().unwrap().into_vector_value();
+    let ptr_vec = builder.build_int_to_ptr(in_vec, i8_ptr_vec_type, "ptr_vec").unwrap();
+    let is_null_vec = builder.build_is_null(ptr_vec, "is_null_vec").unwrap();
+    builder.build_return(Some(&is_null_vec)).unwrap();
+    assert!(fn_value.verify(true));
+}
+
+#[llvm_versions(12..)]
+#[test]
+fn test_scalable_vector_pointer_ops() {
+    let context = Context::create();
+    let module = context.create_module("test");
+    let int32_vec_type = context.i32_type().scalable_vec_type(4);
+    #[cfg(not(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    )))]
+    let i8_ptr_vec_type = context.i8_type().ptr_type(AddressSpace::default()).scalable_vec_type(4);
+    #[cfg(any(
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let i8_ptr_vec_type = context.ptr_type(AddressSpace::default()).scalable_vec_type(4);
+    let bool_vec_type = context.bool_type().scalable_vec_type(4);
+
+    // Here we're building a function that takes a <vscale x 4 x i32>, converts it to a <vscale x 4 x i8*> and returns a
+    // <vscale x 4 x bool> if the pointer is null
+    let fn_type = bool_vec_type.fn_type(&[int32_vec_type.into()], false);
+    let fn_value = module.add_function("test_ptr_null", fn_type, None);
+    let entry = context.append_basic_block(fn_value, "entry");
+    let builder = context.create_builder();
+
+    builder.position_at_end(entry);
+    let in_vec = fn_value.get_first_param().unwrap().into_scalable_vector_value();
     let ptr_vec = builder.build_int_to_ptr(in_vec, i8_ptr_vec_type, "ptr_vec").unwrap();
     let is_null_vec = builder.build_is_null(ptr_vec, "is_null_vec").unwrap();
     builder.build_return(Some(&is_null_vec)).unwrap();
@@ -1208,6 +1399,48 @@ fn test_insert_element() {
     #[llvm_versions(..12)]
     fn get_empty_vector_of(ty: IntType<'_>) -> VectorValue<'_> {
         ty.vec_type(4).get_undef()
+    }
+
+    let i8_ty = context.i8_type();
+    let i32_ty = context.i32_type();
+    let mut v = get_empty_vector_of(i8_ty);
+    v = builder
+        .build_insert_element(v, i8_ty.const_int(0, false), i32_ty.const_int(0, false), "v0")
+        .unwrap();
+    v = builder
+        .build_insert_element(v, i8_ty.const_int(1, false), i32_ty.const_int(1, false), "v1")
+        .unwrap();
+    v = builder
+        .build_insert_element(v, i8_ty.const_int(2, false), i32_ty.const_int(2, false), "v2")
+        .unwrap();
+    v = builder
+        .build_insert_element(v, i8_ty.const_int(3, false), i32_ty.const_int(3, false), "v3")
+        .unwrap();
+    let _ = v;
+
+    builder.build_return(None).unwrap();
+
+    assert!(module.verify().is_ok());
+}
+
+#[llvm_versions(12..)]
+#[test]
+fn test_insert_element_scalable() {
+    use inkwell::types::IntType;
+    use inkwell::values::ScalableVectorValue;
+
+    let context = Context::create();
+    let module = context.create_module("vec");
+
+    let fn_type = context.void_type().fn_type(&[], false);
+    let fn_value = module.add_function("vec_fn", fn_type, None);
+    let builder = context.create_builder();
+    let entry = context.append_basic_block(fn_value, "entry");
+
+    builder.position_at_end(entry);
+
+    fn get_empty_vector_of(ty: IntType<'_>) -> ScalableVectorValue<'_> {
+        ty.scalable_vec_type(4).get_poison()
     }
 
     let i8_ty = context.i8_type();
@@ -1683,12 +1916,32 @@ fn test_bit_cast() {
     ))]
     let i64_ptr_type = context.ptr_type(AddressSpace::default());
     let i32_vec_type = i32_type.vec_type(2);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let i32_scalable_vec_type = i32_type.scalable_vec_type(2);
     let arg_types = [
         i32_type.into(),
         f32_type.into(),
         i32_vec_type.into(),
         i32_ptr_type.into(),
         f64_type.into(),
+        #[cfg(any(
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0",
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ))]
+        i32_scalable_vec_type.into(),
     ];
     let fn_type = void_type.fn_type(&arg_types, false);
     let fn_value = module.add_function("bc", fn_type, None);
@@ -1699,6 +1952,16 @@ fn test_bit_cast() {
     let i32_vec_arg = fn_value.get_nth_param(2).unwrap();
     let i32_ptr_arg = fn_value.get_nth_param(3).unwrap();
     let f64_arg = fn_value.get_nth_param(4).unwrap();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let i32_scalable_vec_arg = fn_value.get_nth_param(5).unwrap();
 
     builder.position_at_end(entry);
 
@@ -1706,6 +1969,21 @@ fn test_bit_cast() {
 
     builder.build_bit_cast(f32_arg, f32_type, "f32tof32").unwrap();
     builder.build_bit_cast(i32_vec_arg, i64_type, "2xi32toi64").unwrap();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    {
+        let i64_scalable_vec_type = i64_type.scalable_vec_type(1);
+        let f32_scalable_vec_type = f32_type.scalable_vec_type(2);
+        builder.build_bit_cast(i32_scalable_vec_arg, i64_scalable_vec_type, "vscalex2xi32tovscalex1xi64").unwrap();
+        builder.build_bit_cast(i32_scalable_vec_arg, f32_scalable_vec_type, "vscalex2xi32tovscalex2xf32").unwrap();
+    }
     builder.build_bit_cast(i32_ptr_arg, i64_ptr_type, "i32*toi64*").unwrap();
 
     builder.build_return(None).unwrap();

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -527,7 +527,7 @@ fn test_mem_instructions() {
     assert!(fadd_instruction.set_alignment(16).is_err());
 }
 
-#[llvm_versions(11..)]
+#[llvm_versions(12..)]
 #[test]
 fn test_mem_instructions() {
     let context = Context::create();

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -430,6 +430,16 @@ fn test_vec_type() {
     assert_eq!(vec_type.get_size(), 42);
 }
 
+#[llvm_versions(11..)]
+#[test]
+fn test_scalable_vec_type() {
+    let context = Context::create();
+    let int = context.i8_type();
+    let vec_type = int.scalable_vec_type(42);
+
+    assert_eq!(vec_type.get_size(), 42);
+}
+
 #[test]
 fn test_type_copies() {
     let context = Context::create();
@@ -550,6 +560,15 @@ fn test_no_vector_zero() {
     let context = Context::create();
     let int = context.i32_type();
     int.vec_type(0);
+}
+
+#[llvm_versions(11..)]
+#[test]
+#[should_panic]
+fn test_no_scalable_vector_zero() {
+    let context = Context::create();
+    let int = context.i32_type();
+    int.scalable_vec_type(0);
 }
 
 #[test]

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -276,6 +276,37 @@ fn sized_types(global_ctx: &Context) {
     ))]
     assert!(ptr_type.vec_type(42).is_sized());
 
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    {
+        assert!(bool_type.scalable_vec_type(42).is_sized());
+        assert!(i8_type.scalable_vec_type(42).is_sized());
+        assert!(i16_type.scalable_vec_type(42).is_sized());
+        assert!(i32_type.scalable_vec_type(42).is_sized());
+        assert!(i64_type.scalable_vec_type(42).is_sized());
+        assert!(i128_type.scalable_vec_type(42).is_sized());
+        assert!(f16_type.scalable_vec_type(42).is_sized());
+        assert!(f32_type.scalable_vec_type(42).is_sized());
+        assert!(f64_type.scalable_vec_type(42).is_sized());
+        assert!(f80_type.scalable_vec_type(42).is_sized());
+        assert!(f128_type.scalable_vec_type(42).is_sized());
+        assert!(ppc_f128_type.scalable_vec_type(42).is_sized());
+        #[cfg(any(
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ))]
+        assert!(ptr_type.scalable_vec_type(42).is_sized());
+    }
+
     let opaque_struct_type = global_ctx.opaque_struct_type("opaque");
 
     assert!(!opaque_struct_type.is_sized());
@@ -324,6 +355,16 @@ fn test_const_zero() {
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let vec_type = f64_type.vec_type(42);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_type = f64_type.scalable_vec_type(42);
     let array_type = f64_type.array_type(42);
 
     bool_type.size_of();
@@ -331,6 +372,16 @@ fn test_const_zero() {
     struct_type.size_of();
     ptr_type.size_of();
     vec_type.size_of();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    scalable_vec_type.size_of();
     array_type.size_of();
 
     bool_type.get_alignment();
@@ -338,6 +389,16 @@ fn test_const_zero() {
     struct_type.get_alignment();
     ptr_type.get_alignment();
     vec_type.get_alignment();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    scalable_vec_type.get_alignment();
     array_type.get_alignment();
 
     let bool_zero = bool_type.const_zero();
@@ -355,6 +416,16 @@ fn test_const_zero() {
     let struct_zero = struct_type.const_zero();
     let ptr_zero = ptr_type.const_zero();
     let vec_zero = vec_type.const_zero();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_zero = scalable_vec_type.const_zero();
     let array_zero = array_type.const_zero();
 
     assert!(bool_zero.is_null());
@@ -372,6 +443,16 @@ fn test_const_zero() {
     assert!(struct_zero.is_null());
     assert!(ptr_zero.is_null());
     assert!(vec_zero.is_null());
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert!(scalable_vec_zero.is_null());
     assert!(array_zero.is_null());
 
     assert_eq!(bool_zero.print_to_string().to_str(), Ok("i1 false"));
@@ -415,6 +496,19 @@ fn test_const_zero() {
     assert_eq!(ptr_zero.print_to_string().to_str(), Ok(ptr_type));
 
     assert_eq!(vec_zero.print_to_string().to_str(), Ok("<42 x double> zeroinitializer"));
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert_eq!(
+        scalable_vec_zero.print_to_string().to_str(),
+        Ok("<vscale x 42 x double> zeroinitializer")
+    );
     assert_eq!(
         array_zero.print_to_string().to_str(),
         Ok("[42 x double] zeroinitializer")
@@ -430,7 +524,7 @@ fn test_vec_type() {
     assert_eq!(vec_type.get_size(), 42);
 }
 
-#[llvm_versions(11..)]
+#[llvm_versions(12..)]
 #[test]
 fn test_scalable_vec_type() {
     let context = Context::create();
@@ -537,6 +631,17 @@ fn test_basic_type_enum() {
         &context.ptr_type(addr),
         &context.struct_type(&[int.as_basic_type_enum()], false),
         &int.vec_type(1),
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0",
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ))]
+        &int.scalable_vec_type(1),
     ];
     for basic_type in types {
         #[cfg(not(any(
@@ -562,7 +667,7 @@ fn test_no_vector_zero() {
     int.vec_type(0);
 }
 
-#[llvm_versions(11..)]
+#[llvm_versions(12..)]
 #[test]
 #[should_panic]
 fn test_no_scalable_vector_zero() {

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -632,7 +632,6 @@ fn test_basic_type_enum() {
         &context.struct_type(&[int.as_basic_type_enum()], false),
         &int.vec_type(1),
         #[cfg(any(
-            feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -197,6 +197,16 @@ fn test_set_get_name() {
     let array_val = f64_type.const_array(&[f64_val]);
     let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
     let vec_val = VectorType::const_vector(&[i8_val]);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_val = f64_type.scalable_vec_type(42).const_zero();
     let ppc_f128_val = ppc_f128_type.const_float(0.0);
 
     assert_eq!(bool_val.get_name().to_str(), Ok(""));
@@ -213,6 +223,16 @@ fn test_set_get_name() {
     assert_eq!(array_val.get_name().to_str(), Ok(""));
     assert_eq!(struct_val.get_name().to_str(), Ok(""));
     assert_eq!(vec_val.get_name().to_str(), Ok(""));
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert_eq!(scalable_vec_val.get_name().to_str(), Ok(""));
     assert_eq!(ppc_f128_val.get_name().to_str(), Ok(""));
 
     // LLVM Gem: You can't set names on constant values, so this doesn't do anything:
@@ -230,7 +250,17 @@ fn test_set_get_name() {
     array_val.set_name("my_val12");
     struct_val.set_name("my_val13");
     vec_val.set_name("my_val14");
-    ppc_f128_val.set_name("my_val14");
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    scalable_vec_val.set_name("my_val15");
+    ppc_f128_val.set_name("my_val16");
 
     assert_eq!(bool_val.get_name().to_str(), Ok(""));
     assert_eq!(i8_val.get_name().to_str(), Ok(""));
@@ -246,6 +276,16 @@ fn test_set_get_name() {
     assert_eq!(array_val.get_name().to_str(), Ok(""));
     assert_eq!(struct_val.get_name().to_str(), Ok(""));
     assert_eq!(vec_val.get_name().to_str(), Ok(""));
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert_eq!(scalable_vec_val.get_name().to_str(), Ok(""));
     assert_eq!(ppc_f128_val.get_name().to_str(), Ok(""));
 
     let void_type = context.void_type();
@@ -265,6 +305,16 @@ fn test_set_get_name() {
     let ptr_type = context.ptr_type(AddressSpace::default());
     let struct_type = context.struct_type(&[bool_type.into()], false);
     let vec_type = bool_type.vec_type(1);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_type = bool_type.scalable_vec_type(1);
 
     let module = context.create_module("types");
     let builder = context.create_builder();
@@ -277,6 +327,17 @@ fn test_set_get_name() {
         array_type.into(),
         ptr_type.into(),
         vec_type.into(),
+        #[cfg(any(
+            feature = "llvm11-0",
+            feature = "llvm12-0",
+            feature = "llvm13-0",
+            feature = "llvm14-0",
+            feature = "llvm15-0",
+            feature = "llvm16-0",
+            feature = "llvm17-0",
+            feature = "llvm18-0"
+        ))]
+        scalable_vec_type.into(),
     ];
     let fn_type = void_type.fn_type(&fn_type_params, false);
 
@@ -291,6 +352,16 @@ fn test_set_get_name() {
     let array_param = function.get_nth_param(3).unwrap().into_array_value();
     let ptr_param = function.get_nth_param(4).unwrap().into_pointer_value();
     let vec_param = function.get_nth_param(5).unwrap().into_vector_value();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_param = function.get_nth_param(6).unwrap().into_scalable_vector_value();
     let phi_val = builder.build_phi(bool_type, "phi_node").unwrap();
 
     assert_eq!(int_param.get_name().to_str(), Ok(""));
@@ -299,6 +370,16 @@ fn test_set_get_name() {
     assert_eq!(array_param.get_name().to_str(), Ok(""));
     assert_eq!(ptr_param.get_name().to_str(), Ok(""));
     assert_eq!(vec_param.get_name().to_str(), Ok(""));
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert_eq!(scalable_vec_param.get_name().to_str(), Ok(""));
     assert_eq!(phi_val.get_name().to_str(), Ok("phi_node"));
 
     int_param.set_name("my_val");
@@ -307,6 +388,16 @@ fn test_set_get_name() {
     array_param.set_name("my_val4");
     struct_param.set_name("my_val5");
     vec_param.set_name("my_val6");
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    scalable_vec_param.set_name("my_val7");
     phi_val.set_name("phi");
 
     assert_eq!(int_param.get_name().to_str(), Ok("my_val"));
@@ -315,6 +406,16 @@ fn test_set_get_name() {
     assert_eq!(array_param.get_name().to_str(), Ok("my_val4"));
     assert_eq!(struct_param.get_name().to_str(), Ok("my_val5"));
     assert_eq!(vec_param.get_name().to_str(), Ok("my_val6"));
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert_eq!(scalable_vec_param.get_name().to_str(), Ok("my_val7"));
     assert_eq!(phi_val.get_name().to_str(), Ok("phi"));
 
     // TODO: Test globals, supposedly constant globals work?
@@ -372,6 +473,16 @@ fn test_undef() {
     let array_val = f64_type.const_array(&[f64_val]);
     let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
     let vec_val = VectorType::const_vector(&[i8_val]);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_val = f64_type.scalable_vec_type(42).const_zero();
     let ppc_f128_val = ppc_f128_type.const_float(0.0);
 
     assert!(!bool_val.is_undef());
@@ -388,6 +499,16 @@ fn test_undef() {
     assert!(!array_val.is_undef());
     assert!(!struct_val.is_undef());
     assert!(!vec_val.is_undef());
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert!(!scalable_vec_val.is_undef());
     assert!(!ppc_f128_val.is_undef());
 
     let bool_undef = bool_type.get_undef();
@@ -417,6 +538,16 @@ fn test_undef() {
     let array_undef = array_type.get_undef();
     let struct_undef = context.struct_type(&[bool_type.into()], false).get_undef();
     let vec_undef = bool_type.vec_type(1).get_undef();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_undef = bool_type.scalable_vec_type(1).get_undef();
     let ppc_f128_undef = ppc_f128_type.get_undef();
 
     assert!(bool_undef.is_undef());
@@ -433,6 +564,16 @@ fn test_undef() {
     assert!(array_undef.is_undef());
     assert!(struct_undef.is_undef());
     assert!(vec_undef.is_undef());
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert!(scalable_vec_undef.is_undef());
     assert!(ppc_f128_undef.is_undef());
 }
 
@@ -458,6 +599,16 @@ fn test_poison() {
     ))]
     let ptr_type = context.ptr_type(AddressSpace::default());
     let array_type = f64_type.array_type(42);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_type = f64_type.scalable_vec_type(42);
     let ppc_f128_type = context.ppc_f128_type();
 
     assert_eq!(array_type.get_element_type().into_float_type(), f64_type);
@@ -489,6 +640,16 @@ fn test_poison() {
     let array_val = f64_type.const_array(&[f64_val]);
     let struct_val = context.const_struct(&[i8_val.into(), f128_val.into()], false);
     let vec_val = VectorType::const_vector(&[i8_val]);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_val = scalable_vec_type.const_zero();
     let ppc_f128_val = ppc_f128_type.const_float(0.0);
 
     assert!(!bool_val.is_poison());
@@ -505,6 +666,16 @@ fn test_poison() {
     assert!(!array_val.is_poison());
     assert!(!struct_val.is_poison());
     assert!(!vec_val.is_poison());
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert!(!scalable_vec_val.is_poison());
     assert!(!ppc_f128_val.is_poison());
 
     let bool_poison = bool_type.get_poison();
@@ -534,6 +705,16 @@ fn test_poison() {
     let array_poison = array_type.get_poison();
     let struct_poison = context.struct_type(&[bool_type.into()], false).get_poison();
     let vec_poison = bool_type.vec_type(1).get_poison();
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_poison = scalable_vec_type.get_poison();
     let ppc_f128_poison = ppc_f128_type.get_poison();
 
     assert!(bool_poison.is_poison());
@@ -550,6 +731,16 @@ fn test_poison() {
     assert!(array_poison.is_poison());
     assert!(struct_poison.is_poison());
     assert!(vec_poison.is_poison());
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert!(scalable_vec_poison.is_poison());
     assert!(ppc_f128_poison.is_poison());
 }
 
@@ -1343,6 +1534,16 @@ fn test_consts() {
     let f128_val = f128_type.const_float(7.8);
     let ppc_f128_val = ppc_f128_type.const_float(9.0);
     let vec_val = VectorType::const_vector(&[i8_val]);
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    let scalable_vec_val = f64_type.scalable_vec_type(42).const_zero();
     let array_val = i8_type.const_array(&[i8_val]);
     let arbitrary_precision_int = i64_type.const_int_arbitrary_precision(&[1, 2]);
 
@@ -1358,6 +1559,16 @@ fn test_consts() {
     assert!(f128_val.is_const());
     assert!(ppc_f128_val.is_const());
     assert!(vec_val.is_const());
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    assert!(scalable_vec_val.is_const());
     assert!(array_val.is_const());
     assert!(arbitrary_precision_int.is_const());
 
@@ -1365,6 +1576,20 @@ fn test_consts() {
 
     assert!(!vec_val.is_constant_vector());
     assert!(vec_val.is_constant_data_vector());
+
+    #[cfg(any(
+        feature = "llvm12-0",
+        feature = "llvm13-0",
+        feature = "llvm14-0",
+        feature = "llvm15-0",
+        feature = "llvm16-0",
+        feature = "llvm17-0",
+        feature = "llvm18-0"
+    ))]
+    {
+        assert!(!scalable_vec_val.is_constant_vector());
+        assert!(!scalable_vec_val.is_constant_data_vector());
+    }
 
     assert_eq!(bool_val.get_zero_extended_constant(), Some(1));
     assert_eq!(i8_val.get_zero_extended_constant(), Some(u8::MAX as u64));
@@ -1554,6 +1779,35 @@ fn test_vectors() {
 
     let extracted = builder
         .build_extract_element(vector_param, i32_zero, "extract")
+        .unwrap();
+
+    builder.build_return(Some(&extracted)).unwrap();
+
+    assert!(module.verify().is_ok());
+}
+
+#[llvm_versions(12..)]
+#[test]
+fn test_scalable_vectors() {
+    let context = Context::create();
+    let builder = context.create_builder();
+    let module = context.create_module("my_mod");
+    let i32_type = context.i32_type();
+    let i32_zero = i32_type.const_int(0, false);
+    let i32_seven = i32_type.const_int(7, false);
+    let scalable_vec_type = i32_type.scalable_vec_type(2);
+    let fn_type = i32_type.fn_type(&[scalable_vec_type.into()], false);
+    let fn_value = module.add_function("my_func", fn_type, None);
+    let bb = context.append_basic_block(fn_value, "entry");
+    let scalable_vector_param = fn_value.get_first_param().unwrap().into_scalable_vector_value();
+
+    builder.position_at_end(bb);
+    builder
+        .build_insert_element(scalable_vector_param, i32_seven, i32_zero, "insert")
+        .unwrap();
+
+    let extracted = builder
+        .build_extract_element(scalable_vector_param, i32_zero, "extract")
         .unwrap();
 
     builder.build_return(Some(&extracted)).unwrap();

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -328,7 +328,6 @@ fn test_set_get_name() {
         ptr_type.into(),
         vec_type.into(),
         #[cfg(any(
-            feature = "llvm11-0",
             feature = "llvm12-0",
             feature = "llvm13-0",
             feature = "llvm14-0",
@@ -1576,20 +1575,6 @@ fn test_consts() {
 
     assert!(!vec_val.is_constant_vector());
     assert!(vec_val.is_constant_data_vector());
-
-    #[cfg(any(
-        feature = "llvm12-0",
-        feature = "llvm13-0",
-        feature = "llvm14-0",
-        feature = "llvm15-0",
-        feature = "llvm16-0",
-        feature = "llvm17-0",
-        feature = "llvm18-0"
-    ))]
-    {
-        assert!(!scalable_vec_val.is_constant_vector());
-        assert!(!scalable_vec_val.is_constant_data_vector());
-    }
 
     assert_eq!(bool_val.get_zero_extended_constant(), Some(1));
     assert_eq!(i8_val.get_zero_extended_constant(), Some(u8::MAX as u64));


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

This adds scalable vector support through the new `ScalableVectorType` and `ScalableVectorValue`.

<!--- Describe your changes in detail -->

## Related Issue

#541 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

Tests mirroring the fixed vector kind have been added for type, value and builder. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
