### PR TITLE
Deprecate legacy PassManager in favor of PassBuilderOptions and run_passes

### DIFF
--- a/src/passes.rs
+++ b/src/passes.rs
@@ -150,6 +150,7 @@ impl PassManagerBuilder {
     ///
     /// pass_manager_builder.populate_function_pass_manager(&fpm);
     /// ```
+    #[allow(deprecated)]
     pub fn populate_function_pass_manager(&self, pass_manager: &PassManager<FunctionValue>) {
         unsafe {
             LLVMPassManagerBuilderPopulateFunctionPassManager(self.pass_manager_builder, pass_manager.pass_manager)
@@ -176,6 +177,7 @@ impl PassManagerBuilder {
     ///
     /// pass_manager_builder.populate_module_pass_manager(&fpm);
     /// ```
+    #[allow(deprecated)]
     pub fn populate_module_pass_manager(&self, pass_manager: &PassManager<Module>) {
         unsafe { LLVMPassManagerBuilderPopulateModulePassManager(self.pass_manager_builder, pass_manager.pass_manager) }
     }
@@ -200,6 +202,7 @@ impl PassManagerBuilder {
     ///
     /// pass_manager_builder.populate_lto_pass_manager(&lpm, false, false);
     /// ```
+    #[allow(deprecated)]
     #[llvm_versions(..=14)]
     pub fn populate_lto_pass_manager(&self, pass_manager: &PassManager<Module>, internalize: bool, run_inliner: bool) {
         use llvm_sys::transforms::pass_manager_builder::LLVMPassManagerBuilderPopulateLTOPassManager;
@@ -229,11 +232,13 @@ pub trait PassManagerSubType {
     type Input;
 
     unsafe fn create<I: Borrow<Self::Input>>(input: I) -> LLVMPassManagerRef;
+    #[allow(deprecated)]
     unsafe fn run_in_pass_manager(&self, pass_manager: &PassManager<Self>) -> bool
     where
         Self: Sized;
 }
 
+#[allow(deprecated)]
 impl PassManagerSubType for Module<'_> {
     type Input = ();
 
@@ -248,6 +253,7 @@ impl PassManagerSubType for Module<'_> {
 
 // With GATs https://github.com/rust-lang/rust/issues/44265 this could be
 // type Input<'a> = &'a Module;
+#[allow(deprecated)]
 impl<'ctx> PassManagerSubType for FunctionValue<'ctx> {
     type Input = Module<'ctx>;
 
@@ -266,7 +272,7 @@ impl<'ctx> PassManagerSubType for FunctionValue<'ctx> {
 /// documentation](https://llvm.org/docs/Passes.html).
 #[derive(Debug)]
 #[deprecated(
-    since = "0.8.0",
+    since = "0.9.0",
     note = "Use [`PassBuilderOptions`] with [`Module::run_passes`] instead (new pass manager). This struct will be removed once LLVM 16 support is dropped."
 )]
 pub struct PassManager<T> {
@@ -274,6 +280,7 @@ pub struct PassManager<T> {
     sub_type: PhantomData<T>,
 }
 
+#[allow(deprecated)]
 impl PassManager<FunctionValue<'_>> {
     /// Acquires the underlying raw pointer belonging to this `PassManager<T>` type.
     pub fn as_mut_ptr(&self) -> LLVMPassManagerRef {
@@ -290,6 +297,7 @@ impl PassManager<FunctionValue<'_>> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: PassManagerSubType> PassManager<T> {
     pub unsafe fn new(pass_manager: LLVMPassManagerRef) -> Self {
         assert!(!pass_manager.is_null());
@@ -1092,6 +1100,7 @@ impl<T: PassManagerSubType> PassManager<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T> Drop for PassManager<T> {
     fn drop(&mut self) {
         unsafe { LLVMDisposePassManager(self.pass_manager) }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -27,6 +27,7 @@ use crate::context::AsContextRef;
 use crate::data_layout::DataLayout;
 use crate::memory_buffer::MemoryBuffer;
 use crate::module::Module;
+#[allow(deprecated)]
 use crate::passes::PassManager;
 use crate::support::{LLVMString, to_c_str};
 use crate::types::{AnyType, AsTypeRef, IntType, StructType};
@@ -1133,6 +1134,7 @@ impl TargetMachine {
     }
 
     // TODO: Move to PassManager?
+    #[allow(deprecated)]
     pub fn add_analysis_passes<T>(&self, pass_manager: &PassManager<T>) {
         unsafe { LLVMAddAnalysisPasses(self.target_machine, pass_manager.pass_manager) }
     }

--- a/tests/all/test_passes.rs
+++ b/tests/all/test_passes.rs
@@ -1,4 +1,5 @@
 use inkwell::context::Context;
+#[allow(deprecated)]
 use inkwell::passes::{PassManager, PassManagerBuilder, PassRegistry};
 
 use inkwell::OptimizationLevel;
@@ -8,6 +9,7 @@ use inkwell::passes::PassBuilderOptions;
 use inkwell::targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetMachine};
 
 #[test]
+#[allow(deprecated)]
 fn test_init_all_passes_for_module() {
     let context = Context::create();
     let module = context.create_module("my_module");
@@ -122,6 +124,7 @@ fn test_init_all_passes_for_module() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_pass_manager_builder() {
     let pass_manager_builder = PassManagerBuilder::create();
 


### PR DESCRIPTION
## Description

This PR deprecates the `PassManager` struct.

The legacy `PassManager<T>` is replaced by the new pass manager workflow:

- `PassBuilderOptions`
- `Module::run_passes`

This aligns Inkwell with LLVM's new pass manager infrastructure.

The `PassManager` struct  will be removed once LLVM 16 support is dropped.

## Related Issue

Issue #505 

## How This Has Been Tested

- Ran `cargo clippy --features llvm20-1`, which completed successfully and only reported warnings related to deprecated APIs,  which are expected due to ongoing transition to the new LLVM pass manager infrastructure.
- Ran `cargo test --features llvm20-1`, with all tests passing. (328 passed, 17 ignored, consistent with master branch)
-  Ran `cargo doc --no-deps --features llvm20-1`, documentation builds successfully with no errors.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
