### PR TITLE
docs: fix warnings and typos

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -806,7 +806,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     /// Landing pads are places where control flow jumps to if a [`Builder::build_invoke`] triggered an exception.
-    /// The landing pad will match the exception against its *clauses*. Depending on the clause
+    /// The landing pad will match the exception against its `clauses`. Depending on the clause
     /// that is matched, the exception can then be handled, or resumed after some optional cleanup,
     /// causing the exception to bubble up.
     ///
@@ -848,7 +848,7 @@ impl<'ctx> Builder<'ctx> {
     /// ```
     ///
     /// * **catch all**: An implementation of the C++ `catch(...)`, which catches all exceptions.
-    /// A catch clause with a NULL pointer value will match anything.
+    ///   A catch clause with a NULL pointer value will match anything.
     ///
     /// ```no_run
     /// use inkwell::context::Context;
@@ -920,7 +920,7 @@ impl<'ctx> Builder<'ctx> {
     /// ```
     ///
     /// * **filter**: A filter clause encodes that only some types of exceptions are valid at this
-    /// point. A filter clause is made by constructing a clause from a constant array.
+    ///   point. A filter clause is made by constructing a clause from a constant array.
     ///
     /// ```no_run
     /// use inkwell::context::Context;
@@ -3455,12 +3455,14 @@ impl<'ctx> Builder<'ctx> {
         unsafe { Ok(IntValue::new(val)) }
     }
 
-    /// Builds a cmpxchg instruction. It allows you to atomically compare and replace memory.
+    /// Builds a [`cmpxchg`](https://llvm.org/docs/LangRef.html#cmpxchg-instruction) instruction.
+    ///
+    /// This instruction allows to atomically compare and replace memory.
     ///
     /// May return one of the following errors:
     /// - `Err(BuilderError::PointeeTypeMismatch)` if the pointer does not point to an element of the value type
     /// - `Err(BuilderError::ValueTypeMismatch)` if the value to compare and the new values are not of the same type, or if
-    /// the value does not have a pointer or integer type
+    ///   the value does not have a pointer or integer type
     /// - `Err(BuilderError::OrderingError)` if the following conditions are not satisfied:
     ///     - Both success and failure orderings are not Monotonic or stronger
     ///     - The failure ordering is stronger than the success ordering
@@ -3490,7 +3492,6 @@ impl<'ctx> Builder<'ctx> {
     /// builder.build_cmpxchg(i32_ptr_param, i32_seven, i32_eight, AtomicOrdering::AcquireRelease, AtomicOrdering::Monotonic).unwrap();
     /// builder.build_return(None).unwrap();
     /// ```
-    // https://llvm.org/docs/LangRef.html#cmpxchg-instruction
     pub fn build_cmpxchg<V: BasicValue<'ctx>>(
         &self,
         ptr: PointerValue<'ctx>,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -400,8 +400,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     /// * `ty` - Function type.
     /// * `is_local_to_unit` - True if this function is not externally visible.
     /// * `is_definition` - True if this is a function definition ("When isDefinition: false,
-    /// subprograms describe a declaration in the type tree as opposed to a definition of a
-    /// function").
+    ///   subprograms describe a declaration in the type tree as opposed to a definition of a
+    ///   function").
     /// * `scope_line` - Set to the beginning of the scope this starts
     /// * `flags` - E.g.: LLVMDIFlagLValueReference. These flags are used to emit dwarf attributes.
     /// * `is_optimized` - True if optimization is ON.
@@ -1363,7 +1363,11 @@ impl<'ctx> DIGlobalVariableExpression<'ctx> {
     }
 }
 
-/// https://llvm.org/docs/LangRef.html#diexpression
+/// Specialized metadata node that contains a DWARF-like expression.
+///
+/// # Remarks
+///
+/// See also the [LLVM language reference](https://llvm.org/docs/LangRef.html#diexpression).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DIExpression<'ctx> {
     pub(crate) metadata_ref: LLVMMetadataRef,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,19 +136,19 @@ assert_unique_used_features! {
 
 /// Defines the address space in which a global will be inserted.
 ///
-/// The default address space is zero. An address space can always be created from a `u16`:
+/// The default address space is number zero. An address space can always be created from a [`u16`]:
 /// ```no_run
 /// inkwell::AddressSpace::from(1u16);
 /// ```
 ///
-/// An Address space is a 24-bit number. To convert from a u32, use the `TryFrom` instance
+/// An address space is a 24-bit number. To convert from a [`u32`], use the [`TryFrom`] implementation:
 ///
 /// ```no_run
 /// inkwell::AddressSpace::try_from(42u32).expect("fits in 24-bit unsigned int");
 /// ```
 ///
 /// # Remarks
-/// See also: https://llvm.org/doxygen/NVPTXBaseInfo_8h_source.html
+/// See also: <https://llvm-swift.github.io/LLVMSwift/Structs/AddressSpace.html>
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
 pub struct AddressSpace(u32);
 
@@ -379,10 +379,11 @@ pub enum AtomicRMWBinOp {
     FMin,
 }
 
-/// Defines the optimization level used to compile a `Module`.
+/// Defines the optimization level used to compile a [`Module`](crate::module::Module).
 ///
 /// # Remarks
-/// See also: https://llvm.org/doxygen/CodeGen_8h_source.html
+///
+/// See the C++ API documentation: [`llvm::CodeGenOpt`](https://llvm.org/doxygen/namespacellvm_1_1CodeGenOpt.html).
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/memory_manager.rs
+++ b/src/memory_manager.rs
@@ -11,8 +11,8 @@ use llvm_sys::prelude::LLVMBool;
 ///
 /// # StackMap and GC Integration
 ///
-/// By examining the `section_name` argument in [`allocate_data_section`], you
-/// can detect sections such as `.llvm_stackmaps` (on ELF) or `__llvm_stackmaps`
+/// By examining the `section_name` argument in [`McjitMemoryManager::allocate_data_section`],
+/// you can detect sections such as `.llvm_stackmaps` (on ELF) or `__llvm_stackmaps`
 /// (on Mach-O). Recording the location of these sections may be useful for
 /// custom garbage collectors. For more information, refer to the [LLVM
 /// StackMaps documentation](https://llvm.org/docs/StackMaps.html#stack-map-section).

--- a/src/module.rs
+++ b/src/module.rs
@@ -859,11 +859,12 @@ impl<'ctx> Module<'ctx> {
         unsafe { MemoryBuffer::new(memory_buffer) }
     }
 
-    /// Ensures that the current `Module` is valid, and returns a `Result`
-    /// that describes whether or not it is, returning a LLVM allocated string on error.
+    /// Check whether the current [`Module`] is valid.
+    ///
+    /// The error variant is an LLVM-allocated string.
     ///
     /// # Remarks
-    /// See also: http://llvm.org/doxygen/Analysis_2Analysis_8cpp_source.html
+    /// See also: [`LLVMVerifyModule`](https://llvm.org/doxygen/group__LLVMCAnalysis.html#ga5645aec2d95116c0432a676db77b2cb0).
     pub fn verify(&self) -> Result<(), LLVMString> {
         let mut err_str = MaybeUninit::uninit();
 
@@ -1627,11 +1628,15 @@ impl<'ctx> Module<'ctx> {
     }
 
     /// Construct and run a set of passes over a module.
+    ///
     /// This function takes a string with the passes that should be used.
-    /// The format of this string is the same as opt's -passes argument for the new pass manager.
+    /// The format of this string is the same as
+    /// [`opt`](https://llvm.org/docs/CommandGuide/opt.html)'s
+    /// `-{passes}` argument for the new pass manager.
     /// Individual passes may be specified, separated by commas.
-    /// Full pipelines may also be invoked using default<O3> and friends.
-    /// See opt for full reference of the Passes format.
+    /// Full pipelines may also be invoked using `"default<O3>"` and friends.
+    /// See [`opt`](https://llvm.org/docs/CommandGuide/opt.html)
+    /// for full reference of the `passes` format.
     #[llvm_versions(13..)]
     pub fn run_passes(
         &self,

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -636,7 +636,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// right-hand side.
     ///
     /// 2. Bitwise operators with constant operands are always grouped so that
-    /// shifts are performed first, then ors, then ands, then xors.
+    /// shifts are performed first, then ORs, then ANDs, then XORs.
     ///
     /// 3. Compare instructions are converted from <, >, ≤, or ≥ to = or ≠ if possible.
     ///
@@ -906,7 +906,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     /// returns something else (like constant 0), and can still be TRE’d. It can be
     /// TRE'd if all other return instructions in the function return the exact same value.
     ///
-    /// 4. If it can prove that callees do not access theier caller stack frame,
+    /// 4. If it can prove that callees do not access their caller stack frame,
     /// they are marked as eligible for tail call elimination (by the code generator).
     #[llvm_versions(..=16)]
     pub fn add_tail_call_elimination_pass(&self) {

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -72,7 +72,7 @@ enum_type_set! {
         StructType,
         /// A contiguous homogeneous "SIMD" container type.
         VectorType,
-        /// A contiguous homogenous scalable "SIMD" container type.
+        /// A contiguous homogeneous scalable "SIMD" container type.
         ScalableVectorType,
         /// A valueless type.
         VoidType,
@@ -93,7 +93,7 @@ enum_type_set! {
         StructType,
         /// A contiguous homogeneous "SIMD" container type.
         VectorType,
-        /// A contiguous homogenous scalable "SIMD" container type.
+        /// A contiguous homogeneous scalable "SIMD" container type.
         ScalableVectorType,
     }
 }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -175,7 +175,7 @@ impl<'ctx> InstructionValue<'ctx> {
                 return Some(*self);
             }
         }
-        return self.get_next_instruction()?.get_instruction_with_name(name);
+        self.get_next_instruction()?.get_instruction_with_name(name)
     }
 
     /// Set name of the `InstructionValue`.

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -534,7 +534,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// 2) Bitcast has one: a variable float pointer %0
     /// 3) Function call has two: i8 pointer %1 argument, and the free function itself
     /// 4) Void return has zero: void is not a value and does not count as an operand
-    /// even though the return instruction can take values.
+    ///    even though the return instruction can take values.
     pub fn get_num_operands(self) -> u32 {
         unsafe { LLVMGetNumOperands(self.as_value_ref()) as u32 }
     }
@@ -602,7 +602,7 @@ impl<'ctx> InstructionValue<'ctx> {
     /// 2) Bitcast has one: a variable float pointer %0
     /// 3) Function call has two: i8 pointer %1 argument, and the free function itself
     /// 4) Void return has zero: void is not a value and does not count as an operand
-    /// even though the return instruction can take values.
+    ///    even though the return instruction can take values.
     pub fn get_operand(self, index: u32) -> Option<Either<BasicValueEnum<'ctx>, BasicBlock<'ctx>>> {
         let num_operands = self.get_num_operands();
 

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1011,7 +1011,7 @@ fn test_floats() {
         assert_eq!(f128_pi.get_type(), f128_type);
         assert_eq!(f128_pi_cast.get_type(), f128_type);
 
-        // REIVEW: Why are these not FPTrunc, FPExt, FPToSI, FPToUI, BitCast instructions?
+        // REVIEW: Why are these not FPTrunc, FPExt, FPToSI, FPToUI, BitCast instructions?
         // Only thing I can think of is that they're constants and therefore precalculated
         assert!(f32_pi.as_instruction().is_none());
         assert!(f128_pi.as_instruction().is_none());


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

Fix warnings reported by `rustdoc` and `typos` invocations.

No code change except for 2c6427dcb640589e135d1ae404a90134f90b41b1.

When building the documentation with LLVM > 16, there's a broken link to `add_prune_eh_pass` in `builder.rs` (`build_invoke`) because the function doesn't exist. Linked to #505.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
