### PR TITLE
FunctionType::get_param_types: support metadata type

### DIFF
--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -111,6 +111,28 @@ enum_type_set! {
 }
 
 impl<'ctx> BasicMetadataTypeEnum<'ctx> {
+    /// Create [`BasicMetadataTypeEnum`] from [`LLVMTypeRef`].
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if the referenced type cannot be represented as [`BasicMetadataTypeEnum`],
+    /// or the underlying pointer is null.
+    ///
+    /// Before LLVM 6, [`BasicMetadataTypeEnum::MetadataType`] variants cannot be created
+    /// with this function. Attempting to do results in undefined behavior.
+    #[llvm_versions(6..)]
+    pub unsafe fn new(type_: LLVMTypeRef) -> Self {
+        match LLVMGetTypeKind(type_) {
+            LLVMTypeKind::LLVMMetadataTypeKind => Self::MetadataType(MetadataType::new(type_)),
+            _ => BasicTypeEnum::new(type_).into(),
+        }
+    }
+
+    #[llvm_versions(..6)]
+    pub unsafe fn new(type_: LLVMTypeRef) -> Self {
+        BasicTypeEnum::new(type_).into()
+    }
+
     pub fn into_array_type(self) -> ArrayType<'ctx> {
         if let BasicMetadataTypeEnum::ArrayType(t) = self {
             t

--- a/src/types/fn_type.rs
+++ b/src/types/fn_type.rs
@@ -10,7 +10,7 @@ use std::mem::forget;
 use crate::context::ContextRef;
 use crate::support::LLVMString;
 use crate::types::traits::AsTypeRef;
-use crate::types::{AnyType, BasicTypeEnum, PointerType, Type};
+use crate::types::{AnyType, BasicMetadataTypeEnum, BasicTypeEnum, PointerType, Type};
 use crate::AddressSpace;
 
 /// A `FunctionType` is the type of a function variable.
@@ -96,7 +96,7 @@ impl<'ctx> FunctionType<'ctx> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```
     /// use inkwell::context::Context;
     ///
     /// let context = Context::create();
@@ -107,7 +107,7 @@ impl<'ctx> FunctionType<'ctx> {
     /// assert_eq!(param_types.len(), 1);
     /// assert_eq!(param_types[0].into_float_type(), f32_type);
     /// ```
-    pub fn get_param_types(self) -> Vec<BasicTypeEnum<'ctx>> {
+    pub fn get_param_types(self) -> Vec<BasicMetadataTypeEnum<'ctx>> {
         let count = self.count_param_types();
         let mut raw_vec: Vec<LLVMTypeRef> = Vec::with_capacity(count as usize);
         let ptr = raw_vec.as_mut_ptr();
@@ -120,7 +120,10 @@ impl<'ctx> FunctionType<'ctx> {
             Vec::from_raw_parts(ptr, count as usize, count as usize)
         };
 
-        raw_vec.iter().map(|val| unsafe { BasicTypeEnum::new(*val) }).collect()
+        raw_vec
+            .iter()
+            .map(|val| unsafe { BasicMetadataTypeEnum::new(*val) })
+            .collect()
     }
 
     /// Counts the number of param types this `FunctionType` has.


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

Fixes #546 as suggested in the issue.

`FunctionType::get_param_types()` now returns `Vec<BasicMetadataTypeEnum>` instead of `Vec<BasicTypeEnum>`.

The conversion is provided by implementing `BasicMetadataTypeEnum::new`, which delegates to `BasicTypeEnum::new` for non-metadata types. This only works for LLVM >= 6, because of the same gate on `MetadataType::new`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

#546

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

- dedicated non-regression test for the original issue.
- enabled running the doctest on `FunctionType::get_param_types()`.

## Breaking Changes

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

Signature change for `FunctionType::get_param_types()`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
