### PR TITLE
Add debug information utility functions and support Metadata on Operands

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -591,6 +591,12 @@ impl<'ctx> BasicBlock<'ctx> {
     }
 }
 
+unsafe impl AsValueRef for BasicBlock<'_> {
+    fn as_value_ref(&self) -> LLVMValueRef {
+        self.basic_block as LLVMValueRef
+    }
+}
+
 impl fmt::Debug for BasicBlock<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let llvm_value = unsafe { CStr::from_ptr(LLVMPrintValueToString(self.basic_block as LLVMValueRef)) };

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -506,7 +506,7 @@ impl<'ctx> BasicBlock<'ctx> {
     ///
     /// bb1.replace_all_uses_with(&bb2);
     ///
-    /// assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);
+    /// assert_eq!(branch_inst.get_operand(0).unwrap().into_basic_block().unwrap(), bb2);
     /// ```
     pub fn replace_all_uses_with(self, other: &BasicBlock<'ctx>) {
         let value = unsafe { LLVMBasicBlockAsValue(self.basic_block) };

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -171,7 +171,11 @@ pub struct DIScope<'ctx> {
     _marker: PhantomData<&'ctx Context>,
 }
 
-impl DIScope<'_> {
+impl<'ctx> DIScope<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DIScope` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1108,7 +1112,11 @@ impl<'ctx> AsDIScope<'ctx> for DIFile<'ctx> {
     }
 }
 
-impl DIFile<'_> {
+impl<'ctx> DIFile<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DIFile` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1126,6 +1134,10 @@ pub struct DICompileUnit<'ctx> {
 impl<'ctx> DICompileUnit<'ctx> {
     pub fn get_file(&self) -> DIFile<'ctx> {
         self.file
+    }
+
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
     }
 
     /// Acquires the underlying raw pointer belonging to this `DICompileUnit` type.
@@ -1150,7 +1162,11 @@ pub struct DINamespace<'ctx> {
     _marker: PhantomData<&'ctx Context>,
 }
 
-impl DINamespace<'_> {
+impl<'ctx> DINamespace<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DINamespace` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1182,7 +1198,11 @@ impl<'ctx> AsDIScope<'ctx> for DISubprogram<'ctx> {
     }
 }
 
-impl DISubprogram<'_> {
+impl<'ctx> DISubprogram<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DISubprogram` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1196,7 +1216,7 @@ pub struct DIType<'ctx> {
     _marker: PhantomData<&'ctx Context>,
 }
 
-impl DIType<'_> {
+impl<'ctx> DIType<'ctx> {
     pub fn get_size_in_bits(&self) -> u64 {
         unsafe { LLVMDITypeGetSizeInBits(self.metadata_ref) }
     }
@@ -1207,6 +1227,10 @@ impl DIType<'_> {
 
     pub fn get_offset_in_bits(&self) -> u64 {
         unsafe { LLVMDITypeGetOffsetInBits(self.metadata_ref) }
+    }
+
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
     }
 
     /// Acquires the underlying raw pointer belonging to this `DIType` type.
@@ -1240,7 +1264,11 @@ impl<'ctx> DIDerivedType<'ctx> {
     }
 }
 
-impl DIDerivedType<'_> {
+impl<'ctx> DIDerivedType<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
     }
@@ -1270,6 +1298,10 @@ impl<'ctx> DIBasicType<'ctx> {
         }
     }
 
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DIBasicType` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1297,6 +1329,10 @@ impl<'ctx> DICompositeType<'ctx> {
             metadata_ref: self.metadata_ref,
             _marker: PhantomData,
         }
+    }
+
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
     }
 
     /// Acquires the underlying raw pointer belonging to this `DICompositeType` type.
@@ -1337,10 +1373,14 @@ impl<'ctx> AsDIScope<'ctx> for DILexicalBlock<'ctx> {
     }
 }
 
-impl DILexicalBlock<'_> {
+impl<'ctx> DILexicalBlock<'ctx> {
     /// Acquires the underlying raw pointer belonging to this `DILexicalBlock` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
+    }
+
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
     }
 }
 
@@ -1374,6 +1414,10 @@ impl<'ctx> DILocation<'ctx> {
         }
     }
 
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DILocation` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1387,7 +1431,11 @@ pub struct DILocalVariable<'ctx> {
     _marker: PhantomData<&'ctx Context>,
 }
 
-impl DILocalVariable<'_> {
+impl<'ctx> DILocalVariable<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'ctx> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DILocalVariable` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref
@@ -1422,7 +1470,11 @@ pub struct DIExpression<'ctx> {
     _marker: PhantomData<&'ctx Context>,
 }
 
-impl DIExpression<'_> {
+impl<'ctx> DIExpression<'ctx> {
+    pub fn as_metadata_value(&self, context: impl AsContextRef<'ctx>) -> MetadataValue<'_> {
+        unsafe { MetadataValue::new(LLVMMetadataAsValue(context.as_ctx_ref(), self.metadata_ref)) }
+    }
+
     /// Acquires the underlying raw pointer belonging to this `DIExpression` type.
     pub fn as_mut_ptr(&self) -> LLVMMetadataRef {
         self.metadata_ref

--- a/src/module.rs
+++ b/src/module.rs
@@ -56,6 +56,8 @@ use crate::support::{to_c_str, LLVMString};
 use crate::targets::TargetMachine;
 use crate::targets::{CodeModel, InitializationConfig, Target, TargetTriple};
 use crate::types::{AsTypeRef, BasicType, FunctionType, StructType};
+#[llvm_versions(19..)]
+use llvm_sys::core::{LLVMIsNewDbgInfoFormat, LLVMSetIsNewDbgInfoFormat};
 
 use crate::values::BasicValue;
 use crate::values::{AsValueRef, FunctionValue, GlobalValue, MetadataValue};
@@ -1639,6 +1641,20 @@ impl<'ctx> Module<'ctx> {
                 Err(LLVMString::new(message as *const libc::c_char))
             }
         }
+    }
+
+    /// https://llvm.org/docs/RemoveDIsDebugInfo.html
+    /// Set true to use new debug information format.
+    #[llvm_versions(19..)]
+    pub fn set_new_debug_format(&self, value: bool) {
+        unsafe { LLVMSetIsNewDbgInfoFormat(self.module.get(), value.into()) }
+    }
+
+    /// https://llvm.org/docs/RemoveDIsDebugInfo.html
+    /// Returns true if this module is set to utilize the new debug format.
+    #[llvm_versions(19..)]
+    pub fn is_new_debug_format(&self) -> bool {
+        unsafe { LLVMIsNewDbgInfoFormat(self.module.get()) != 0 }
     }
 }
 

--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -160,7 +160,7 @@ impl<'ctx> BasicValueUse<'ctx> {
     /// let free_instruction = builder.build_free(arg1).unwrap();
     /// let return_instruction = builder.build_return(None).unwrap();
     ///
-    /// let free_operand0 = free_instruction.get_operand(0).unwrap().left().unwrap();
+    /// let free_operand0 = free_instruction.get_operand(0).unwrap().into_basic_value().unwrap();
     /// let free_operand0_instruction = free_operand0.as_instruction_value().unwrap();
     /// let bitcast_use_value = free_operand0_instruction
     ///     .get_first_use()

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -116,7 +116,9 @@ impl<'ctx> AnyValueEnum<'ctx> {
                 }
                 AnyValueEnum::InstructionValue(InstructionValue::new(value))
             },
-            LLVMTypeKind::LLVMMetadataTypeKind => panic!("Metadata values are not supported as AnyValue's."),
+            LLVMTypeKind::LLVMMetadataTypeKind => {
+                panic!("Metadata values are not supported as AnyValue's.")
+            },
             _ => panic!("The given type is not supported."),
         }
     }
@@ -263,7 +265,8 @@ impl<'ctx> BasicValueEnum<'ctx> {
     ///
     /// The ref must be valid and of supported enum type options ([LLVMTypeKind]).
     pub unsafe fn new(value: LLVMValueRef) -> Self {
-        match LLVMGetTypeKind(LLVMTypeOf(value)) {
+        let kind = LLVMGetTypeKind(LLVMTypeOf(value));
+        match kind {
             LLVMTypeKind::LLVMFloatTypeKind
             | LLVMTypeKind::LLVMFP128TypeKind
             | LLVMTypeKind::LLVMDoubleTypeKind
@@ -290,7 +293,7 @@ impl<'ctx> BasicValueEnum<'ctx> {
             LLVMTypeKind::LLVMScalableVectorTypeKind => {
                 BasicValueEnum::ScalableVectorValue(ScalableVectorValue::new(value))
             },
-            _ => unreachable!("The given type is not a basic type."),
+            _ => unreachable!("The given type is not a basic type: {:?}", kind),
         }
     }
 

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -939,23 +939,23 @@ pub enum OperandValue<'ctx> {
     BasicMetadataValue(BasicMetadataValueEnum<'ctx>),
 }
 impl<'ctx> OperandValue<'ctx> {
-    pub fn into_basic_value(self) -> Option<BasicValueEnum<'ctx>> {
+    pub fn into_basic_value(self) -> BasicValueEnum<'ctx> {
         match self {
-            OperandValue::BasicValue(value) => Some(value),
-            _ => None,
+            OperandValue::BasicValue(value) => value,
+            _ => panic!("Found {self:?} but expected the BasicValue variant"),
         }
     }
-    pub fn into_basic_block(self) -> Option<BasicBlock<'ctx>> {
+    pub fn into_basic_block(self) -> BasicBlock<'ctx> {
         match self {
-            OperandValue::BasicBlock(value) => Some(value),
-            _ => None,
+            OperandValue::BasicBlock(value) => value,
+            _ => panic!("Found {self:?} but expected the BasicBlock variant"),
         }
     }
 
-    pub fn into_metadata_value(self) -> Option<BasicMetadataValueEnum<'ctx>> {
+    pub fn into_metadata_value(self) -> BasicMetadataValueEnum<'ctx> {
         match self {
-            OperandValue::BasicMetadataValue(value) => Some(value),
-            _ => None,
+            OperandValue::BasicMetadataValue(value) => value,
+            _ => panic!("Found {self:?} but expected the VectorValue variant"),
         }
     }
 }

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -988,21 +988,21 @@ impl<'ctx> TryFrom<OperandValue<'ctx>> for BasicValueEnum<'ctx> {
     type Error = ();
 
     fn try_from(value: OperandValue<'ctx>) -> Result<Self, Self::Error> {
-        value.into_basic_value().ok_or(())
+        Ok(value.into_basic_value())
     }
 }
 impl<'ctx> TryFrom<OperandValue<'ctx>> for BasicBlock<'ctx> {
     type Error = ();
 
     fn try_from(value: OperandValue<'ctx>) -> Result<Self, Self::Error> {
-        value.into_basic_block().ok_or(())
+        Ok(value.into_basic_block())
     }
 }
 impl<'ctx> TryFrom<OperandValue<'ctx>> for BasicMetadataValueEnum<'ctx> {
     type Error = ();
 
     fn try_from(value: OperandValue<'ctx>) -> Result<Self, Self::Error> {
-        value.into_metadata_value().ok_or(())
+        Ok(value.into_metadata_value())
     }
 }
 

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -117,7 +117,13 @@ impl<'ctx> MetadataValue<'ctx> {
         };
 
         vec.iter()
-            .map(|val| unsafe { BasicMetadataValueEnum::new(*val) })
+            .filter_map(|val| {
+                if !val.is_null() {
+                    unsafe { Some(BasicMetadataValueEnum::new(*val)) }
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -59,7 +59,7 @@ pub use crate::values::global_value::GlobalValue;
 
 pub use crate::values::global_value::UnnamedAddress;
 pub use crate::values::instruction_value::{
-    AtomicError, InstructionOpcode, InstructionValue, InstructionValueError, OperandIter, OperandUseIter,
+    AtomicError, InstructionOpcode, InstructionValue, InstructionValueError, OperandIter, OperandUseIter, OperandValue,
 };
 pub use crate::values::int_value::IntValue;
 pub use crate::values::metadata_value::{MetadataValue, FIRST_CUSTOM_METADATA_KIND_ID};

--- a/tests/all/test_basic_block.rs
+++ b/tests/all/test_basic_block.rs
@@ -1,3 +1,4 @@
+use inkwell::basic_block::BasicBlock;
 use inkwell::context::Context;
 use inkwell::values::InstructionOpcode;
 
@@ -185,7 +186,7 @@ fn test_rauw() {
     bb1.replace_all_uses_with(&bb1); // no-op
     bb1.replace_all_uses_with(&bb2);
 
-    assert_eq!(branch_inst.get_operand(0).unwrap().right().unwrap(), bb2);
+    assert_eq!(BasicBlock::try_from(branch_inst.get_operand(0).unwrap()).unwrap(), bb2);
 }
 
 #[test]

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -47,8 +47,8 @@ fn test_operands() {
     let store_operand0 = store_instruction.get_operand(0).unwrap();
     let store_operand1 = store_instruction.get_operand(1).unwrap();
 
-    assert_eq!(store_operand0.left().unwrap(), f32_val); // f32 const
-    assert_eq!(store_operand1.left().unwrap(), arg1); // f32* arg1
+    assert_eq!(store_operand0.into_basic_value().unwrap(), f32_val); // f32 const
+    assert_eq!(store_operand1.into_basic_value().unwrap(), arg1); // f32* arg1
     assert!(store_instruction.get_operand(2).is_none());
     assert!(store_instruction.get_operand(3).is_none());
     assert!(store_instruction.get_operand(4).is_none());
@@ -57,12 +57,12 @@ fn test_operands() {
     let store_operand0 = store_operands.next().unwrap().unwrap();
     let store_operand1 = store_operands.next().unwrap().unwrap();
 
-    assert_eq!(store_operand0.left().unwrap(), f32_val); // f32 const
-    assert_eq!(store_operand1.left().unwrap(), arg1); // f32* arg1
+    assert_eq!(store_operand0.into_basic_value().unwrap(), f32_val); // f32 const
+    assert_eq!(store_operand1.into_basic_value().unwrap(), arg1); // f32* arg1
     assert!(store_operands.next().is_none());
 
-    let free_operand0 = free_instruction.get_operand(0).unwrap().left().unwrap();
-    let free_operand1 = free_instruction.get_operand(1).unwrap().left().unwrap();
+    let free_operand0 = free_instruction.get_operand(0).unwrap().into_basic_value().unwrap();
+    let free_operand1 = free_instruction.get_operand(1).unwrap().into_basic_value().unwrap();
 
     assert!(free_operand0.is_pointer_value()); // (implicitly casted) i8* arg1
     assert!(free_operand1.is_pointer_value()); // Free function ptr
@@ -72,7 +72,14 @@ fn test_operands() {
 
     let free_operand0_instruction = free_operand0.as_instruction_value().unwrap();
     assert_eq!(free_operand0_instruction.get_opcode(), BitCast);
-    assert_eq!(free_operand0_instruction.get_operand(0).unwrap().left().unwrap(), arg1);
+    assert_eq!(
+        free_operand0_instruction
+            .get_operand(0)
+            .unwrap()
+            .into_basic_value()
+            .unwrap(),
+        arg1
+    );
     assert!(free_operand0_instruction.get_operand(1).is_none());
     assert!(free_operand0_instruction.get_operand(2).is_none());
 
@@ -106,7 +113,7 @@ fn test_operands() {
         .get_used_value()
         .left()
         .unwrap();
-    let free_call_param = free_instruction.get_operand(0).unwrap().left().unwrap();
+    let free_call_param = free_instruction.get_operand(0).unwrap().into_basic_value().unwrap();
 
     assert_eq!(bit_cast_use_value, free_call_param);
 
@@ -195,7 +202,7 @@ fn test_basic_block_operand() {
     builder.position_at_end(basic_block);
 
     let branch_instruction = builder.build_unconditional_branch(basic_block2).unwrap();
-    let bb_operand = branch_instruction.get_operand(0).unwrap().right().unwrap();
+    let bb_operand = branch_instruction.get_operand(0).unwrap().into_basic_block().unwrap();
 
     assert_eq!(bb_operand, basic_block2);
 


### PR DESCRIPTION
## Description

Adds a few utility functions around debug information and changes instruction operand handling to support debug metadata, with some fixes to error messaging around value types too.

### Changes
- Changes `InstructionValue::get_operand` family of functions (including `get_operands`)  to return a new `OperandValue`. They currently had `Either<BasicValue, BasicBlock>` which is insufficient for operands - they can be metadata values as well.
- Added Helper functions for the transitional DbgRecord changes.  
`Module::is_new_debug_format` - this corresponds to `LLVMIsNewDbgInfoFormat`
`Module::set_new_debug_format` - this corresponds to `LLVMSetIsNewDbgInfoFormat`
- Added `as_metadata_value` to the suite of `DI*` types, as all these types are metadata values that can be fetched via instruction operands (old) or `DbgRecord` (new)
- Better output to the panics in the enum variants, so you can see what kind was unimplemente
- Updated tests to all pass for the new `get_operand` call.


## How This Has Been Tested

This was tested with llvm 20.1 locally in a personal project. Ex usage such as:
```
    module.set_new_debug_format(false);
    module.get_functions().for_each(|function| {
        function.get_basic_blocks().iter().for_each(|block| {
            block.get_instructions().skip(1).for_each(|instr| {
                    (0..instr.get_num_operands()).for_each(|i| {
                            if let Some(OperandValue::BasicMetadataValue(metadata)) =
                                instr.get_operand(i)
                            {
                                ... Handle debug metadata operands here....
                            }
                        });
                    });
                }
            });
        });
```

## Breaking Changes

Changes `InstructionValue::get_operand` and `OperandIter` to use `OperandValue` instead of `Either<BasicValue, BasicBlock>`. This was required because operands on a value instruction can be more than just BasicValue or BasicBlock, they can also be `MetadataValue` in the case of debug intrinsics. 

- All `left()` calls must now be `into_basic_value()` or `try_into()` or `into()`
- All `right()` calls must now be `into_basic_block()` or `try_into()` or `into()`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
