### PR TITLE
Removes uneccesary less-than 64-bit check on 32-bit value.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3696,7 +3696,7 @@ fn is_alignment_ok(align: u32) -> bool {
     // This replicates the assertions LLVM runs.
     //
     // See https://github.com/TheDan64/inkwell/issues/168
-    align > 0 && align.is_power_of_two() && (align as f64).log2() < 64.0
+    align > 0 && align.is_power_of_two()
 }
 
 impl Drop for Builder<'_> {


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

The is_alignment_ok function in builder.rs uses log2 to determine the number of bits that are number needs. It compares the result with `64`. This is unnecessary as the `align` parameter is only 32-bits, so this comparison will always return `true`.

If `align` were 64-bit, the check would still be unnecessary because you can't have 2^64 as a 64-bit value. If `align` were 128-bit, then you could perform this check using `align.trailing_zeros()`, which is faster than converting to f64 and using log2, which would be inaccurate for an 128-bit integer anyway.

## How This Has Been Tested

No tests needed. It's logically sound.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
