### PR TITLE
Add `get_bit_width` method for float type

### DIFF
--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -269,7 +269,18 @@ impl<'ctx> FloatType<'ctx> {
         let type_kind = unsafe { LLVMGetTypeKind(self.as_type_ref()) };
 
         match type_kind {
-            llvm_sys::LLVMTypeKind::LLVMHalfTypeKind | llvm_sys::LLVMTypeKind::LLVMBFloatTypeKind => 16,
+            llvm_sys::LLVMTypeKind::LLVMHalfTypeKind => 16,
+            #[cfg(any(
+                feature = "llvm11-0",
+                feature = "llvm12-0",
+                feature = "llvm13-0",
+                feature = "llvm14-0",
+                feature = "llvm15-0",
+                feature = "llvm16-0",
+                feature = "llvm17-0",
+                feature = "llvm18-1"
+            ))]
+            llvm_sys::LLVMTypeKind::LLVMBFloatTypeKind => 16,
             llvm_sys::LLVMTypeKind::LLVMFloatTypeKind => 32,
             llvm_sys::LLVMTypeKind::LLVMDoubleTypeKind => 64,
             llvm_sys::LLVMTypeKind::LLVMX86_FP80TypeKind => 80,

--- a/src/types/float_type.rs
+++ b/src/types/float_type.rs
@@ -1,4 +1,4 @@
-use llvm_sys::core::{LLVMConstReal, LLVMConstRealOfStringAndSize};
+use llvm_sys::core::{LLVMConstReal, LLVMConstRealOfStringAndSize, LLVMGetTypeKind};
 use llvm_sys::execution_engine::LLVMCreateGenericValueOfFloat;
 use llvm_sys::prelude::LLVMTypeRef;
 
@@ -252,6 +252,30 @@ impl<'ctx> FloatType<'ctx> {
     )]
     pub fn ptr_type(self, address_space: AddressSpace) -> PointerType<'ctx> {
         self.float_type.ptr_type(address_space)
+    }
+
+    /// Gets the bit width of a `FloatType`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use inkwell::context::Context;
+    ///
+    /// let context = Context::create();
+    /// let f128_type = context.f128_type();
+    ///
+    /// assert_eq!(f128_type.get_bit_width(), 128);
+    /// ```
+    pub fn get_bit_width(self) -> u32 {
+        let type_kind = unsafe { LLVMGetTypeKind(self.as_type_ref()) };
+
+        match type_kind {
+            llvm_sys::LLVMTypeKind::LLVMHalfTypeKind | llvm_sys::LLVMTypeKind::LLVMBFloatTypeKind => 16,
+            llvm_sys::LLVMTypeKind::LLVMFloatTypeKind => 32,
+            llvm_sys::LLVMTypeKind::LLVMDoubleTypeKind => 64,
+            llvm_sys::LLVMTypeKind::LLVMX86_FP80TypeKind => 80,
+            llvm_sys::LLVMTypeKind::LLVMFP128TypeKind | llvm_sys::LLVMTypeKind::LLVMPPC_FP128TypeKind => 128,
+            _ => unreachable!(),
+        }
     }
 
     /// Print the definition of a `FloatType` to `LLVMString`.

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -490,6 +490,25 @@ fn test_const_zero() {
 }
 
 #[test]
+fn test_float_type() {
+    let context = Context::create();
+
+    let f16_type = context.f16_type();
+    let f32_type = context.f32_type();
+    let f64_type = context.f64_type();
+    let f128_type = context.f128_type();
+    let x86_f80_type = context.x86_f80_type();
+    let ppc_f128_type = context.ppc_f128_type();
+
+    assert_eq!(f16_type.get_bit_width(), 16);
+    assert_eq!(f32_type.get_bit_width(), 32);
+    assert_eq!(f64_type.get_bit_width(), 64);
+    assert_eq!(f128_type.get_bit_width(), 128);
+    assert_eq!(x86_f80_type.get_bit_width(), 80);
+    assert_eq!(ppc_f128_type.get_bit_width(), 128);
+}
+
+#[test]
 fn test_vec_type() {
     let context = Context::create();
     let int = context.i8_type();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

This adds the `get_bit_width` function to float type similar to the one found in integer type.

<!--- Describe your changes in detail -->

## Related Issue

#437 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

Added new unit test

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
