### PR TITLE
Fix comment typos in `test_conversion_to_pointer_value`

### DIFF
--- a/tests/all/test_instruction_conversion.rs
+++ b/tests/all/test_instruction_conversion.rs
@@ -103,7 +103,7 @@ fn test_conversion_to_pointer_value() {
     let module = context.create_module("testing");
     let builder = context.create_builder();
 
-    // Create a function whose the first parameter is of IntType
+    // Create a function with no parameters
     let fn_type = context.void_type().fn_type(&[], false);
     let function = module.add_function("testing", fn_type, None);
     let basic_block = context.append_basic_block(function, "entry");
@@ -120,7 +120,7 @@ fn test_conversion_to_pointer_value() {
         .as_instruction()
         .unwrap();
 
-    // Test the instruction conversion to a FloatValue
+    // Test the instruction conversion to a PointerValue
     let ptr_conversion: Result<PointerValue, _> = alloca_instr.try_into();
     assert!(ptr_conversion.is_ok());
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Minor typo fixes in comments in `test_conversion_to_pointer_value`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

#604 

## How This Has Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

Only comments were changed, so this doesn't affect any other parts of the code.

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
