### PR TITLE
Made this code not weird.

### DIFF
--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -225,11 +225,11 @@ pub fn enable_llvm_pretty_stack_trace() {
 ///
 /// B) Finds no null byte and allocates a new C string based on the input Rust string.
 #[inline]
-pub(crate) fn to_c_str(mut s: &str) -> Cow<'_, CStr> {
+pub(crate) fn to_c_str(s: &str) -> Cow<'_, CStr> {
     if s.is_empty() {
-        s = "\0";
+        return Cow::Borrowed(c"");
     }
-
+    
     match CStr::from_bytes_until_nul(s.as_bytes()) {
         Ok(c) => Cow::from(c),
         // SAFETY: No internal 0 byte since already `FromBytesUntilNulError`

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -229,7 +229,7 @@ pub(crate) fn to_c_str(s: &str) -> Cow<'_, CStr> {
     if s.is_empty() {
         return Cow::Borrowed(c"");
     }
-    
+
     match CStr::from_bytes_until_nul(s.as_bytes()) {
         Ok(c) => Cow::from(c),
         // SAFETY: No internal 0 byte since already `FromBytesUntilNulError`


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

I was just reading through the source code, and I spotted this weird thing in the `to_c_str` implementation that didn't really make any sense to me. It's a simple change, and semantically doesn't change anything, but I felt driven to make the code not weird.

## How This Has Been Tested

All tests passed for `--no-default-features --features "llvm21-1 target-x86"`.

I don't know whether or not there are any tests for the `to_c_str` implementation, but `c""` is equivalent to `b"\0"` in terms of the underlying byte sequence.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
