### PR TITLE
Add BasicValueEnum::is_const() Method

### DIFF
--- a/src/values/traits.rs
+++ b/src/values/traits.rs
@@ -1,4 +1,4 @@
-use llvm_sys::core::LLVMIsConst;
+use llvm_sys::core::LLVMIsConstant;
 use llvm_sys::prelude::LLVMValueRef;
 
 #[llvm_versions(12..)]
@@ -134,7 +134,7 @@ pub unsafe trait BasicValue<'ctx>: AnyValue<'ctx> {
 
     /// Returns true if this value is a constant.
     fn is_const(&self) -> bool {
-        unsafe { LLVMIsConst(self.as_value_ref()) == 1 }
+        unsafe { LLVMIsConstant(self.as_value_ref()) == 1 }
     }
 
     // REVIEW: Possible encompassing methods to implement:


### PR DESCRIPTION
## Summary

This PR adds a new method to Inkwell’s BasicValueEnum:

```rust
/// Returns true if this BasicValueEnum represents a constant value.
  pub fn is_const(&self) -> bool {
      match self {
          BasicValueEnum::IntValue(v) => v.is_const(),
          BasicValueEnum::FloatValue(v) => v.is_const(),
          BasicValueEnum::PointerValue(v) => v.is_const(),
          BasicValueEnum::StructValue(v) => v.is_const(),
          BasicValueEnum::ArrayValue(v) => v.is_const(),
          BasicValueEnum::VectorValue(v) => v.is_const(),
          BasicValueEnum::ScalableVectorValue(v) => v.is_const(), 
      }
  }
```

This addition provides a clean and consistent way to check whether a BasicValueEnum represents a constant, without needing to manually match all of its possible variants.

## Motivation

While working on my compiler project [@cyrus_lang](https://github.com/cyrus-lang), I ran into a situation where I needed to determine if a BasicValueEnum was constant in order to decide how to construct a struct at runtime.

Specifically, when generating LLVM IR for struct initialization, I needed to know whether the struct could be built as a `constant aggregate` or if its fields should instead be populated at runtime using `insertvalue`. Since BasicValueEnum didn’t provide a unified way to check const-ness, I had to write a manual helper like this:

```rust
use inkwell::values::BasicValueEnum;

pub fn is_basic_value_constant<'a>(basic_value: BasicValueEnum<'a>) -> bool {
    match basic_value {
        BasicValueEnum::IntValue(int_value) => int_value.is_const(),
        BasicValueEnum::FloatValue(float_value) => float_value.is_const(),
        BasicValueEnum::PointerValue(ptr_value) => ptr_value.is_const(),
        BasicValueEnum::StructValue(struct_value) => struct_value.is_const(),
        BasicValueEnum::ArrayValue(array_value) => array_value.is_const(),
        BasicValueEnum::VectorValue(vector_value) => vector_value.is_const(),
        BasicValueEnum::ScalableVectorValue(scalable_value) => scalable_value.is_const(),
    }
}
```

Adding `BasicValueEnum::is_const()` directly to Inkwell made this logic both cleaner and more idiomatic.
It now integrates naturally with the rest of the API and eliminates repetitive pattern matching across compiler code.