### PR TITLE
fix: make LLVMString Send and Sync

### DIFF
--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -21,6 +21,9 @@ pub struct LLVMString {
     pub(crate) ptr: *const c_char,
 }
 
+unsafe impl Send for LLVMString {}
+unsafe impl Sync for LLVMString {}
+
 impl LLVMString {
     pub(crate) unsafe fn new(ptr: *const c_char) -> Self {
         LLVMString { ptr }


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

Similar to the [Unique](https://stdrs.dev/nightly/x86_64-unknown-linux-gnu/std/ptr/struct.Unique.html) pointer, here the underlying data is unaliased and hence 'safe' to implement `Send` and `Sync`.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

#488

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
