### PR TITLE
Fixes bug in write_bitcode_to_file in #6.

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -815,7 +815,7 @@ impl<'ctx> Module<'ctx> {
         {
             use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
             use std::os::unix::io::AsRawFd;
-    
+
             // REVIEW: as_raw_fd docs suggest it only works in *nix
             // Also, should_close should maybe be hardcoded to true?
             unsafe {

--- a/src/module.rs
+++ b/src/module.rs
@@ -809,25 +809,24 @@ impl<'ctx> Module<'ctx> {
 
     // See GH issue #6
     /// `write_bitcode_to_path` should be preferred over this method, as it does not work on all operating systems.
-    pub fn write_bitcode_to_file(&self, file: &File, should_close: bool, unbuffered: bool) -> bool {
-        #[cfg(unix)]
-        {
-            use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
-            use std::os::unix::io::AsRawFd;
+    pub fn write_bitcode_to_file(&self, file: &File, unbuffered: bool) -> bool {
+        use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
+        use std::os::unix::io::AsRawFd;
 
-            // REVIEW: as_raw_fd docs suggest it only works in *nix
-            // Also, should_close should maybe be hardcoded to true?
-            unsafe {
-                LLVMWriteBitcodeToFD(
-                    self.module.get(),
-                    file.as_raw_fd(),
-                    should_close as i32,
-                    unbuffered as i32,
-                ) == 0
-            }
+        // REVIEW: as_raw_fd docs suggest it only works in *nix
+        // Also, should_close should maybe be hardcoded to true?
+        unsafe {
+            LLVMWriteBitcodeToFD(
+                self.module.get(),
+                file.as_raw_fd(),
+                // should_close: Rust will close the
+                // File itself, so `should_close` can
+                // cause a hard failure on non-unix
+                // systems such as Windows.
+                0,
+                unbuffered as i32,
+            ) == 0
         }
-        #[cfg(not(unix))]
-        return false;
     }
 
     /// Writes this `Module` to a `MemoryBuffer`.

--- a/src/module.rs
+++ b/src/module.rs
@@ -807,7 +807,6 @@ impl<'ctx> Module<'ctx> {
         unsafe { LLVMWriteBitcodeToFile(self.module.get(), c_string.as_ptr()) == 0 }
     }
 
-    // See GH issue #6
     /// `write_bitcode_to_path` should be preferred over this method, as it does not work on all operating systems.
     pub fn write_bitcode_to_file(&self, file: &File, unbuffered: bool) -> bool {
         #[cfg(not(unix))]

--- a/src/module.rs
+++ b/src/module.rs
@@ -824,8 +824,7 @@ impl<'ctx> Module<'ctx> {
                     file.as_raw_fd(),
                     // should_close: Rust will close the
                     // File itself, so `should_close` can
-                    // cause a hard failure on non-unix
-                    // systems such as Windows.
+                    // cause a hard failure.
                     0,
                     unbuffered as i32,
                 ) == 0

--- a/src/module.rs
+++ b/src/module.rs
@@ -810,22 +810,27 @@ impl<'ctx> Module<'ctx> {
     // See GH issue #6
     /// `write_bitcode_to_path` should be preferred over this method, as it does not work on all operating systems.
     pub fn write_bitcode_to_file(&self, file: &File, unbuffered: bool) -> bool {
-        use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
-        use std::os::unix::io::AsRawFd;
-
-        // REVIEW: as_raw_fd docs suggest it only works in *nix
-        // Also, should_close should maybe be hardcoded to true?
-        unsafe {
-            LLVMWriteBitcodeToFD(
-                self.module.get(),
-                file.as_raw_fd(),
-                // should_close: Rust will close the
-                // File itself, so `should_close` can
-                // cause a hard failure on non-unix
-                // systems such as Windows.
-                0,
-                unbuffered as i32,
-            ) == 0
+        #[cfg(not(unix))]
+        return false;
+        #[cfg(unix)]
+        {
+            use llvm_sys::bit_writer::LLVMWriteBitcodeToFD;
+            use std::os::unix::io::AsRawFd;
+    
+            // REVIEW: as_raw_fd docs suggest it only works in *nix
+            // Also, should_close should maybe be hardcoded to true?
+            unsafe {
+                LLVMWriteBitcodeToFD(
+                    self.module.get(),
+                    file.as_raw_fd(),
+                    // should_close: Rust will close the
+                    // File itself, so `should_close` can
+                    // cause a hard failure on non-unix
+                    // systems such as Windows.
+                    0,
+                    unbuffered as i32,
+                ) == 0
+            }
         }
     }
 

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -29,38 +29,43 @@ fn test_write_bitcode_to_path() {
     remove_file(&path).unwrap();
 }
 
+// TODO: If this TODO/REVIEW is here in the upstream repo, then remove it. It is out of date.
 // REVIEW: This test infrequently fails. Seems to happen more often on travis.
 // Possibly a LLVM bug? Wrapper is really straightforward. See issue #6 on GH
-// #[test]
-// fn test_write_bitcode_to_file() {
-//     use context::Context;
-//     use std::env::temp_dir;
-//     use std::fs::{File, remove_file};
-//     use std::io::{Read, Seek, SeekFrom};
+#[test]
+fn test_write_bitcode_to_file() {
+    use inkwell::context::Context;
+    use std::env::temp_dir;
+    use std::fs::{File, remove_file};
+    use std::io::{Read, Seek, SeekFrom};
 
-//     let mut path = temp_dir();
+    let mut path = temp_dir();
 
-//     path.push("temp2.bc");
+    path.push("temp2.bc");
 
-//     let mut file = File::create(&path).unwrap();
+    let mut file = File::create(&path).unwrap();
 
-//     let context = Context::create();
-//     let module = context.create_module("my_module");
-//     let void_type = context.void_type();
-//     let fn_type = void_type.fn_type(&[], false);
+    let context = Context::create();
+    let module = context.create_module("my_module");
+    let void_type = context.void_type();
+    let fn_type = void_type.fn_type(&[], false);
+    
+    module.add_function("my_fn", fn_type, None);
+    module.write_bitcode_to_file(&file, false);
 
-//     module.add_function("my_fn", fn_type, None);
-//     module.write_bitcode_to_file(&file, true, false);
+    drop(file);
 
-//     let mut contents = Vec::new();
-//     let mut file2 = File::open(&path).expect("Could not open temp file");
+    let mut contents = Vec::new();
+    let mut file2 = File::open(&path).expect("Could not open temp file");
+    
+    file2.read_to_end(&mut contents).expect("Unable to verify written file");
 
-//     file.read_to_end(&mut contents).expect("Unable to verify written file");
+    assert!(contents.len() > 0);
 
-//     assert!(contents.len() > 0);
+    drop(file2);
 
-//     remove_file(&path).unwrap();
-// }
+    remove_file(&path).expect("Failed to remove file.");
+}
 
 #[test]
 fn test_get_function() {

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -35,13 +35,13 @@ fn test_write_bitcode_to_file() {
     use inkwell::context::Context;
     use std::env::temp_dir;
     use std::fs::{File, remove_file};
-    use std::io::{Read, Seek, SeekFrom};
+    use std::io::Read;
 
     let mut path = temp_dir();
 
     path.push("temp2.bc");
 
-    let mut file = File::create(&path).unwrap();
+    let file = File::create(&path).unwrap();
 
     let context = Context::create();
     let module = context.create_module("my_module");
@@ -50,7 +50,7 @@ fn test_write_bitcode_to_file() {
 
     module.add_function("my_fn", fn_type, None);
     module.write_bitcode_to_file(&file, false);
-
+    
     drop(file);
 
     let mut contents = Vec::new();
@@ -58,7 +58,7 @@ fn test_write_bitcode_to_file() {
 
     file2.read_to_end(&mut contents).expect("Unable to verify written file");
 
-    assert!(contents.len() > 0);
+    assert!(!contents.is_empty());
 
     drop(file2);
 

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -32,6 +32,7 @@ fn test_write_bitcode_to_path() {
 // TODO: If this TODO/REVIEW is here in the upstream repo, then remove it. It is out of date.
 // REVIEW: This test infrequently fails. Seems to happen more often on travis.
 // Possibly a LLVM bug? Wrapper is really straightforward. See issue #6 on GH
+#[cfg(unix)]
 #[test]
 fn test_write_bitcode_to_file() {
     use inkwell::context::Context;

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -29,9 +29,6 @@ fn test_write_bitcode_to_path() {
     remove_file(&path).unwrap();
 }
 
-// TODO: If this TODO/REVIEW is here in the upstream repo, then remove it. It is out of date.
-// REVIEW: This test infrequently fails. Seems to happen more often on travis.
-// Possibly a LLVM bug? Wrapper is really straightforward. See issue #6 on GH
 #[cfg(unix)]
 #[test]
 fn test_write_bitcode_to_file() {

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -47,7 +47,7 @@ fn test_write_bitcode_to_file() {
     let module = context.create_module("my_module");
     let void_type = context.void_type();
     let fn_type = void_type.fn_type(&[], false);
-    
+
     module.add_function("my_fn", fn_type, None);
     module.write_bitcode_to_file(&file, false);
 
@@ -55,7 +55,7 @@ fn test_write_bitcode_to_file() {
 
     let mut contents = Vec::new();
     let mut file2 = File::open(&path).expect("Could not open temp file");
-    
+
     file2.read_to_end(&mut contents).expect("Unable to verify written file");
 
     assert!(contents.len() > 0);

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -50,7 +50,7 @@ fn test_write_bitcode_to_file() {
 
     module.add_function("my_fn", fn_type, None);
     module.write_bitcode_to_file(&file, false);
-    
+
     drop(file);
 
     let mut contents = Vec::new();


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

write_bitcode_to_file would fail if `should_close` was true because it would double-close the file descriptor.

## Related Issue

Closes #6 

## How This Has Been Tested

I also fixed the test in test_module.rs, and it passes on 21-1 (didn't test any others because I don't have it setup for other versions, guess I'll have to see if it fails in the CI.

## Option\<Breaking Changes\>

Removes `should_close` argument from `write_bitcode_to_file` because it isn't applicable in safe Rust as Rust will automatically close the File unless you use `std::mem::forget`. As far as I'm aware, there's no way to prevent Rust from automatically closing a file besides with `into_raw_fd`, which can't be called on a File reference.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
