### PR TITLE
[Feature] We should be able to walk through the operands of a call wi…

### DIFF
--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -7,8 +7,6 @@ use crate::basic_block::BasicBlock;
 use crate::values::{AnyValueEnum, BasicValueEnum, MetadataValue};
 
 /// Either [BasicValueEnum], a [BasicBlock] or a [Metadata].
-///
-/// Note that [Metadata] variants are only constructed for LLVM 17+.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Operand<'ctx> {
     /// Represents a [BasicValueEnum].

--- a/src/values/enums.rs
+++ b/src/values/enums.rs
@@ -461,6 +461,7 @@ impl<'ctx> AggregateValueEnum<'ctx> {
 
 impl<'ctx> BasicMetadataValueEnum<'ctx> {
     pub(crate) unsafe fn new(value: LLVMValueRef) -> Self {
+        assert!(!value.is_null());
         match LLVMGetTypeKind(LLVMTypeOf(value)) {
             LLVMTypeKind::LLVMFloatTypeKind
             | LLVMTypeKind::LLVMFP128TypeKind

--- a/src/values/metadata_value.rs
+++ b/src/values/metadata_value.rs
@@ -101,7 +101,7 @@ impl<'ctx> MetadataValue<'ctx> {
 
     // SubTypes: Node only one day
     // REVIEW: BasicMetadataValueEnum only if you can put metadata in metadata...
-    pub fn get_node_values(self) -> Vec<BasicMetadataValueEnum<'ctx>> {
+    pub fn get_node_values(self) -> Vec<Option<BasicMetadataValueEnum<'ctx>>> {
         if self.is_string() {
             return Vec::new();
         }
@@ -117,7 +117,13 @@ impl<'ctx> MetadataValue<'ctx> {
         };
 
         vec.iter()
-            .map(|val| unsafe { BasicMetadataValueEnum::new(*val) })
+            .map(|val| {
+                if val.is_null() {
+                    None
+                } else {
+                    Some(unsafe { BasicMetadataValueEnum::new(*val) })
+                }
+            })
             .collect()
     }
 

--- a/tests/all/test_instruction_values.rs
+++ b/tests/all/test_instruction_values.rs
@@ -662,7 +662,6 @@ fn test_metadata_kinds() {
     ]);
 }
 
-#[llvm_versions(17..)]
 #[test]
 fn test_metadata_as_operand() {
     // clang can introduce instructions such as
@@ -713,10 +712,13 @@ fn test_metadata_as_operand() {
     );
     let instruction = debug_info_builder.insert_declare_at_end(i32_ptr, Some(var_info), None, debug_loc, block);
     assert_eq!(instruction.get_num_operands(), 4);
-    assert!(instruction.get_operand(0).is_some());
-    assert!(instruction.get_operand(1).is_none());
-    assert!(instruction.get_operand(2).is_none());
-    assert!(instruction.get_operand(3).is_some());
+    assert_eq!(instruction.get_operands().count(), 4);
+    for (i, operand) in instruction.get_operands().enumerate() {
+        assert!(operand.is_some());
+        // A cheap (and certainly insufficient) test that we can walk through
+        // the operand without segfaulting.
+        eprintln!("operand {i} is {:?}", operand);
+    }
 }
 
 #[test]

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -917,7 +917,11 @@ fn test_metadata() {
     let md_node_child = context.metadata_node(&[bool_val.into(), f32_val.into()]);
     let md_node = context.metadata_node(&[bool_val.into(), f32_val.into(), md_string.into(), md_node_child.into()]);
 
-    let node_values = md_node.get_node_values();
+    let node_values: Vec<_> = md_node
+        .get_node_values()
+        .iter()
+        .map(|v| v.expect("Node value should not have been none"))
+        .collect();
 
     assert_eq!(md_node.get_string_value(), None);
     assert_eq!(node_values.len(), 4);
@@ -938,7 +942,11 @@ fn test_metadata() {
 
     assert_eq!(global_md.len(), 1);
 
-    let md = global_md[0].get_node_values();
+    let md: Vec<_> = md_node
+        .get_node_values()
+        .iter()
+        .map(|v| v.expect("Node value should not have been none"))
+        .collect();
 
     assert_eq!(md.len(), 4);
     assert_eq!(md[0].into_int_value(), bool_val);
@@ -992,7 +1000,11 @@ fn test_metadata() {
     assert!(ret_instr.has_metadata());
     assert!(ret_instr.get_metadata(1).is_none());
 
-    let md_node_values = ret_instr.get_metadata(2).unwrap().get_node_values();
+    let md_node_values: Vec<_> = md_node
+        .get_node_values()
+        .iter()
+        .map(|v| v.expect("Node value should not have been none"))
+        .collect();
 
     assert_eq!(md_node_values.len(), 1);
     assert_eq!(


### PR DESCRIPTION
…th metadata arguments

## Description

- We expand `Operand` to accept a new variant `Metadata`. This is probably a breaking change, so there may be a better way to do this.
- We expand `Operand::get_operand_unchecked` to create these variants when the operand is a metadata.
- Slightly expands the error messages in case of panic in `AnyValueEnum::new` and `BasicValueEnum::new`.
- Replaces the `unreachable!` of `BasicValueEnum::new` with a `panic!`, since it turns out to be reachable.
- Some testing.

There are still at least two unknowns in this version of the MR:

1. Right now, we return `None` for operands that are marked as `LLVMMetadataTypeKind` but that convert to `null`. Not sure that this is the right behavior.
2. So far, I've only ever used inkwell to inspect IR, not to produce it, so I'm not particularly confident about my test.

## Related Issue

issue #633 

## How This Has Been Tested

New test `test_metadata_as_operand`.

Tests launched on macOS 12.7.6  with `cargo test --features llvm18-1`.

The following tests do not pass on my machine, but as far as I can tell, it's not related:
- `test_object_file::test_symbol_iterator` (`assertion failed: has_symbol_a`)
- `test_targets::test_default_triple` (`unknown OS`)

Waiting to see if it fares better in CI.

## Option\<Breaking Changes\>

I didn't find any way to implement this change that did not introduce at least one variant to at least one `enum`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
