### PR TITLE
Report user's call location in case of `panic` in `into_*_value` type of functions

### DIFF
--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -163,6 +163,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         matches!(self, AnyValueEnum::InstructionValue(_))
     }
 
+    #[track_caller]
     pub fn into_array_value(self) -> ArrayValue<'ctx> {
         if let AnyValueEnum::ArrayValue(v) = self {
             v
@@ -171,6 +172,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_int_value(self) -> IntValue<'ctx> {
         if let AnyValueEnum::IntValue(v) = self {
             v
@@ -179,6 +181,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_float_value(self) -> FloatValue<'ctx> {
         if let AnyValueEnum::FloatValue(v) = self {
             v
@@ -187,6 +190,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_phi_value(self) -> PhiValue<'ctx> {
         if let AnyValueEnum::PhiValue(v) = self {
             v
@@ -195,6 +199,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_function_value(self) -> FunctionValue<'ctx> {
         if let AnyValueEnum::FunctionValue(v) = self {
             v
@@ -203,6 +208,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_pointer_value(self) -> PointerValue<'ctx> {
         if let AnyValueEnum::PointerValue(v) = self {
             v
@@ -211,6 +217,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_struct_value(self) -> StructValue<'ctx> {
         if let AnyValueEnum::StructValue(v) = self {
             v
@@ -219,6 +226,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_vector_value(self) -> VectorValue<'ctx> {
         if let AnyValueEnum::VectorValue(v) = self {
             v
@@ -227,6 +235,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_scalable_vector_value(self) -> ScalableVectorValue<'ctx> {
         if let AnyValueEnum::ScalableVectorValue(v) = self {
             v
@@ -235,6 +244,7 @@ impl<'ctx> AnyValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_instruction_value(self) -> InstructionValue<'ctx> {
         if let AnyValueEnum::InstructionValue(v) = self {
             v
@@ -338,6 +348,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         matches!(self, BasicValueEnum::ScalableVectorValue(_))
     }
 
+    #[track_caller]
     pub fn into_array_value(self) -> ArrayValue<'ctx> {
         if let BasicValueEnum::ArrayValue(v) = self {
             v
@@ -346,6 +357,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_int_value(self) -> IntValue<'ctx> {
         if let BasicValueEnum::IntValue(v) = self {
             v
@@ -354,6 +366,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_float_value(self) -> FloatValue<'ctx> {
         if let BasicValueEnum::FloatValue(v) = self {
             v
@@ -362,6 +375,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_pointer_value(self) -> PointerValue<'ctx> {
         if let BasicValueEnum::PointerValue(v) = self {
             v
@@ -370,6 +384,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_struct_value(self) -> StructValue<'ctx> {
         if let BasicValueEnum::StructValue(v) = self {
             v
@@ -378,6 +393,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_vector_value(self) -> VectorValue<'ctx> {
         if let BasicValueEnum::VectorValue(v) = self {
             v
@@ -386,6 +402,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_scalable_vector_value(self) -> ScalableVectorValue<'ctx> {
         if let BasicValueEnum::ScalableVectorValue(v) = self {
             v
@@ -417,6 +434,7 @@ impl<'ctx> AggregateValueEnum<'ctx> {
         matches!(self, AggregateValueEnum::StructValue(_))
     }
 
+    #[track_caller]
     pub fn into_array_value(self) -> ArrayValue<'ctx> {
         if let AggregateValueEnum::ArrayValue(v) = self {
             v
@@ -425,6 +443,7 @@ impl<'ctx> AggregateValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_struct_value(self) -> StructValue<'ctx> {
         if let AggregateValueEnum::StructValue(v) = self {
             v
@@ -498,6 +517,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         matches!(self, BasicMetadataValueEnum::MetadataValue(_))
     }
 
+    #[track_caller]
     pub fn into_array_value(self) -> ArrayValue<'ctx> {
         if let BasicMetadataValueEnum::ArrayValue(v) = self {
             v
@@ -506,6 +526,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_int_value(self) -> IntValue<'ctx> {
         if let BasicMetadataValueEnum::IntValue(v) = self {
             v
@@ -514,6 +535,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_float_value(self) -> FloatValue<'ctx> {
         if let BasicMetadataValueEnum::FloatValue(v) = self {
             v
@@ -522,6 +544,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_pointer_value(self) -> PointerValue<'ctx> {
         if let BasicMetadataValueEnum::PointerValue(v) = self {
             v
@@ -530,6 +553,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_struct_value(self) -> StructValue<'ctx> {
         if let BasicMetadataValueEnum::StructValue(v) = self {
             v
@@ -538,6 +562,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_vector_value(self) -> VectorValue<'ctx> {
         if let BasicMetadataValueEnum::VectorValue(v) = self {
             v
@@ -546,6 +571,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_scalable_vector_value(self) -> ScalableVectorValue<'ctx> {
         if let BasicMetadataValueEnum::ScalableVectorValue(v) = self {
             v
@@ -554,6 +580,7 @@ impl<'ctx> BasicMetadataValueEnum<'ctx> {
         }
     }
 
+    #[track_caller]
     pub fn into_metadata_value(self) -> MetadataValue<'ctx> {
         if let BasicMetadataValueEnum::MetadataValue(v) = self {
             v


### PR DESCRIPTION
## Description

Currently, when an `into` conversion fails, the error location reported points to the source code of Inkwell, e.g.

```
thread 'main' panicked at /home/rakivo/Coding/inkwell/src/values/enums.rs:369:13:
```

This can be quite frustrating because, to determine where your program failed to perform the conversion, you either need to run it with `RUST_BACKTRACE=1` and then examine the stack trace or use a debugger.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added documentation and doc tests to any new functions or types
- [x] I have updated documentation and doc tests to any modified functions or types as applicable
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed: `test result: ok. 328 passed; 0 failed; 18 ignored; 0 measured; 0 filtered out; finished in 5.23s`
- [x] I am basing my changes off master, instead of one of the llvm version branches (they're deprecated and no longer necessary)
- [x] I have ran cargo clippy and updated portions of code pertaining to my changes
- [x] I will keep my code reasonably up to date via rebasing over merging whenever possible (This helps avoid unnecessary merge commits)

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)

