### PR TITLE
RFC: Encode zero kind_id semantic in return type

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -9,6 +9,7 @@ use llvm_sys::core::{LLVMGetTypeAttributeValue, LLVMIsTypeAttribute};
 use llvm_sys::prelude::LLVMAttributeRef;
 
 use std::ffi::CStr;
+use std::num::NonZeroU32;
 
 #[llvm_versions(12..)]
 use crate::types::AnyTypeEnum;
@@ -170,14 +171,16 @@ impl Attribute {
     /// use inkwell::attributes::Attribute;
     ///
     /// // This kind id doesn't exist:
-    /// assert_eq!(Attribute::get_named_enum_kind_id("foobar"), 0);
+    /// assert_eq!(Attribute::get_named_enum_kind_id("foobar"), None);
     ///
     /// // These are real kind ids:
-    /// assert_eq!(Attribute::get_named_enum_kind_id("align"), 1);
-    /// assert_eq!(Attribute::get_named_enum_kind_id("builtin"), 5);
+    /// assert_eq!(Attribute::get_named_enum_kind_id("align").unwrap().get(), 1);
+    /// assert_eq!(Attribute::get_named_enum_kind_id("builtin").unwrap().get(), 5);
     /// ```
-    pub fn get_named_enum_kind_id(name: &str) -> u32 {
-        unsafe { LLVMGetEnumAttributeKindForName(name.as_ptr() as *const ::libc::c_char, name.len()) }
+    pub fn get_named_enum_kind_id(name: &str) -> Option<NonZeroU32> {
+        let id = unsafe { LLVMGetEnumAttributeKindForName(name.as_ptr() as *const ::libc::c_char, name.len()) };
+
+        NonZeroU32::new(id)
     }
 
     /// Gets the kind id associated with an enum `Attribute`.


### PR DESCRIPTION
## Description

LLVM returns id=0 for unknown attribute ids. This patch encode this semantic via zero-cost Option<NonZeroU32>, which will provide .unwrap() and other convenient methods.

## Reasoning

I'd like to have convenient .unwrap(), .ok_or() and other methods to validate that attribute exist. However, this patch is pure cosmetics, so feel free to drop it

## Considerations

- NonZeroU32 has kinda ugly conversion API
- Should we refactor functions that accept kind_id to NonZeroU32 too? Like `Context::create_enum_attribute`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
