### PR TITLE
Fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,5 +178,8 @@ regex = "1"
 version = "0.62.2"
 features = ["Win32_System_SystemInformation", "Win32_System_Memory"]
 
+[package.metadata.docs.rs]
+features = ["llvm22-1-no-llvm-linking"]
+
 [badges]
 codecov = { repository = "TheDan64/inkwell" }


### PR DESCRIPTION
## Description

This PR should fix the docs build in `docs.rs` by enabling a a non-linking feature of LLVM

## Related Issue

https://github.com/TheDan64/inkwell/issues/634

## How This Has Been Tested

Building with and without this feature, I've seen and done similar changes in other projects in the past (more commonly so that docs show all available features), the full spec of that toml table is [here](https://docs.rs/about/metadata).

When running locally, the docs build fails in the same way with default features but works with the feature enabled.


## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
