### PR TITLE
Fix: MemoryBuffer UB and PassManager Runtime Segfaults (#185, #304)

### DIFF
--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -65,16 +65,11 @@ impl MemoryBuffer<'static> {
 
     /// Create a memory buffer copied from a byte slice with a trailing nul byte.
     ///
-    /// # Panics
+    /// # Safety
     ///
-    /// Panics if the input byte slice does not terminate with a nul byte.
-    pub fn create_from_memory_range_copy(input: &[u8], name: &str) -> Self {
-        assert_eq!(
-            input[input.len() - 1],
-            b'\0',
-            "input byte slice must terminate with a nul byte"
-        );
-
+    /// The `input` byte slice must confidently terminate with a nul byte (`\0`),
+    /// otherwise LLVM will experience out-of-bounds undefined behavior/segfaults.
+    pub unsafe fn create_from_memory_range_copy(input: &[u8], name: &str) -> Self {
         let name_c_string = to_c_str(name);
 
         let memory_buffer = unsafe {
@@ -106,16 +101,11 @@ impl<'a> MemoryBuffer<'a> {
 
     /// Create a memory buffer from a byte slice with a trailing nul byte.
     ///
-    /// # Panics
+    /// # Safety
     ///
-    /// Panics if the input byte slice does not terminate with a nul byte.
-    pub fn create_from_memory_range(input: &'a [u8], name: &str) -> Self {
-        assert_eq!(
-            input[input.len() - 1],
-            b'\0',
-            "input byte slice must terminate with a nul byte"
-        );
-
+    /// The `input` byte slice must confidently terminate with a nul byte (`\0`),
+    /// otherwise LLVM will experience out-of-bounds undefined behavior/segfaults.
+    pub unsafe fn create_from_memory_range(input: &'a [u8], name: &str) -> Self {
         let name_c_string = to_c_str(name);
 
         let memory_buffer = unsafe {
@@ -124,7 +114,7 @@ impl<'a> MemoryBuffer<'a> {
                 // decremented since technically the nul byte is one past the end of the input.
                 input.len() - 1,
                 name_c_string.as_ptr(),
-                false as i32, // guaranteed to have nul-terminator by CStr
+                false as i32, // required to be false since LLVM expects already nul-terminated arrays
             )
         };
 

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -298,28 +298,7 @@ impl PassManager<FunctionValue<'_>> {
 }
 
 #[allow(deprecated)]
-impl<T: PassManagerSubType> PassManager<T> {
-    pub unsafe fn new(pass_manager: LLVMPassManagerRef) -> Self {
-        assert!(!pass_manager.is_null());
-
-        PassManager {
-            pass_manager,
-            sub_type: PhantomData,
-        }
-    }
-
-    pub fn create<I: Borrow<T::Input>>(input: I) -> PassManager<T> {
-        let pass_manager = unsafe { T::create(input) };
-
-        unsafe { PassManager::new(pass_manager) }
-    }
-
-    /// This method returns true if any of the passes modified the function or module
-    /// and false otherwise.
-    pub fn run_on(&self, input: &T) -> bool {
-        unsafe { input.run_in_pass_manager(self) }
-    }
-
+impl<'ctx> PassManager<Module<'ctx>> {
     /// This pass promotes "by reference" arguments to be "by value" arguments.
     /// In practice, this means looking for internal functions that have pointer
     /// arguments. If it can prove, through the use of alias analysis, that an
@@ -479,6 +458,31 @@ impl<T: PassManagerSubType> PassManager<T> {
     pub fn add_strip_symbol_pass(&self) {
         unsafe { LLVMAddStripSymbolsPass(self.pass_manager) }
     }
+}
+
+#[allow(deprecated)]
+impl<T: PassManagerSubType> PassManager<T> {
+    pub unsafe fn new(pass_manager: LLVMPassManagerRef) -> Self {
+        assert!(!pass_manager.is_null());
+
+        PassManager {
+            pass_manager,
+            sub_type: PhantomData,
+        }
+    }
+
+    pub fn create<I: Borrow<T::Input>>(input: I) -> PassManager<T> {
+        let pass_manager = unsafe { T::create(input) };
+
+        unsafe { PassManager::new(pass_manager) }
+    }
+
+    /// This method returns true if any of the passes modified the function or module
+    /// and false otherwise.
+    pub fn run_on(&self, input: &T) -> bool {
+        unsafe { input.run_in_pass_manager(self) }
+    }
+
 
     /// No LLVM documentation is available at this time.
     #[llvm_versions(..=16)]

--- a/tests/all/test_memory_buffer.rs
+++ b/tests/all/test_memory_buffer.rs
@@ -5,7 +5,7 @@ use inkwell::memory_buffer::MemoryBuffer;
 #[test]
 fn test_memory_buffer() {
     let buffer = b"mem\0";
-    let memory_buffer = MemoryBuffer::create_from_memory_range(buffer, "mem_buf");
+    let memory_buffer = unsafe { MemoryBuffer::create_from_memory_range(buffer, "mem_buf") };
 
     assert_eq!(memory_buffer.as_slice(), buffer);
 }
@@ -13,12 +13,12 @@ fn test_memory_buffer() {
 #[test]
 fn test_memory_buffer_copied() {
     let buffer = b"mem\0";
-    let memory_buffer_copied = MemoryBuffer::create_from_memory_range_copy(buffer, "mem_buf_copied");
+    let memory_buffer_copied = unsafe { MemoryBuffer::create_from_memory_range_copy(buffer, "mem_buf_copied") };
 
     assert_ne!(memory_buffer_copied.as_slice().as_ptr(), buffer.as_ptr() as *const _);
     assert_eq!(memory_buffer_copied.as_slice(), buffer);
 
-    let memory_buffer = MemoryBuffer::create_from_memory_range(memory_buffer_copied.as_slice(), "mem_buf");
+    let memory_buffer = unsafe { MemoryBuffer::create_from_memory_range(memory_buffer_copied.as_slice(), "mem_buf") };
 
     assert_eq!(memory_buffer_copied.as_slice(), memory_buffer.as_slice());
 }
@@ -28,7 +28,7 @@ fn test_memory_buffer_copied() {
 fn test_memory_buffer_panic() {
     let buffer = b"mem";
     // panic since no trailing nul byte.
-    MemoryBuffer::create_from_memory_range(buffer, "mem_buf");
+    unsafe { MemoryBuffer::create_from_memory_range(buffer, "mem_buf") };
 }
 
 #[test]

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -144,7 +144,7 @@ fn test_write_and_load_memory_buffer() {
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir");
+    let memory_buffer = unsafe { MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir") };
 
     assert_eq!(memory_buffer.get_size(), 16);
     assert_eq!(memory_buffer.as_slice(), b"garbage ir data\0");
@@ -154,7 +154,7 @@ fn test_garbage_ir_fails_create_module_from_ir() {
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir_copy() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(b"garbage ir data\0", "my_ir");
+    let memory_buffer = unsafe { MemoryBuffer::create_from_memory_range_copy(b"garbage ir data\0", "my_ir") };
 
     assert_eq!(memory_buffer.get_size(), 16);
     assert_eq!(memory_buffer.as_slice(), b"garbage ir data\0");
@@ -217,7 +217,7 @@ fn test_get_struct_type_global_context() {
 #[test]
 fn test_parse_from_buffer() {
     let context = Context::create();
-    let garbage_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir");
+    let garbage_buffer = unsafe { MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir") };
     let module_result = Module::parse_bitcode_from_buffer(&garbage_buffer, &context);
 
     assert!(module_result.is_err());

--- a/tests/all/test_types.rs
+++ b/tests/all/test_types.rs
@@ -152,7 +152,7 @@ fn test_function_type_metadata_params() {
     let i32_type = context.i32_type();
     let md_type = context.metadata_type();
 
-    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(llvm_ir, "my_mod");
+    let memory_buffer = unsafe { MemoryBuffer::create_from_memory_range_copy(llvm_ir, "my_mod") };
     let module = context.create_module_from_ir(memory_buffer).unwrap();
 
     let fn_type = module.get_function("my_fn").unwrap().get_type();

--- a/tests/all/test_values.rs
+++ b/tests/all/test_values.rs
@@ -185,7 +185,7 @@ fn test_call_site_function_value_indirect_call() {
         declare void @dummy_fn();
     \0";
 
-    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(llvm_ir, "my_mod");
+    let memory_buffer = unsafe { MemoryBuffer::create_from_memory_range_copy(llvm_ir, "my_mod") };
     let context = Context::create();
     let module = context.create_module_from_ir(memory_buffer).unwrap();
 


### PR DESCRIPTION
Addresses two important soundness and stability issues from Milestone 8:

1. **MemoryBuffer UB (#185, #516)**:
   - Made `MemoryBuffer::create_from_memory_range` and its `_copy` variant `pub unsafe fn`.
   - Removed the runtime panics and documented the requirement for the caller to provide a legally null-terminated slice, eliminating a false sense of safety.
   - Updated all internal test usages with `unsafe {}` blocks.

2. **PassManager Type Safety (#304)**:
   - Moved 15 module-only passes (e.g., `add_function_inlining_pass`, `add_argument_promotion_pass`, `add_always_inliner_pass`) from the generic `PassManager<T>` implementation into an explicit `impl<'ctx> PassManager<Module<'ctx>>`.
   - Adding a module level pass to a `FunctionValue` pass manager will now result in a clean Rust compiler error instead of an opaque runtime LLVM segmentation fault.

This eliminates immediate footguns and brings the API closer to true zero-cost abstractions for safe usage.