### PR TITLE
Add create_mcjit_execution_engine_with_memory_manager for custom MCJIT memory management

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod debug_info;
 pub mod execution_engine;
 pub mod intrinsics;
 pub mod memory_buffer;
+pub mod memory_manager;
 #[deny(missing_docs)]
 pub mod module;
 pub mod object_file;

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -1,0 +1,179 @@
+use llvm_sys::prelude::LLVMBool;
+
+/// A trait for user-defined memory management in MCJIT.
+///
+/// Implementors can override how LLVM's MCJIT engine allocates memory for code
+/// and data sections. This is sometimes needed for:
+/// - custom allocators,
+/// - sandboxed or restricted environments,
+/// - capturing stack map sections (e.g., for garbage collection),
+/// - or other specialized JIT memory management requirements.
+///
+/// # StackMap and GC Integration
+///
+/// By examining the `section_name` argument in [`allocate_data_section`], you
+/// can detect sections such as `.llvm_stackmaps` (on ELF) or `__llvm_stackmaps`
+/// (on Mach-O). Recording the location of these sections may be useful for
+/// custom garbage collectors. For more information, refer to the [LLVM
+/// StackMaps documentation](https://llvm.org/docs/StackMaps.html#stack-map-section).
+///
+/// Typically, on Darwin (Mach-O), the stack map section name is `__llvm_stackmaps`,
+/// and on Linux (ELF), it is `.llvm_stackmaps`.
+pub trait McjitMemoryManager: std::fmt::Debug {
+    /// Allocates a block of memory for a code section.
+    ///
+    /// # Parameters
+    ///
+    /// * `size` - The size in bytes for the code section.
+    /// * `alignment` - The required alignment in bytes.
+    /// * `section_id` - A numeric ID that LLVM uses to identify this section.
+    /// * `section_name` - A name for this section, if provided by LLVM.
+    ///
+    /// # Returns
+    ///
+    /// Returns a pointer to the allocated memory. Implementors must ensure it is
+    /// at least `size` bytes long and meets `alignment` requirements.
+    fn allocate_code_section(
+        &mut self,
+        size: libc::uintptr_t,
+        alignment: libc::c_uint,
+        section_id: libc::c_uint,
+        section_name: &str,
+    ) -> *mut u8;
+
+    /// Allocates a block of memory for a data section.
+    ///
+    /// # Parameters
+    ///
+    /// * `size` - The size in bytes for the data section.
+    /// * `alignment` - The required alignment in bytes.
+    /// * `section_id` - A numeric ID that LLVM uses to identify this section.
+    /// * `section_name` - A name for this section, if provided by LLVM.
+    /// * `is_read_only` - Whether this data section should be read-only.
+    ///
+    /// # Returns
+    ///
+    /// Returns a pointer to the allocated memory. Implementors must ensure it is
+    /// at least `size` bytes long and meets `alignment` requirements.
+    fn allocate_data_section(
+        &mut self,
+        size: libc::uintptr_t,
+        alignment: libc::c_uint,
+        section_id: libc::c_uint,
+        section_name: &str,
+        is_read_only: bool,
+    ) -> *mut u8;
+
+    /// Finalizes memory permissions for all allocated sections.
+    ///
+    /// This is called once all sections have been allocated. Implementors can set
+    /// permissions such as making code sections executable or data sections
+    /// read-only.
+    ///
+    /// # Errors
+    ///
+    /// If any error occurs (for example, failing to set page permissions),
+    /// return an `Err(String)`. This error is reported back to LLVM as a C string.
+    fn finalize_memory(&mut self) -> Result<(), String>;
+
+    /// Cleans up or deallocates resources before the memory manager is destroyed.
+    ///
+    /// This is called when LLVM has finished using the memory manager. Any
+    /// additional allocations or references should be released here if needed.
+    fn destroy(&mut self);
+}
+
+/// Holds a boxed `McjitMemoryManager` and passes it to LLVM as an opaque pointer.
+///
+/// LLVM calls into the adapter using the extern "C" function pointers defined below.
+#[derive(Debug)]
+pub struct MemoryManagerAdapter {
+    pub memory_manager: Box<dyn McjitMemoryManager>,
+}
+
+// ------ Extern "C" Adapters ------
+
+/// Adapter for `allocate_code_section`.
+///
+/// Called by LLVM with a raw pointer (`opaque`). Casts back to `MemoryManagerAdapter`
+/// and delegates to `allocate_code_section`.
+pub(crate) extern "C" fn allocate_code_section_adapter(
+    opaque: *mut libc::c_void,
+    size: libc::uintptr_t,
+    alignment: libc::c_uint,
+    section_id: libc::c_uint,
+    section_name: *const libc::c_char,
+) -> *mut u8 {
+    let adapter = unsafe { &mut *(opaque as *mut MemoryManagerAdapter) };
+    let sname = c_str_to_str(section_name);
+    adapter
+        .memory_manager
+        .allocate_code_section(size, alignment, section_id, sname)
+}
+
+/// Adapter for `allocate_data_section`.
+///
+/// Note that `LLVMBool` is `0` for false, and `1` for true. We check `!= 0` to
+/// interpret it as a bool.
+pub(crate) extern "C" fn allocate_data_section_adapter(
+    opaque: *mut libc::c_void,
+    size: libc::uintptr_t,
+    alignment: libc::c_uint,
+    section_id: libc::c_uint,
+    section_name: *const libc::c_char,
+    is_read_only: LLVMBool,
+) -> *mut u8 {
+    let adapter = unsafe { &mut *(opaque as *mut MemoryManagerAdapter) };
+    let sname = c_str_to_str(section_name);
+    adapter
+        .memory_manager
+        .allocate_data_section(size, alignment, section_id, sname, is_read_only != 0)
+}
+
+/// Adapter for `finalize_memory`.
+///
+/// If an error is returned, the message is converted into a C string and set in `err_msg_out`.
+pub(crate) extern "C" fn finalize_memory_adapter(
+    opaque: *mut libc::c_void,
+    err_msg_out: *mut *mut libc::c_char,
+) -> libc::c_int {
+    let adapter = unsafe { &mut *(opaque as *mut MemoryManagerAdapter) };
+    match adapter.memory_manager.finalize_memory() {
+        Ok(()) => 0,
+        Err(e) => {
+            let cstring = std::ffi::CString::new(e).unwrap_or_default();
+            unsafe {
+                *err_msg_out = cstring.into_raw();
+            }
+            1
+        },
+    }
+}
+
+/// Adapter for `destroy`.
+///
+/// Called when LLVM is done with the memory manager. Calls `destroy` and drops
+/// the adapter to free resources.
+pub(crate) extern "C" fn destroy_adapter(opaque: *mut libc::c_void) {
+    let adapter = unsafe { &mut *(opaque as *mut MemoryManagerAdapter) };
+    adapter.memory_manager.destroy();
+
+    // Re-box to drop the adapter and its contents
+    unsafe {
+        let _ = Box::from_raw(adapter);
+    }
+}
+
+/// Converts a raw C string pointer to a Rust `&str`.
+///
+/// # Safety
+///
+/// The caller must ensure `ptr` points to a valid, null-terminated UTF-8 string.
+/// If the string is invalid UTF-8 or `ptr` is null, an empty string is returned.
+fn c_str_to_str<'a>(ptr: *const libc::c_char) -> &'a str {
+    if ptr.is_null() {
+        ""
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(ptr) }.to_str().unwrap_or("")
+    }
+}

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -105,7 +105,7 @@ pub(crate) extern "C" fn allocate_code_section_adapter(
     section_name: *const libc::c_char,
 ) -> *mut u8 {
     let adapter = unsafe { &mut *(opaque as *mut MemoryManagerAdapter) };
-    let sname = c_str_to_str(section_name);
+    let sname = unsafe { c_str_to_str(section_name) };
     adapter
         .memory_manager
         .allocate_code_section(size, alignment, section_id, sname)
@@ -124,7 +124,7 @@ pub(crate) extern "C" fn allocate_data_section_adapter(
     is_read_only: LLVMBool,
 ) -> *mut u8 {
     let adapter = unsafe { &mut *(opaque as *mut MemoryManagerAdapter) };
-    let sname = c_str_to_str(section_name);
+    let sname = unsafe { c_str_to_str(section_name) };
     adapter
         .memory_manager
         .allocate_data_section(size, alignment, section_id, sname, is_read_only != 0)
@@ -170,7 +170,7 @@ pub(crate) extern "C" fn destroy_adapter(opaque: *mut libc::c_void) {
 ///
 /// The caller must ensure `ptr` points to a valid, null-terminated UTF-8 string.
 /// If the string is invalid UTF-8 or `ptr` is null, an empty string is returned.
-fn c_str_to_str<'a>(ptr: *const libc::c_char) -> &'a str {
+unsafe fn c_str_to_str<'a>(ptr: *const libc::c_char) -> &'a str {
     if ptr.is_null() {
         ""
     } else {

--- a/src/module.rs
+++ b/src/module.rs
@@ -705,8 +705,8 @@ impl<'ctx> Module<'ctx> {
         // Override fields
         options.OptLevel = opt_level as u32;
         options.CodeModel = code_model.into();
-        options.NoFramePointerElim = if no_frame_pointer_elim { 1 } else { 0 };
-        options.EnableFastISel = if enable_fast_isel { 1 } else { 0 };
+        options.NoFramePointerElim = no_frame_pointer_elim as i32;
+        options.EnableFastISel = enable_fast_isel as i32;
         options.MCJMM = mmgr;
 
         // 5) Create MCJIT

--- a/src/module.rs
+++ b/src/module.rs
@@ -694,14 +694,16 @@ impl<'ctx> Module<'ctx> {
         }
 
         // 4) Build LLVMMCJITCompilerOptions
-        let mut options: llvm_sys::execution_engine::LLVMMCJITCompilerOptions = unsafe { std::mem::zeroed() };
+        let mut options_uninit = MaybeUninit::<llvm_sys::execution_engine::LLVMMCJITCompilerOptions>::zeroed();
         unsafe {
             // Ensure defaults are initialized
             llvm_sys::execution_engine::LLVMInitializeMCJITCompilerOptions(
-                &mut options,
+                options_uninit.as_mut_ptr(),
                 std::mem::size_of::<llvm_sys::execution_engine::LLVMMCJITCompilerOptions>(),
             );
         }
+        let mut options = unsafe { options_uninit.assume_init() };
+
         // Override fields
         options.OptLevel = opt_level as u32;
         options.CodeModel = code_model.into();

--- a/src/module.rs
+++ b/src/module.rs
@@ -9,10 +9,10 @@ use llvm_sys::core::LLVMGetTypeByName;
 
 use llvm_sys::core::{
     LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddNamedMetadataOperand, LLVMCloneModule,
-    LLVMDisposeModule, LLVMDumpModule, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetLastFunction,
-    LLVMGetLastGlobal, LLVMGetModuleContext, LLVMGetModuleIdentifier, LLVMGetNamedFunction, LLVMGetNamedGlobal,
-    LLVMGetNamedMetadataNumOperands, LLVMGetNamedMetadataOperands, LLVMGetTarget, LLVMPrintModuleToFile,
-    LLVMPrintModuleToString, LLVMSetDataLayout, LLVMSetModuleIdentifier, LLVMSetTarget, LLVMDisposeMessage
+    LLVMDisposeMessage, LLVMDisposeModule, LLVMDumpModule, LLVMGetFirstFunction, LLVMGetFirstGlobal,
+    LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetModuleContext, LLVMGetModuleIdentifier, LLVMGetNamedFunction,
+    LLVMGetNamedGlobal, LLVMGetNamedMetadataNumOperands, LLVMGetNamedMetadataOperands, LLVMGetTarget,
+    LLVMPrintModuleToFile, LLVMPrintModuleToString, LLVMSetDataLayout, LLVMSetModuleIdentifier, LLVMSetTarget,
 };
 #[llvm_versions(7..)]
 use llvm_sys::core::{LLVMAddModuleFlag, LLVMGetModuleFlag};
@@ -20,6 +20,7 @@ use llvm_sys::core::{LLVMAddModuleFlag, LLVMGetModuleFlag};
 use llvm_sys::error::LLVMGetErrorMessage;
 use llvm_sys::execution_engine::{
     LLVMCreateExecutionEngineForModule, LLVMCreateInterpreterForModule, LLVMCreateJITCompilerForModule,
+    LLVMCreateSimpleMCJITMemoryManager,
 };
 use llvm_sys::prelude::{LLVMModuleRef, LLVMValueRef};
 #[llvm_versions(13..)]
@@ -29,7 +30,7 @@ use llvm_sys::LLVMLinkage;
 use llvm_sys::LLVMModuleFlagBehavior;
 
 use std::cell::{Cell, Ref, RefCell};
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
 use std::fs::File;
 use std::marker::PhantomData;
 use std::mem::{forget, MaybeUninit};
@@ -45,12 +46,16 @@ use crate::data_layout::DataLayout;
 use crate::debug_info::{DICompileUnit, DWARFEmissionKind, DWARFSourceLanguage, DebugInfoBuilder};
 use crate::execution_engine::ExecutionEngine;
 use crate::memory_buffer::MemoryBuffer;
+use crate::memory_manager::{
+    allocate_code_section_adapter, allocate_data_section_adapter, destroy_adapter, finalize_memory_adapter,
+    McjitMemoryManager, MemoryManagerAdapter,
+};
 #[llvm_versions(13..)]
 use crate::passes::PassBuilderOptions;
 use crate::support::{to_c_str, LLVMString};
 #[llvm_versions(13..)]
 use crate::targets::TargetMachine;
-use crate::targets::{InitializationConfig, Target, TargetTriple};
+use crate::targets::{CodeModel, InitializationConfig, Target, TargetTriple};
 use crate::types::{AsTypeRef, BasicType, FunctionType, StructType};
 #[llvm_versions(7..)]
 use crate::values::BasicValue;
@@ -601,6 +606,130 @@ impl<'ctx> Module<'ctx> {
             }
         }
 
+        let execution_engine = unsafe { execution_engine.assume_init() };
+        let execution_engine = unsafe { ExecutionEngine::new(Rc::new(execution_engine), true) };
+
+        *self.owned_by_ee.borrow_mut() = Some(execution_engine.clone());
+
+        Ok(execution_engine)
+    }
+
+    /// Creates an MCJIT `ExecutionEngine` for this `Module` using a custom memory manager.
+    ///
+    /// # Parameters
+    ///
+    /// * `memory_manager` - Specifies how LLVM allocates and finalizes code and data sections.
+    ///   Implement the [`McjitMemoryManager`] trait to customize these operations.
+    /// * `opt_level` - Sets the desired optimization level (e.g. `None`, `Less`, `Default`, `Aggressive`).
+    ///   Higher levels generally produce faster code at the expense of longer compilation times.
+    /// * `code_model` - Determines how code addresses are represented. Common values include
+    ///   `CodeModel::Default` or `CodeModel::JITDefault`. This impacts the generated machine code layout.
+    /// * `no_frame_pointer_elim` - If true, frame pointer elimination is disabled. This may assist
+    ///   with certain debugging or profiling tasks but can incur a performance cost.
+    /// * `enable_fast_isel` - If true, uses a faster instruction selector where possible. This can
+    ///   improve compilation speed, though it may produce less optimized code in some cases.
+    ///
+    /// # Returns
+    ///
+    /// Returns a newly created [`ExecutionEngine`] for MCJIT on success. Returns an error if:
+    /// - The native target fails to initialize,
+    /// - The `Module` is already owned by another `ExecutionEngine`,
+    /// - Or MCJIT fails to create the engine (in which case an error string is returned from LLVM).
+    ///
+    /// # Notes
+    ///
+    /// Using a custom memory manager can help intercept or manage allocations for specific
+    /// sections (for example, capturing `.llvm_stackmaps` or applying custom permissions).
+    /// For details, refer to the [`McjitMemoryManager`] documentation.
+    ///
+    /// # Safety
+    ///
+    /// The returned [`ExecutionEngine`] takes ownership of the memory manager. Do not move
+    /// or free the `memory_manager` after calling this method. When the `ExecutionEngine`
+    /// is dropped, LLVM will destroy the memory manager by calling
+    /// [`McjitMemoryManager::destroy()`] and freeing its adapter.
+    pub fn create_mcjit_execution_engine_with_memory_manager(
+        &self,
+        memory_manager: impl McjitMemoryManager + 'static,
+        opt_level: OptimizationLevel,
+        code_model: CodeModel,
+        no_frame_pointer_elim: bool,
+        enable_fast_isel: bool,
+    ) -> Result<ExecutionEngine<'ctx>, LLVMString> {
+        use std::mem::MaybeUninit;
+        // ...
+
+        // 1) Initialize the native target
+        Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
+            err_string.push('\0');
+            LLVMString::create_from_str(&err_string)
+        })?;
+
+        // Check if the module is already owned by an ExecutionEngine
+        if self.owned_by_ee.borrow().is_some() {
+            let string = "This module is already owned by an ExecutionEngine.\0";
+            return Err(LLVMString::create_from_str(string));
+        }
+
+        // 2) Box the memory_manager into a MemoryManagerAdapter
+        let adapter = MemoryManagerAdapter {
+            memory_manager: Box::new(memory_manager),
+        };
+        let adapter_box = Box::new(adapter);
+        let opaque = Box::into_raw(adapter_box) as *mut c_void;
+
+        // 3) Create the LLVMMCJITMemoryManager using the custom callbacks
+        let mmgr = unsafe {
+            LLVMCreateSimpleMCJITMemoryManager(
+                opaque,
+                allocate_code_section_adapter,
+                allocate_data_section_adapter,
+                finalize_memory_adapter,
+                Some(destroy_adapter),
+            )
+        };
+        if mmgr.is_null() {
+            let msg = "Failed to create SimpleMCJITMemoryManager.\0";
+            return Err(LLVMString::create_from_str(msg));
+        }
+
+        // 4) Build LLVMMCJITCompilerOptions
+        let mut options: llvm_sys::execution_engine::LLVMMCJITCompilerOptions = unsafe { std::mem::zeroed() };
+        unsafe {
+            // Ensure defaults are initialized
+            llvm_sys::execution_engine::LLVMInitializeMCJITCompilerOptions(
+                &mut options,
+                std::mem::size_of::<llvm_sys::execution_engine::LLVMMCJITCompilerOptions>(),
+            );
+        }
+        // Override fields
+        options.OptLevel = opt_level as u32;
+        options.CodeModel = code_model.into();
+        options.NoFramePointerElim = if no_frame_pointer_elim { 1 } else { 0 };
+        options.EnableFastISel = if enable_fast_isel { 1 } else { 0 };
+        options.MCJMM = mmgr;
+
+        // 5) Create MCJIT
+        let mut execution_engine = MaybeUninit::uninit();
+        let mut err_string = MaybeUninit::uninit();
+        let code = unsafe {
+            llvm_sys::execution_engine::LLVMCreateMCJITCompilerForModule(
+                execution_engine.as_mut_ptr(),
+                self.module.get(),
+                &mut options,
+                std::mem::size_of::<llvm_sys::execution_engine::LLVMMCJITCompilerOptions>(),
+                err_string.as_mut_ptr(),
+            )
+        };
+
+        // If creation fails, extract the error string
+        if code == 1 {
+            unsafe {
+                return Err(LLVMString::new(err_string.assume_init()));
+            }
+        }
+
+        // Otherwise, it succeeded, so wrap the raw pointer
         let execution_engine = unsafe { execution_engine.assume_init() };
         let execution_engine = unsafe { ExecutionEngine::new(Rc::new(execution_engine), true) };
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -676,6 +676,8 @@ impl<'ctx> Module<'ctx> {
             memory_manager: Box::new(memory_manager),
         };
         let adapter_box = Box::new(adapter);
+        // Convert the Box into a raw pointer for LLVM.
+        // In `destroy_adapter`, we use `Box::from_raw` to safely reclaim ownership.
         let opaque = Box::into_raw(adapter_box) as *mut c_void;
 
         // 3) Create the LLVMMCJITMemoryManager using the custom callbacks

--- a/tests/all/test_execution_engine.rs
+++ b/tests/all/test_execution_engine.rs
@@ -1,6 +1,11 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use inkwell::context::Context;
 use inkwell::execution_engine::FunctionLookupError;
-use inkwell::targets::{InitializationConfig, Target};
+use inkwell::memory_manager::McjitMemoryManager;
+use inkwell::module::Linkage;
+use inkwell::targets::{CodeModel, InitializationConfig, Target};
 use inkwell::{AddressSpace, IntPredicate, OptimizationLevel};
 
 type Thunk = unsafe extern "C" fn();
@@ -151,6 +156,117 @@ fn test_interpreter_execution_engine() {
 }
 
 #[test]
+
+fn test_mcjit_execution_engine_with_memory_manager() {
+    let mmgr = MockMemoryManager::new();
+    let mmgr_for_test = mmgr.clone();
+
+    {
+        let context = Context::create();
+        let module = context.create_module("main_module");
+        let builder = context.create_builder();
+
+        // Define @llvm.experimental.stackmap
+        let fn_type = context
+            .void_type()
+            .fn_type(&[context.i64_type().into(), context.i32_type().into()], true);
+        let stackmap_func = module.add_function("llvm.experimental.stackmap", fn_type, Some(Linkage::External));
+
+        // Set up the function
+        //
+        // `@llvm.experimental.stackmap` a call is present, LLVM will emit a separate stackmap section,
+        // causing the `allocate_data_section` callback to be invoked an additional
+        // time to handle the stackmap data. Specifically:
+        // ```
+        // f64 test_fn() {
+        // entry:
+        //   call void @llvm.experimental.stackmap(i64 12345, i32 0)
+        //   ret f64 64.0
+        // }
+        // ```
+        let double = context.f64_type();
+        let sig = double.fn_type(&[], false);
+        let f = module.add_function("test_fn", sig, None);
+        let b = context.append_basic_block(f, "entry");
+        builder.position_at_end(b);
+
+        // Create a call to the stackmap intrinsic
+        // Stack maps are used by the garbage collector to find roots on the stack
+        // See: https://llvm.org/docs/StackMaps.html#intrinsics
+        builder
+            .build_call(
+                stackmap_func,
+                &[
+                    context.i64_type().const_int(12345, false).into(),
+                    context.i32_type().const_int(0, false).into(),
+                ],
+                "call_stackmap",
+            )
+            .unwrap();
+
+        // Insert a return statement
+        let ret = double.const_float(64.0);
+        builder.build_return(Some(&ret)).unwrap();
+
+        module.verify().unwrap();
+
+        let ee = module
+            .create_mcjit_execution_engine_with_memory_manager(
+                mmgr,
+                OptimizationLevel::None,
+                CodeModel::Default,
+                false,
+                false,
+            )
+            .unwrap();
+
+        unsafe {
+            let test_fn = ee.get_function::<unsafe extern "C" fn() -> f64>("test_fn").unwrap();
+            let return_value = test_fn.call();
+            assert_eq!(return_value, 64.0);
+        }
+    }
+    // ee dropped here. Destroy should be called
+
+    let data = mmgr_for_test.data.borrow();
+    assert_eq!(1, data.code_alloc_calls);
+    assert_eq!(2, data.data_alloc_calls);
+    assert_eq!(1, data.finalize_calls);
+    assert_eq!(1, data.destroy_calls);
+}
+
+#[test]
+fn test_create_mcjit_engine_when_already_owned() {
+    let context = Context::create();
+    let module = context.create_module("owned_module");
+
+    // First engine should succeed
+    let memory_manager = MockMemoryManager::new();
+    let engine_result = module.create_mcjit_execution_engine_with_memory_manager(
+        memory_manager,
+        OptimizationLevel::None,
+        CodeModel::Default,
+        false,
+        false,
+    );
+    assert!(engine_result.is_ok());
+
+    // Second engine should fail
+    let memory_manager2 = MockMemoryManager::new();
+    let second_result = module.create_mcjit_execution_engine_with_memory_manager(
+        memory_manager2,
+        OptimizationLevel::None,
+        CodeModel::Default,
+        false,
+        false,
+    );
+    assert!(
+        second_result.is_err(),
+        "Expected an error when creating a second ExecutionEngine on the same module"
+    );
+}
+
+#[test]
 fn test_add_remove_module() {
     let context = Context::create();
     let module = context.create_module("test");
@@ -235,3 +351,150 @@ fn test_add_remove_module() {
 //         module.create_jit_execution_engine(OptimizationLevel::None).unwrap()
 //     };
 // }
+
+/// A mock memory manager that allocates memory in fixed-size pages for testing.
+#[derive(Debug, Clone)]
+struct MockMemoryManager {
+    data: Rc<RefCell<MockMemoryManagerData>>,
+}
+
+#[derive(Debug)]
+struct MockMemoryManagerData {
+    fixed_capacity_bytes: usize,
+    fixed_page_size: usize,
+
+    code_buff_ptr: std::ptr::NonNull<u8>,
+    code_offset: usize,
+
+    data_buff_ptr: std::ptr::NonNull<u8>,
+    data_offset: usize,
+
+    /// Count call to callbacks for testing
+    code_alloc_calls: usize,
+    data_alloc_calls: usize,
+    finalize_calls: usize,
+    destroy_calls: usize,
+}
+
+impl MockMemoryManager {
+    pub fn new() -> Self {
+        let capacity_bytes = 128 * 1024;
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize };
+
+        let code_buff_ptr = unsafe {
+            std::ptr::NonNull::new_unchecked(libc::mmap(
+                std::ptr::null_mut(),
+                capacity_bytes,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            ) as *mut u8)
+        };
+
+        let data_buff_ptr = unsafe {
+            std::ptr::NonNull::new_unchecked(libc::mmap(
+                std::ptr::null_mut(),
+                capacity_bytes,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            ) as *mut u8)
+        };
+
+        Self {
+            data: Rc::new(RefCell::new(MockMemoryManagerData {
+                fixed_capacity_bytes: capacity_bytes,
+                fixed_page_size: page_size,
+
+                code_buff_ptr,
+                code_offset: 0,
+
+                data_buff_ptr,
+                data_offset: 0,
+
+                code_alloc_calls: 0,
+                data_alloc_calls: 0,
+                finalize_calls: 0,
+                destroy_calls: 0,
+            })),
+        }
+    }
+}
+
+impl McjitMemoryManager for MockMemoryManager {
+    fn allocate_code_section(
+        &mut self,
+        size: libc::size_t,
+        _alignment: libc::c_uint,
+        _section_id: libc::c_uint,
+        _section_name: &str,
+    ) -> *mut u8 {
+        let mut data = self.data.borrow_mut();
+        data.code_alloc_calls += 1;
+
+        let alloc_size = size.div_ceil(data.fixed_page_size) * data.fixed_page_size;
+        let ptr = unsafe { data.code_buff_ptr.as_ptr().add(data.code_offset) };
+        data.code_offset += alloc_size;
+
+        ptr
+    }
+
+    fn allocate_data_section(
+        &mut self,
+        size: libc::size_t,
+        _alignment: libc::c_uint,
+        _section_id: libc::c_uint,
+        _section_name: &str,
+        _is_read_only: bool,
+    ) -> *mut u8 {
+        let mut data = self.data.borrow_mut();
+
+        data.data_alloc_calls += 1;
+
+        let alloc_size = size.div_ceil(data.fixed_page_size) * data.fixed_page_size;
+        let ptr = unsafe { data.data_buff_ptr.as_ptr().add(data.data_offset) };
+        data.data_offset += alloc_size;
+
+        ptr
+    }
+
+    fn finalize_memory(&mut self) -> Result<(), String> {
+        let mut data = self.data.borrow_mut();
+
+        data.finalize_calls += 1;
+
+        unsafe {
+            libc::mprotect(
+                data.code_buff_ptr.as_ptr() as *mut libc::c_void,
+                data.fixed_capacity_bytes,
+                libc::PROT_READ | libc::PROT_EXEC,
+            );
+            libc::mprotect(
+                data.data_buff_ptr.as_ptr() as *mut libc::c_void,
+                data.fixed_capacity_bytes,
+                libc::PROT_READ | libc::PROT_WRITE,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn destroy(&mut self) {
+        let mut data = self.data.borrow_mut();
+
+        data.destroy_calls += 1;
+
+        unsafe {
+            libc::munmap(
+                data.code_buff_ptr.as_ptr() as *mut libc::c_void,
+                data.fixed_capacity_bytes,
+            );
+            libc::munmap(
+                data.data_buff_ptr.as_ptr() as *mut libc::c_void,
+                data.fixed_capacity_bytes,
+            );
+        }
+    }
+}

--- a/tests/all/test_execution_engine.rs
+++ b/tests/all/test_execution_engine.rs
@@ -230,7 +230,12 @@ fn test_mcjit_execution_engine_with_memory_manager() {
 
     let data = mmgr_for_test.data.borrow();
     assert_eq!(1, data.code_alloc_calls);
-    assert_eq!(2, data.data_alloc_calls);
+    assert!(
+        data.data_alloc_calls >= 2,
+        "Expected at least 2 calls to allocate_data_section, but got {}. \
+         We've observed that LLVM 5 typically calls it 3 times, while LLVM 18 often calls it only 2.",
+        data.data_alloc_calls
+    );
     assert_eq!(1, data.finalize_calls);
     assert_eq!(1, data.destroy_calls);
 }


### PR DESCRIPTION
---

## Description

This PR adds a new function, `create_mcjit_execution_engine_with_memory_manager`, which allows users to supply their own JIT memory manager (`McjitMemoryManager` trait). This enables custom allocation, finalization, and teardown logic for code and data sections under MCJIT.

## Related Issue

Close #296

## How This Has Been Tested

Tested on a Mac M1 MAX host running Docker (Debian bookworm),  
with LLVM 18 installed inside the container.

- Manually and testcode verified on AArch64 Linux with a small JIT-compiled function.
  ```
  f64 test_fn() {
  entry:
    call void @llvm.experimental.stackmap(i64 12345, i32 0)
    ret f64 64.0
  }
  ```
- Confirmed that user-defined `allocate_code_section`, `allocate_data_section`, `finalize_memory`, and `destroy` callbacks are invoked by MCJIT.
- No regressions observed in existing tests (the standard test suite still passes).

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the style and guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

---

### Changes

1. **New Public API**  
   ```rust
   pub fn create_mcjit_execution_engine_with_memory_manager(
       &self,
       memory_manager: impl McjitMemoryManager + 'static,
       opt_level: OptimizationLevel,
       code_model: CodeModel,
       no_frame_pointer_elim: bool,
       enable_fast_isel: bool,
   ) -> Result<ExecutionEngine<'ctx>, LLVMString> {
       // ...
       // Implementation that boxes the memory manager, creates an LLVMMCJITMemoryManager, 
       // and finalizes the MCJIT options before returning an `ExecutionEngine`.
       // ...
   }
   ```

2. **`McjitMemoryManager` Trait**  
   - Allows the user to override how code/data sections are allocated and finalized.
   - Includes `allocate_code_section`, `allocate_data_section`, `finalize_memory`, and `destroy`.

3. **`MemoryManagerAdapter`**  
   - Internal struct used to connect user-defined trait implementations to LLVM’s C callbacks (`allocate_code_section_adapter`, `allocate_data_section_adapter`, etc.).
   - Automatically cleans up the memory manager upon `destroy()`.

By merging this PR, Inkwell will support custom JIT memory management for MCJIT, addressing use cases like:
- Allocating executable code in custom memory pools.
- Intercepting `.llvm_stackmaps` for garbage collection.
- Applying security restrictions or sandboxing JIT-compiled code.

Thank you for reviewing!