### PR TITLE
fix missing LinkIn* calls

### DIFF
--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -124,15 +124,15 @@ impl<'ctx> ExecutionEngine<'ctx> {
         **self.execution_engine_rc()
     }
 
-    /// This function probably doesn't need to be called, but is here due to
-    /// linking(?) requirements. Bad things happen if we don't provide it.
-    pub fn link_in_mc_jit() {
+    // This function is noop, but required for proper MCJIT initialization and
+    // registration. Without it, LTO is free to eliminate it
+    pub(crate) fn link_in_mc_jit() {
         unsafe { LLVMLinkInMCJIT() }
     }
 
-    /// This function probably doesn't need to be called, but is here due to
-    /// linking(?) requirements. Bad things happen if we don't provide it.
-    pub fn link_in_interpreter() {
+    // This function is noop, but required for proper MCJIT initialization and
+    // registration. Without it, LTO is free to eliminate it
+    pub(crate) fn link_in_interpreter() {
         unsafe {
             LLVMLinkInInterpreter();
         }

--- a/src/module.rs
+++ b/src/module.rs
@@ -462,6 +462,8 @@ impl<'ctx> Module<'ctx> {
     /// ```
     // SubType: ExecutionEngine<Basic?>
     pub fn create_execution_engine(&self) -> Result<ExecutionEngine<'ctx>, LLVMString> {
+        ExecutionEngine::link_in_mc_jit();
+        ExecutionEngine::link_in_interpreter();
         Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
             err_string.push('\0');
 
@@ -512,6 +514,7 @@ impl<'ctx> Module<'ctx> {
     /// ```
     // SubType: ExecutionEngine<Interpreter>
     pub fn create_interpreter_execution_engine(&self) -> Result<ExecutionEngine<'ctx>, LLVMString> {
+        ExecutionEngine::link_in_interpreter();
         Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
             err_string.push('\0');
 
@@ -567,6 +570,7 @@ impl<'ctx> Module<'ctx> {
         &self,
         opt_level: OptimizationLevel,
     ) -> Result<ExecutionEngine<'ctx>, LLVMString> {
+        ExecutionEngine::link_in_mc_jit();
         Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {
             err_string.push('\0');
 
@@ -649,6 +653,8 @@ impl<'ctx> Module<'ctx> {
     ) -> Result<ExecutionEngine<'ctx>, LLVMString> {
         use std::mem::MaybeUninit;
         // ...
+
+        ExecutionEngine::link_in_mc_jit();
 
         // 1) Initialize the native target
         Target::initialize_native(&InitializationConfig::default()).map_err(|mut err_string| {


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

LLVMLinkIn* are basically no-op, but they are required for proper llvm module registration via static objects. Without calling them, there is no guarantee that LLVM module will exist.

In my case, enabling `lto=true` eliminated them completely, leading to a strange error "JIT not linked in" and hours of debugging how I managed to unlink it :) While functions ExecutionEngine::link_in_* were provided, they were unsearchable by reasonable keywords and were missing even fom Inkwell's own examples.

<!--- Describe your changes in detail -->

## Related Issue

After I understood that the issue was related to LTO, I found #320. 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## How This Has Been Tested

The change is minimal, so no extensive testing required. I was able to build my pretty big compiler with this change, as well as Inkwell examples.

Also cargo test on llvm 20 & 22

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Option\<Breaking Changes\>

This patch hides ExecutionEngine::link_in_* functions from the user. I just personally don't like exposing such a utility, and it is unneeded after this patch.

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
