### PR TITLE
chore: replace once_cell with std LazyLock/LazyCell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,6 @@ llvm-sys-211 = { package = "llvm-sys", version = "211.0.0", optional = true }
 llvm-sys-221 = { package = "llvm-sys", version = "221.0.0", optional = true }
 
 libc = "0.2"
-once_cell = "1.16"
 thiserror = "2.0.11"
 
 static-alloc = { version = "0.2", optional = true }

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,8 +36,8 @@ use llvm_sys::ir_reader::LLVMParseIRInContext2;
 
 use llvm_sys::prelude::{LLVMContextRef, LLVMDiagnosticInfoRef, LLVMMetadataRef, LLVMTypeRef, LLVMValueRef};
 use llvm_sys::target::{LLVMIntPtrTypeForASInContext, LLVMIntPtrTypeInContext};
-use once_cell::sync::Lazy;
-use std::sync::{Mutex, MutexGuard};
+use std::cell::LazyCell;
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use crate::AddressSpace;
 use crate::attributes::Attribute;
@@ -71,11 +71,11 @@ use std::thread_local;
 // This is still technically unsafe because another program in the same process
 // could also be accessing the global context via the C API. `get_global` has been
 // marked unsafe for this reason. Iff this isn't the case then this should be fully safe.
-static GLOBAL_CTX: Lazy<Mutex<Context>> = Lazy::new(|| Mutex::new(Context::create()));
+static GLOBAL_CTX: LazyLock<Mutex<Context>> = LazyLock::new(|| Mutex::new(Context::create()));
 
 thread_local! {
     #[deprecated(note = "use Context::create instead")]
-    pub(crate) static GLOBAL_CTX_LOCK: Lazy<MutexGuard<'static, Context>> = Lazy::new(|| {
+    pub(crate) static GLOBAL_CTX_LOCK: LazyCell<MutexGuard<'static, Context>> = LazyCell::new(|| {
         GLOBAL_CTX.lock().unwrap_or_else(|e| e.into_inner())
     });
 }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -21,8 +21,7 @@ use llvm_sys::target_machine::{
     LLVMTargetMachineOptionsSetCodeGenOptLevel, LLVMTargetMachineOptionsSetCodeModel,
     LLVMTargetMachineOptionsSetFeatures, LLVMTargetMachineOptionsSetRelocMode,
 };
-use once_cell::sync::Lazy;
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 
 use crate::context::AsContextRef;
 use crate::data_layout::DataLayout;
@@ -168,7 +167,7 @@ impl fmt::Display for TargetTriple {
     }
 }
 
-static TARGET_LOCK: Lazy<RwLock<()>> = Lazy::new(|| RwLock::new(()));
+static TARGET_LOCK: LazyLock<RwLock<()>> = LazyLock::new(|| RwLock::new(()));
 
 // NOTE: Versions verified as target-complete: 3.6, 3.7, 3.8, 3.9, 4.0
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
Replace the `once_cell` dependency with `std::sync::LazyLock` and `std::cell::LazyCell`, removing an external dependency.