### PR TITLE
CallSiteValue::get_called_fn_value: return None on indirect calls

### DIFF
--- a/src/values/call_site_value.rs
+++ b/src/values/call_site_value.rs
@@ -1,8 +1,10 @@
 use std::fmt::{self, Display};
 
 use either::Either;
+#[llvm_versions(8..)]
+use llvm_sys::core::LLVMGetCalledFunctionType;
 use llvm_sys::core::{
-    LLVMGetInstructionCallConv, LLVMGetTypeKind, LLVMIsTailCall, LLVMSetInstrParamAlignment,
+    LLVMGetCalledValue, LLVMGetInstructionCallConv, LLVMGetTypeKind, LLVMIsTailCall, LLVMSetInstrParamAlignment,
     LLVMSetInstructionCallConv, LLVMSetTailCall, LLVMTypeOf,
 };
 #[llvm_versions(18..)]
@@ -11,6 +13,7 @@ use llvm_sys::prelude::LLVMValueRef;
 use llvm_sys::LLVMTypeKind;
 
 use crate::attributes::{Attribute, AttributeLoc};
+use crate::types::FunctionType;
 #[llvm_versions(18..)]
 use crate::values::operand_bundle::OperandBundleIter;
 use crate::values::{AsValueRef, BasicValueEnum, FunctionValue, InstructionValue, Value};
@@ -201,9 +204,12 @@ impl<'ctx> CallSiteValue<'ctx> {
 
     /// Gets the `FunctionValue` this `CallSiteValue` is based on.
     ///
+    /// Returns [`None`] if the call this value bases on is indirect or the retrieved function
+    /// value doesn't have the same type as the underlying call instruction.
+    ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -220,12 +226,68 @@ impl<'ctx> CallSiteValue<'ctx> {
     ///
     /// let call_site_value = builder.build_call(fn_value, &[], "my_fn").unwrap();
     ///
-    /// assert_eq!(call_site_value.get_called_fn_value(), fn_value);
+    /// assert_eq!(call_site_value.get_called_fn_value(), Some(fn_value));
     /// ```
-    pub fn get_called_fn_value(self) -> FunctionValue<'ctx> {
-        use llvm_sys::core::LLVMGetCalledValue;
+    pub fn get_called_fn_value(self) -> Option<FunctionValue<'ctx>> {
+        // SAFETY: the passed LLVMValueRef is of type CallSite
+        let called_value = unsafe { LLVMGetCalledValue(self.as_value_ref()) };
 
-        unsafe { FunctionValue::new(LLVMGetCalledValue(self.as_value_ref())).expect("This should never be null?") }
+        let fn_value = unsafe { FunctionValue::new(called_value) };
+
+        // Check that the retrieved function value has the same type as the callee.
+        // This matches the behavior of the C++ API `CallBase::getCalledFunction`.
+        // This is only possible on LLVM >=8, where the `LLVMGetCalledFunctionType` API exists.
+        self.get_called_fn_value_check_type_consistency(fn_value)
+    }
+
+    #[llvm_versions(..8)]
+    #[inline]
+    fn get_called_fn_value_check_type_consistency(
+        &self,
+        fn_value: Option<FunctionValue<'ctx>>,
+    ) -> Option<FunctionValue<'ctx>> {
+        fn_value
+    }
+
+    #[llvm_versions(8..)]
+    #[inline]
+    fn get_called_fn_value_check_type_consistency(
+        &self,
+        fn_value: Option<FunctionValue<'ctx>>,
+    ) -> Option<FunctionValue<'ctx>> {
+        fn_value.filter(|fn_value| fn_value.get_type() == self.get_called_fn_type())
+    }
+
+    /// Gets the type of the function called by the instruction this `CallSiteValue` is based on.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let builder = context.create_builder();
+    /// let module = context.create_module("my_mod");
+    /// let i32_type = context.i32_type();
+    /// let fn_type = i32_type.fn_type(&[], false);
+    /// let fn_value = module.add_function("my_fn", fn_type, None);
+    ///
+    /// let entry_bb = context.append_basic_block(fn_value, "entry");
+    /// builder.position_at_end(entry_bb);
+    ///
+    /// // Recursive call.
+    /// let call_site_value = builder.build_call(fn_value, &[], "my_fn").unwrap();
+    ///
+    /// assert_eq!(call_site_value.get_called_fn_type(), fn_type);
+    /// ```
+    #[llvm_versions(8..)]
+    pub fn get_called_fn_type(self) -> FunctionType<'ctx> {
+        // SAFETY: the passed LLVMValueRef is of type CallSite
+        let fn_type_ref = unsafe { LLVMGetCalledFunctionType(self.as_value_ref()) };
+
+        // FIXME?: this assumes that fn_type_ref is not null.
+        // SAFETY: fn_type_ref is a function type reference.
+        unsafe { FunctionType::new(fn_type_ref) }
     }
 
     /// Counts the number of `Attribute`s on this `CallSiteValue` at an index.

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -41,11 +41,9 @@ impl<'ctx> FunctionValue<'ctx> {
     ///
     /// The ref must be valid and of type function.
     pub unsafe fn new(value: LLVMValueRef) -> Option<Self> {
-        if value.is_null() {
+        if value.is_null() || LLVMIsAFunction(value).is_null() {
             return None;
         }
-
-        assert!(!LLVMIsAFunction(value).is_null());
 
         Some(FunctionValue {
             fn_value: Value::new(value),

--- a/tests/all/test_attributes.rs
+++ b/tests/all/test_attributes.rs
@@ -227,7 +227,7 @@ fn test_attributes_on_call_site_values() {
     assert!(call_site_value
         .get_string_attribute(AttributeLoc::Return, "my_key")
         .is_none());
-    assert_eq!(call_site_value.get_called_fn_value(), fn_value);
+    assert_eq!(call_site_value.get_called_fn_value(), Some(fn_value));
 
     call_site_value.set_alignment_attribute(AttributeLoc::Return, 16);
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

Fixes #571.

- `CallSiteValue::get_called_fn_value` now matches the behavior of [`CallBase::getCalledFunction`](https://llvm.org/doxygen/classllvm_1_1CallBase.html#a2b1ae7cf1bafdd43d1fee4c6ad0a2913) and returns `None` when the underlying instruction is an indirect call or a type inconsistency is detected (the latter only for LLVM >= 8).
- The new `CallSiteValue::get_called_fn_type` corresponds to [`CallBase::getFunctionType`](https://llvm.org/doxygen/classllvm_1_1CallBase.html#ac3c35bd078a268a207f607d0f57dadba) and returns the type of the function called by the underlying call/invoke instruction. This is always well defined, whether the call is indirect or not. This new function only exists for LLVM >=8 because it depends on `LLVMGetCalledFunctionType`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

#571 

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Non-regression on #571 is tested by a dedicated test which uses a simplified version of the issue's reproduction code. For simplicity, this test is restricted to LLVM >= 15 (the test's IR snippet uses opaque pointers).

Doctests of `CallSiteValue::get_called_fn_value` and the new `CallSiteValue::get_called_fn_type` cover the usual-case, happy paths.

## Breaking Changes

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

`CallSiteValue::get_called_fn_value` now returns an `Option<FunctionValue>` instead of a `FunctionValue` to model the fact that it may not be possible to retrieve the underlying function value (when the call is indirect).

## Discussion

`FunctionValue::new` differs from most other type constructors (e.g. `FunctionType::new`) since it checks for the safety requirements and returns `None` if they are not met:

- is it thus obsolete to have it marked `unsafe`?
- is it the intention to have most type constructors behave this way, instead of being `unsafe`?

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
