### PR TITLE
chore: fix warning of elided_lifetimes_in_paths in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ struct CodeGen<'ctx> {
 }
 
 impl<'ctx> CodeGen<'ctx> {
-    fn jit_compile_sum(&self) -> Option<JitFunction<SumFunc>> {
+    fn jit_compile_sum(&self) -> Option<JitFunction<'_, SumFunc>> {
         let i64_type = self.context.i64_type();
         let fn_type = i64_type.fn_type(&[i64_type.into(), i64_type.into(), i64_type.into()], false);
         let function = self.module.add_function("sum", fn_type, None);

--- a/examples/jit.rs
+++ b/examples/jit.rs
@@ -20,7 +20,7 @@ struct CodeGen<'ctx> {
 }
 
 impl<'ctx> CodeGen<'ctx> {
-    fn jit_compile_sum(&self) -> Option<JitFunction<SumFunc>> {
+    fn jit_compile_sum(&self) -> Option<JitFunction<'_, SumFunc>> {
         let i64_type = self.context.i64_type();
         let fn_type = i64_type.fn_type(&[i64_type.into(), i64_type.into(), i64_type.into()], false);
         let function = self.module.add_function("sum", fn_type, None);


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

fix warnings like `indicate the anonymous lifetime` of the example code (when the lint flag `elided_lifetimes_in_paths = "warn"` is enabled).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

trivial change on style, rerun the example code locally

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
