### PR TITLE
Removed unnecessary checks from is_alignment_ok

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3696,7 +3696,8 @@ fn is_alignment_ok(align: u32) -> bool {
     // This replicates the assertions LLVM runs.
     //
     // See https://github.com/TheDan64/inkwell/issues/168
-    align > 0 && align.is_power_of_two()
+    // is_power_of_two returns false for 0.
+    align.is_power_of_two()
 }
 
 impl Drop for Builder<'_> {

--- a/tests/all/test_builder.rs
+++ b/tests/all/test_builder.rs
@@ -1311,7 +1311,8 @@ fn is_alignment_ok(align: u32) -> bool {
     // This replicates the assertions LLVM runs.
     //
     // See https://github.com/TheDan64/inkwell/issues/168
-    align > 0 && align.is_power_of_two() && (align as f64).log2() < 64.0
+    // is_power_of_two returns false for 0.
+    align.is_power_of_two()
 }
 
 #[test]


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

`u32::is_power_of_two` will return `false` for `0`, so I removed the `0` check from `is_alignment_ok`.

## How This Has Been Tested

I was unable to get the tests module build on my machine because it seems that there are some OS specific errors that no one noticed before. I plan on looking into that next.

But I did test it, nonetheless, and the test can be reproduced with just three lines (well, 1-3 lines, depending on what you want to test):
```rust
assert!(!(0_u32.is_power_of_two()));
assert!(!(3_u32.is_power_of_two()));
assert!(32_u32.is_power_of_two());
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
