### PR TITLE
CI: Fix documentation action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on: [ push, pull_request ]
 
 env:
   CARGO_TERM_COLOR: always
-  DOC_LLVM_FEATURE: llvm18-1
-  DOC_LLVM_VERSION: "18.1"
+  DOC_LLVM_FEATURE: llvm21-1
+  DOC_LLVM_VERSION: "21.1"
   DOC_PATH: target/doc
 
 jobs:
@@ -41,12 +41,14 @@ jobs:
         - [ "20.1", "20-1", "20" ]
         - [ "21.1", "21-1", "21" ]
         include:
-        - os: ubuntu-22.04
+        - os: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - name: Install Dependencies
-      run: sudo apt update && sudo apt install -y libtinfo5
+    - name: Install libtinfo5
+      run: |
+        wget https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+        sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
     - name: Install LLVM and Clang (LLVM >= 19.1)
       if: ${{ matrix.llvm-version[0] >= 19 }}
       run: |
@@ -87,12 +89,14 @@ jobs:
         cargo run --example jit --features llvm${{ matrix.llvm-version[1] }} --verbose --release
   doc:
     name: Documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    env:
+      LLVM_SYS_211_PREFIX: ${{ github.workspace }}/llvm
     needs: [ lint, tests ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v4
-    - uses: KyleMayes/install-llvm-action@v2
+    - uses: KyleMayes/install-llvm-action@v2.0.8
       with:
         version: ${{ env.DOC_LLVM_VERSION }}
     - name: Install Rust Nightly


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

The current GitHub documentation [page](https://thedan64.github.io/inkwell/inkwell/index.html) is still at 0.5.0. This fixes the test and documentation workflow to use `ubuntu-latest` (as 22.04 LTS might become unavailable soon with 26.04 LTS) and LLVM 21.1. 

## Related Issue

Weakly related to #634. 

## How This Has Been Tested

Currently deployed to [fork's page](https://my4ng.github.io/inkwell/inkwell/index.html).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
