### PR TITLE
feat(values): derive Clone and Copy for CallableValue (#346)

### DIFF
--- a/src/values/callable_value.rs
+++ b/src/values/callable_value.rs
@@ -164,7 +164,7 @@ impl<'ctx> CallableValueEnum<'ctx> {
 ///
 /// builder.build_return(Some(&ret_val)).unwrap();
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct CallableValue<'ctx>(CallableValueEnum<'ctx>);
 
 unsafe impl AsValueRef for CallableValue<'_> {


### PR DESCRIPTION
## Summary

Resolves #346.

`CallableValue<'ctx>` is a newtype wrapper around `CallableValueEnum<'ctx>`. The inner enum already has `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]` (see `src/values/callable_value.rs:14`), but the outer wrapper only had `Debug`, so callers couldn't `Clone` or `Copy` a `CallableValue`.

The issue author noted "deriving Clone on line 77 of `clonable_value.rs`" was all that was needed. The file layout has shifted since 2022 — the type now lives on line 168 of `src/values/callable_value.rs` and the derive sits at line 167. The fix is the same shape: add `Clone, Copy` to the derive on the wrapper struct.

The owner [agreed on 2022-08-26](https://github.com/TheDan64/inkwell/issues/346#issuecomment-1227837881) that there was no technical reason to leave this out.

## Diff

```rust
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct CallableValue<'ctx>(CallableValueEnum<'ctx>);
```

## Verification

`CallableValueEnum<'ctx>` (the inner type) already derives both `Clone` and `Copy`, and both `FunctionValue` and `PointerValue` (the enum variants) also derive `Clone` and `Copy`. The newtype wrapping a `Copy` type can be `Copy` itself.
