### PR TITLE
feat: replace deprecated object file

### DIFF
--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -136,9 +136,9 @@ fn test_write_and_load_memory_buffer() {
     );
 
     let memory_buffer2 = module.write_bitcode_to_memory();
-    let object_file = memory_buffer2.create_object_file();
+    let binary_file = memory_buffer2.create_binary_file(None);
 
-    assert!(object_file.is_err());
+    assert!(binary_file.is_err());
 }
 
 #[test]


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

The ObjectFile API has been deprecated since LLVM 9, in favour of BinaryFile, [llvm](https://llvm.org/doxygen/group__LLVMCObject.html).

Add lifetimes to the various structs such that a resulting struct never outlives the underlying struct from which it is created.

The `next_section/relocation/symbol` methods now borrow mutably to avoid advancing the underlying pointer while a resulting struct still exists.

## How This Has Been Tested

`cargo test -F llvm21-1` with additional tests, and target machine fixed to x86_64 to avoid native machine testing issues.

## Option\<Breaking Changes\>

- `MemoryBuffer::create_object_file` becomes `create_binary_file`.
- Completely rework the `object_file.rs` structs. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
