### PR TITLE
fix: proper string constant handling

### DIFF
--- a/src/values/array_value.rs
+++ b/src/values/array_value.rs
@@ -141,10 +141,38 @@ impl<'ctx> ArrayValue<'ctx> {
     /// let context = Context::create();
     /// let string = context.const_string(b"hello!", true);
     ///
+    /// let result = b"hello!".as_slice();
+    /// assert_eq!(string.as_const_string(), Some(result));
+    /// ```
+    // SubTypes: Impl only for ArrayValue<IntValue<i8>>
+    pub fn as_const_string(&self) -> Option<&[u8]> {
+        let mut len = 0;
+        let ptr = unsafe { LLVMGetAsString(self.as_value_ref(), &mut len) };
+
+        if ptr.is_null() {
+            None
+        } else {
+            unsafe { Some(std::slice::from_raw_parts(ptr.cast(), len)) }
+        }
+    }
+
+    /// Obtain the string from the ArrayValue
+    /// if the value points to a constant string.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use inkwell::context::Context;
+    /// use std::ffi::CStr;
+    ///
+    /// let context = Context::create();
+    /// let string = context.const_string(b"hello!", true);
+    ///
     /// let result = CStr::from_bytes_with_nul(b"hello!\0").unwrap();
     /// assert_eq!(string.get_string_constant(), Some(result));
     /// ```
     // SubTypes: Impl only for ArrayValue<IntValue<i8>>
+    #[deprecated = "llvm strings can contain internal NULs, and this function truncates such values, use as_const_string instead"]
     pub fn get_string_constant(&self) -> Option<&CStr> {
         let mut len = 0;
         let ptr = unsafe { LLVMGetAsString(self.as_value_ref(), &mut len) };

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -1510,6 +1510,7 @@ fn test_string_values() {
     let i8_type = context.i8_type();
     let string = context.const_string(b"my_string", false);
     let string_null = context.const_string(b"my_string", true);
+    let string_internal_nul = context.const_string(b"my\0string", false);
 
     assert!(string.is_const());
     assert!(string_null.is_const());
@@ -1524,27 +1525,32 @@ fn test_string_values() {
     assert_eq!(string.get_type().get_element_type().into_int_type(), i8_type);
     assert_eq!(string_null.get_type().get_element_type().into_int_type(), i8_type);
 
-    let string_const = string.get_string_constant();
-    let string_null_const = string_null.get_string_constant();
+    let string_const = string.as_const_string();
+    let string_null_const = string_null.as_const_string();
+    let string_internal_nul_const = string_internal_nul.as_const_string();
 
     assert!(string_const.is_some());
     assert!(string_null_const.is_some());
-    assert_eq!(string_const.unwrap().to_str(), Ok("my_string"));
-    assert_eq!(string_null_const.unwrap().to_str(), Ok("my_string"));
+    assert_eq!(string_const.unwrap(), b"my_string");
+    assert_eq!(string_null_const.unwrap(), b"my_string\0");
+    assert_eq!(string_internal_nul_const.unwrap(), b"my\0string");
 
     let i8_val = i8_type.const_int(33, false);
     let i8_val2 = i8_type.const_int(43, false);
     let non_string_vec_i8 = i8_type.const_array(&[i8_val, i8_val2]);
-    let non_string_vec_i8_const = non_string_vec_i8.get_string_constant();
+    let non_string_vec_i8_const = non_string_vec_i8.as_const_string();
 
     // TODOC: Will still interpret vec as string even if not generated with const_string:
     assert!(non_string_vec_i8_const.is_some());
-    assert_eq!(non_string_vec_i8_const.unwrap().to_str(), Ok("!+"));
+    assert_eq!(non_string_vec_i8_const.unwrap(), b"!+");
 
     let i32_type = context.i32_type();
     let i32_val = i32_type.const_int(33, false);
     let i32_val2 = i32_type.const_int(43, false);
     let non_string_vec_i32 = i8_type.const_array(&[i32_val, i32_val2, i32_val2]);
+
+    // This test expects silent truncation
+    #[allow(deprecated)]
     let non_string_vec_i32_const = non_string_vec_i32.get_string_constant();
 
     // TODOC: Will still interpret vec with non i8 but in unexpected ways:


### PR DESCRIPTION

<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

LLVM String means array of i8, which is not necessary NUL-terminated.

If, in Rust, we'll write "hello\0", it will result in the following LLVM IR:

```llvm
@anon...212 = private unnamed_addr global <{ [6 x i8] }> <{ [6 x i8] c"hello\00" }>, align 1
```

This is a struct, where the only field is constant string (LLVMIsConstantString returns true).
Calling LLVMGetAsString for it returns a pointer to start of `"hello\0\0"` buffer AND the actual length of this string = `6`
However, `get_string_constant` disregards the fact that the returned pointer may point to a string containing intermediate NULs such as `"foo\0bar"` thus it is invalid to turn in into a CStr (the `\0` and the part after gets truncated).

## Related Issue

Fixes: https://github.com/TheDan64/inkwell/issues/510

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Tests were updated to use the new method where applicable, an additional test with internal NUL was added.

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

Originally I wanted to modify original function definition, which would be a breaking change, but the new implementation adds another method, which also better follows rust conventions (is_/as_), and deprecates the original method.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
