### PR TITLE
Introduce Concurrent CompilerPool for multithreaded LLVM execution

### DIFF
--- a/src/concurrent/mod.rs
+++ b/src/concurrent/mod.rs
@@ -1,0 +1,3 @@
+pub mod pool;
+
+pub use pool::{CompilerJob, CompilerPool};

--- a/src/concurrent/pool.rs
+++ b/src/concurrent/pool.rs
@@ -1,0 +1,60 @@
+use crate::context::Context;
+use crate::module::Module;
+use crate::memory_buffer::MemoryBuffer;
+use std::thread;
+
+/// A piece of work to be executed in an isolated LLVM context.
+pub trait CompilerJob: Send + 'static {
+    fn execute<'ctx>(self: Box<Self>, context: &'ctx Context) -> Module<'ctx>;
+}
+
+/// A pool designed for compiling isolated closures inside LLVM without violating thread-safety rules.
+#[derive(Debug)]
+pub struct CompilerPool;
+
+impl CompilerPool {
+    /// Executes a list of tasks concurrently across multiple threads.
+    /// Each task receives its own isolated `LLVMContext` and returns a `Module`.
+    /// The modules are serialized to Bitcode as pure bytes (`Vec<u8>`), sent back across the thread boundary,
+    /// and parsed/linked perfectly back into the `master_module`.
+    pub fn execute_and_link<'ctx>(
+        master_context: &'ctx Context,
+        master_module: &Module<'ctx>,
+        jobs: Vec<Box<dyn CompilerJob>>,
+    ) -> Result<(), String> {
+        let mut handles = Vec::with_capacity(jobs.len());
+
+        for job in jobs {
+            let handle = thread::spawn(move || {
+                let local_context = Context::create();
+                let local_module = job.execute(&local_context);
+
+                // Serialize the AST to LLVM Bitcode into a standard safe Vec<u8> byte array.
+                // It's perfectly Send-able across threads without worrying about LLVM Object ownership.
+                let mem_buffer = local_module.write_bitcode_to_memory();
+                mem_buffer.as_slice().to_vec()
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            match handle.join() {
+                Ok(byte_code) => {
+                    // Turn bytes back to MemoryBuffer in main thread Context.
+                    // create_from_memory_range_copy assumes trailing NUL byte exists, which as_slice() includes!
+                    let mem_buffer = MemoryBuffer::create_from_memory_range_copy(&byte_code, "concurrent_module");
+                    
+                    let parsed_module = Module::parse_bitcode_from_buffer(&mem_buffer, master_context)
+                        .map_err(|e| e.to_string())?;
+                        
+                    master_module.link_in_module(parsed_module).map_err(|e| e.to_string())?;
+                }
+                Err(_) => {
+                    return Err("A thread in the CompilerPool unexpectedly panicked.".to_string());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/concurrent/pool.rs
+++ b/src/concurrent/pool.rs
@@ -22,37 +22,54 @@ impl CompilerPool {
         master_module: &Module<'ctx>,
         jobs: Vec<Box<dyn CompilerJob>>,
     ) -> Result<(), String> {
-        let mut handles = Vec::with_capacity(jobs.len());
+        let max_concurrency = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(1);
 
-        for job in jobs {
-            let handle = thread::spawn(move || {
-                let local_context = Context::create();
-                let local_module = job.execute(&local_context);
+        // Process jobs in bounded batches to avoid OS thread exhaustion
+        let mut all_bytes = Vec::with_capacity(jobs.len());
+        
+        let mut pending_jobs: Vec<Box<dyn CompilerJob>> = jobs.into_iter().collect();
 
-                // Serialize the AST to LLVM Bitcode into a standard safe Vec<u8> byte array.
-                // It's perfectly Send-able across threads without worrying about LLVM Object ownership.
-                let mem_buffer = local_module.write_bitcode_to_memory();
-                mem_buffer.as_slice().to_vec()
-            });
-            handles.push(handle);
-        }
+        while !pending_jobs.is_empty() {
+            let batch_size = std::cmp::min(pending_jobs.len(), max_concurrency);
+            let mut handles = Vec::with_capacity(batch_size);
 
-        for handle in handles {
-            match handle.join() {
-                Ok(byte_code) => {
-                    // Turn bytes back to MemoryBuffer in main thread Context.
-                    // create_from_memory_range_copy assumes trailing NUL byte exists, which as_slice() includes!
-                    let mem_buffer = MemoryBuffer::create_from_memory_range_copy(&byte_code, "concurrent_module");
-                    
-                    let parsed_module = Module::parse_bitcode_from_buffer(&mem_buffer, master_context)
-                        .map_err(|e| e.to_string())?;
-                        
-                    master_module.link_in_module(parsed_module).map_err(|e| e.to_string())?;
-                }
-                Err(_) => {
-                    return Err("A thread in the CompilerPool unexpectedly panicked.".to_string());
+            for job in pending_jobs.drain(..batch_size) {
+                let handle = thread::spawn(move || {
+                    let local_context = Context::create();
+                    let local_module = job.execute(&local_context);
+
+                    // Serialize the LLVM module to bitcode and copy it into a standard safe `Vec<u8>`.
+                    // The byte buffer is Send-able across threads without worrying about LLVM object ownership.
+                    let mem_buffer = local_module.write_bitcode_to_memory();
+                    mem_buffer.as_slice().to_vec()
+                });
+                handles.push(handle);
+            }
+
+            for handle in handles {
+                match handle.join() {
+                    Ok(byte_code) => {
+                        all_bytes.push(byte_code);
+                    }
+                    Err(_) => {
+                        return Err("A thread in the CompilerPool unexpectedly panicked.".to_string());
+                    }
                 }
             }
+        }
+
+        // Link all successfully serialized modules into the master module atomically.
+        for byte_code in all_bytes {
+            // Turn bytes back to MemoryBuffer in main thread Context.
+            // create_from_memory_range_copy assumes trailing NUL byte exists, which as_slice() includes!
+            let mem_buffer = MemoryBuffer::create_from_memory_range_copy(&byte_code, "concurrent_module");
+            
+            let parsed_module = Module::parse_bitcode_from_buffer(&mem_buffer, master_context)
+                .map_err(|e| e.to_string())?;
+                
+            master_module.link_in_module(parsed_module).map_err(|e| e.to_string())?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod passes;
 pub mod targets;
 pub mod types;
 pub mod values;
+pub mod concurrent;
 
 // Boilerplate to select a desired llvm_sys version at compile & link time.
 #[cfg(feature = "llvm11-0")]

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -29,3 +29,4 @@ mod test_targets;
 mod test_tari_example;
 mod test_types;
 mod test_values;
+mod test_concurrent;

--- a/tests/all/test_concurrent.rs
+++ b/tests/all/test_concurrent.rs
@@ -1,0 +1,45 @@
+use inkwell::context::Context;
+use inkwell::concurrent::{CompilerPool, CompilerJob};
+use inkwell::module::Module;
+
+struct MyJob {
+    id: usize,
+}
+
+impl CompilerJob for MyJob {
+    fn execute<'ctx>(self: Box<Self>, local_ctx: &'ctx Context) -> Module<'ctx> {
+        let module = local_ctx.create_module(&format!("local_{}", self.id));
+        let i32_type = local_ctx.i32_type();
+        let fn_type = i32_type.fn_type(&[], false);
+        let fn_val = module.add_function(&format!("do_work_{}", self.id), fn_type, None);
+        
+        let builder = local_ctx.create_builder();
+        let block = local_ctx.append_basic_block(fn_val, "entry");
+        builder.position_at_end(block);
+        
+        let ret_val = i32_type.const_int(self.id as u64, false);
+        builder.build_return(Some(&ret_val)).unwrap();
+        
+        module
+    }
+}
+
+#[test]
+fn test_concurrent_compiler_pool() {
+    let master_context = Context::create();
+    let master_module = master_context.create_module("master");
+
+    let mut jobs: Vec<Box<dyn CompilerJob>> = Vec::new();
+
+    // Spawn 3 identical independent generation tasks
+    for i in 0..3 {
+        jobs.push(Box::new(MyJob { id: i }));
+    }
+
+    assert!(CompilerPool::execute_and_link(&master_context, &master_module, jobs).is_ok());
+
+    // Verify all 3 functions made it into the master module successfully
+    assert!(master_module.get_function("do_work_0").is_some());
+    assert!(master_module.get_function("do_work_1").is_some());
+    assert!(master_module.get_function("do_work_2").is_some());
+}

--- a/tests/all/test_concurrent.rs
+++ b/tests/all/test_concurrent.rs
@@ -36,7 +36,8 @@ fn test_concurrent_compiler_pool() {
         jobs.push(Box::new(MyJob { id: i }));
     }
 
-    assert!(CompilerPool::execute_and_link(&master_context, &master_module, jobs).is_ok());
+    CompilerPool::execute_and_link(&master_context, &master_module, jobs)
+        .expect("CompilerPool::execute_and_link should succeed");
 
     // Verify all 3 functions made it into the master module successfully
     assert!(master_module.get_function("do_work_0").is_some());


### PR DESCRIPTION
Provides a high-level concurrent API for executing tasks in isolated LLVM contexts and safely linking them together across threads without invoking C++ assertions or Segfaults.