### PR TITLE
Fixes type name in `expect` message for `Operand`

### DIFF
--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -77,7 +77,7 @@ impl<'ctx> Operand<'ctx> {
     #[must_use]
     #[track_caller]
     pub fn unwrap_value(self) -> BasicValueEnum<'ctx> {
-        self.expect_value("Called unwrap_value() on UsedValue::Block.")
+        self.expect_value("Called unwrap_value() on Operand::Block.")
     }
 
     /// Unwrap [BasicBlock]. Will panic if it is not.
@@ -85,7 +85,7 @@ impl<'ctx> Operand<'ctx> {
     #[must_use]
     #[track_caller]
     pub fn unwrap_block(self) -> BasicBlock<'ctx> {
-        self.expect_block("Called unwrap_block() on UsedValue::Value.")
+        self.expect_block("Called unwrap_block() on Operand::Value.")
     }
 }
 


### PR DESCRIPTION
## Description

When I made the `Operand` type in `basic_value_use.rs`, I initially named it `UsedValue`, but then later renamed it to `Operand` before submitting the pull request. When I renamed it, I forgot to change the type name used in a couple of error messages. This PR fixes that name issue.

## How This Has Been Tested

Nothing to be tested, the only change is a string.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
