### PR TITLE
Reset `positioned` in `Builder::clear_insertion_position`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3247,6 +3247,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn clear_insertion_position(&self) {
+        self.positioned.set(PositionState::NotSet);
         unsafe { LLVMClearInsertionPosition(self.builder) }
     }
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
Resets the `positioned` field in the `Builder::clear_insertion_position` method. This fixes the problem described in https://github.com/TheDan64/inkwell/issues/560.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
Fixes https://github.com/TheDan64/inkwell/issues/560.

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
```
$ cargo test -q -F llvm18-0 2>/dev/null

running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 150 tests
...................................................................i................... 87/150
...............................................................
test result: ok. 149 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 344 tests
....................................................................................... 87/344
.............................iiiii..................................................... 174/344
........................................................iiiiiiiiiiii................... 261/344
...................................................................i...............
test result: ok. 326 passed; 0 failed; 18 ignored; 0 measured; 0 filtered out; finished in 3.07s
```

<!--- ## Option\<Breaking Changes\> -->

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
