### PR TITLE
Memory buffer v2

### DIFF
--- a/tests/all/test_memory_buffer.rs
+++ b/tests/all/test_memory_buffer.rs
@@ -1,19 +1,40 @@
+use std::path::Path;
+
 use inkwell::memory_buffer::MemoryBuffer;
 
 #[test]
 fn test_memory_buffer() {
-    let buffer = c"mem";
-    let memory_buffer = MemoryBuffer::create_from_memory_range(buffer, "mem");
+    let buffer = b"mem\0";
+    let memory_buffer = MemoryBuffer::create_from_memory_range(buffer, "mem_buf");
 
-    assert_eq!(memory_buffer.as_slice().as_ptr(), buffer.as_ptr() as *const _);
-    assert_eq!(memory_buffer.get_size(), 4);
+    assert_eq!(memory_buffer.as_slice(), buffer);
 }
 
 #[test]
 fn test_memory_buffer_copied() {
-    let buffer = c"mem";
-    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(buffer, "mem");
+    let buffer = b"mem\0";
+    let memory_buffer_copied = MemoryBuffer::create_from_memory_range_copy(buffer, "mem_buf_copied");
 
-    assert_ne!(memory_buffer.as_slice().as_ptr(), buffer.as_ptr() as *const _);
-    assert_eq!(memory_buffer.get_size(), 4);
+    assert_ne!(memory_buffer_copied.as_slice().as_ptr(), buffer.as_ptr() as *const _);
+    assert_eq!(memory_buffer_copied.as_slice(), buffer);
+
+    let memory_buffer = MemoryBuffer::create_from_memory_range(memory_buffer_copied.as_slice(), "mem_buf");
+
+    assert_eq!(memory_buffer_copied.as_slice(), memory_buffer.as_slice());
+}
+
+#[test]
+#[should_panic]
+fn test_memory_buffer_panic() {
+    let buffer = b"mem";
+    // panic since no trailing nul byte.
+    MemoryBuffer::create_from_memory_range(buffer, "mem_buf");
+}
+
+#[test]
+fn test_memory_buffer_file() {
+    let memory_buffer = MemoryBuffer::create_from_file(Path::new("./LICENSE")).unwrap();
+
+    assert_eq!(memory_buffer.as_slice()[memory_buffer.get_size() - 1], b'\0'); // nul byte
+    assert_eq!(memory_buffer.as_slice()[memory_buffer.get_size() - 2], b'\n'); // new line character
 }

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -144,7 +144,7 @@ fn test_write_and_load_memory_buffer() {
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range(c"garbage ir data", "my_ir");
+    let memory_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir");
 
     assert_eq!(memory_buffer.get_size(), 16);
     assert_eq!(memory_buffer.as_slice(), b"garbage ir data\0");
@@ -154,7 +154,7 @@ fn test_garbage_ir_fails_create_module_from_ir() {
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir_copy() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(c"garbage ir data", "my_ir");
+    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(b"garbage ir data\0", "my_ir");
 
     assert_eq!(memory_buffer.get_size(), 16);
     assert_eq!(memory_buffer.as_slice(), b"garbage ir data\0");
@@ -216,7 +216,7 @@ fn test_get_struct_type_global_context() {
 #[test]
 fn test_parse_from_buffer() {
     let context = Context::create();
-    let garbage_buffer = MemoryBuffer::create_from_memory_range(c"garbage ir data", "my_ir");
+    let garbage_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir");
     let module_result = Module::parse_bitcode_from_buffer(&garbage_buffer, &context);
 
     assert!(module_result.is_err());

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -146,7 +146,7 @@ fn test_function_type() {
 /// Regression test for inkwell#546
 #[test]
 fn test_function_type_metadata_params() {
-    let llvm_ir = c"declare void @my_fn(i32, metadata)";
+    let llvm_ir = b"declare void @my_fn(i32, metadata)\0";
 
     let context = Context::create();
     let i32_type = context.i32_type();

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -169,7 +169,7 @@ fn test_call_site_function_value_indirect_call() {
     // }
     // ```
 
-    let llvm_ir = c"
+    let llvm_ir = b"
         source_filename = \"my_mod\";
 
         define void @my_fn() {
@@ -182,7 +182,7 @@ fn test_call_site_function_value_indirect_call() {
         }
 
         declare void @dummy_fn();
-    ";
+    \0";
 
     let memory_buffer = MemoryBuffer::create_from_memory_range_copy(llvm_ir, "my_mod");
     let context = Context::create();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

This fixes two issues with the previous design.

1. The `&CStr` input was overly restrictive. It is OK to have interior nul bytes, as shown in object file tests where in memory buffer read from binary ELF files, most bytes are indeed nul. It will now panic only if the last byte is not nul.

2. The input data length in creation is now correct at input.len() - 1, as the nul byte should be at one past the end of the actual data. Similarly, the get_size (and hence as_slice) have the length plused one to include the trailing nul byte. This should now align with the LLVM documentation.

It was an oversight of mine to not have noticed them in the C++ documentation and testing with actual binary files. Additional tests have been added to ensure compliance with LLVM.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

#654

## How This Has Been Tested

`cargo test -F llvm21-1`

## Option\<Breaking Changes\>

- Reverted `create_from_memory_range` and `create_from_memory_range_copy` to take &[u8] input once again.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
