### PR TITLE
Fixes #695: Underflow in create_from_memory_range.

### DIFF
--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -113,7 +113,7 @@ impl<'a> MemoryBuffer<'a> {
                 input.len(),
                 name_c_string.as_ptr(),
                 /* If this is `true`, LLVM will expect a null-terminator. If it is false, the null-terminator is not
-                 * necesary.
+                 * necessary.
                  * https://llvm.org/doxygen/IR_2Core_8cpp_source.html#l04679
                  * ```
                  * LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRange(

--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -66,25 +66,14 @@ impl MemoryBuffer<'static> {
         unsafe { Ok(Self::new(memory_buffer)) }
     }
 
-    /// Create a memory buffer copied from a byte slice with a trailing nul byte.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the input byte slice does not terminate with a nul byte.
+    /// Create a memory buffer copied from a byte slice.
     pub fn create_from_memory_range_copy(input: &[u8], name: &str) -> Self {
-        assert_eq!(
-            input[input.len() - 1],
-            b'\0',
-            "input byte slice must terminate with a nul byte"
-        );
-
         let name_c_string = to_c_str(name);
 
         let memory_buffer = unsafe {
             LLVMCreateMemoryBufferWithMemoryRangeCopy(
                 input.as_ptr() as *const libc::c_char,
-                // decremented since technically the nul byte is one past the end of the input.
-                input.len() - 1,
+                input.len(),
                 name_c_string.as_ptr(),
             )
         };
@@ -112,7 +101,7 @@ impl<'a> MemoryBuffer<'a> {
         let name_c_string = to_c_str(name);
 
         let memory_buffer = unsafe {
-            /* LLVMCreateMemoryBufferWithMemoryRange does not expect a nul-terminated string.
+            /* LLVMCreateMemoryBufferWithMemoryRange does not expect a null-terminated string.
              * StringRef documentation: https://llvm.org/doxygen/StringRef_8h_source.html#l00132
              * ```
              * Get a pointer to the start of the string (which may not be null
@@ -123,7 +112,7 @@ impl<'a> MemoryBuffer<'a> {
                 input.as_ptr() as *const libc::c_char,
                 input.len(),
                 name_c_string.as_ptr(),
-                /* If this is `true`, LLVM will expect a nul-terminator. If it is false, the nul-terminator is not
+                /* If this is `true`, LLVM will expect a null-terminator. If it is false, the null-terminator is not
                  * necesary.
                  * https://llvm.org/doxygen/IR_2Core_8cpp_source.html#l04679
                  * ```
@@ -132,7 +121,7 @@ impl<'a> MemoryBuffer<'a> {
                  *    size_t InputDataLength,
                  *    const char *BufferName,
                  *    LLVMBool RequiresNullTerminator) {
-                 * 
+                 *
                  * return wrap(MemoryBuffer::getMemBuffer(StringRef(InputData, InputDataLength),
                  *                                        StringRef(BufferName),
                  *                                        RequiresNullTerminator).release());
@@ -141,10 +130,10 @@ impl<'a> MemoryBuffer<'a> {
                  * `MemoryBuffer::getMemBuffer` documentation.
                  * https://llvm.org/doxygen/classllvm_1_1MemoryBuffer.html#a0f68098734d6d3b451aacf5b38a67131
                  * ```
-                 * Note that InputData must be null terminated if RequiresNullTerminator is true. 
+                 * Note that InputData must be null terminated if RequiresNullTerminator is true.
                  * ```
                  */
-                false as c_int,
+                false as libc::c_int,
             )
         };
 
@@ -167,8 +156,7 @@ impl<'a> MemoryBuffer<'a> {
 
     /// Gets the byte size of this `MemoryBuffer`, counting the trailing nul byte.
     pub fn get_size(&self) -> usize {
-        // buffer size does not include the trailing nul byte, hence incremented.
-        unsafe { LLVMGetBufferSize(self.as_mut_ptr()) + 1 }
+        unsafe { LLVMGetBufferSize(self.as_mut_ptr()) }
     }
 
     /// Convert this [`MemoryBuffer`] and optional [`Context`] into a [`BinaryFile`].

--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -154,7 +154,7 @@ impl<'a> MemoryBuffer<'a> {
         }
     }
 
-    /// Gets the byte size of this `MemoryBuffer`, counting the trailing nul byte.
+    /// Gets the byte size of this `MemoryBuffer`.
     pub fn get_size(&self) -> usize {
         unsafe { LLVMGetBufferSize(self.as_mut_ptr()) }
     }

--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -107,27 +107,44 @@ impl<'a> MemoryBuffer<'a> {
         self.memory_buffer.as_ptr()
     }
 
-    /// Create a memory buffer from a byte slice with a trailing nul byte.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the input byte slice does not terminate with a nul byte.
+    /// Create a memory buffer from a byte slice.
     pub fn create_from_memory_range(input: &'a [u8], name: &str) -> Self {
-        assert_eq!(
-            input[input.len() - 1],
-            b'\0',
-            "input byte slice must terminate with a nul byte"
-        );
-
         let name_c_string = to_c_str(name);
 
         let memory_buffer = unsafe {
+            /* LLVMCreateMemoryBufferWithMemoryRange does not expect a nul-terminated string.
+             * StringRef documentation: https://llvm.org/doxygen/StringRef_8h_source.html#l00132
+             * ```
+             * Get a pointer to the start of the string (which may not be null
+             * terminated).
+             * ```
+             */
             LLVMCreateMemoryBufferWithMemoryRange(
                 input.as_ptr() as *const libc::c_char,
-                // decremented since technically the nul byte is one past the end of the input.
-                input.len() - 1,
+                input.len(),
                 name_c_string.as_ptr(),
-                false as i32, // guaranteed to have nul-terminator by CStr
+                /* If this is `true`, LLVM will expect a nul-terminator. If it is false, the nul-terminator is not
+                 * necesary.
+                 * https://llvm.org/doxygen/IR_2Core_8cpp_source.html#l04679
+                 * ```
+                 * LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRange(
+                 *    const char *InputData,
+                 *    size_t InputDataLength,
+                 *    const char *BufferName,
+                 *    LLVMBool RequiresNullTerminator) {
+                 * 
+                 * return wrap(MemoryBuffer::getMemBuffer(StringRef(InputData, InputDataLength),
+                 *                                        StringRef(BufferName),
+                 *                                        RequiresNullTerminator).release());
+                 * }
+                 * ```
+                 * `MemoryBuffer::getMemBuffer` documentation.
+                 * https://llvm.org/doxygen/classllvm_1_1MemoryBuffer.html#a0f68098734d6d3b451aacf5b38a67131
+                 * ```
+                 * Note that InputData must be null terminated if RequiresNullTerminator is true. 
+                 * ```
+                 */
+                false as c_int,
             )
         };
 

--- a/tests/all/test_memory_buffer.rs
+++ b/tests/all/test_memory_buffer.rs
@@ -4,7 +4,7 @@ use inkwell::memory_buffer::MemoryBuffer;
 
 #[test]
 fn test_memory_buffer() {
-    let buffer = b"mem\0";
+    let buffer = b"mem";
     let memory_buffer = MemoryBuffer::create_from_memory_range(buffer, "mem_buf");
 
     assert_eq!(memory_buffer.as_slice(), buffer);
@@ -12,7 +12,7 @@ fn test_memory_buffer() {
 
 #[test]
 fn test_memory_buffer_copied() {
-    let buffer = b"mem\0";
+    let buffer = b"mem";
     let memory_buffer_copied = MemoryBuffer::create_from_memory_range_copy(buffer, "mem_buf_copied");
 
     assert_ne!(memory_buffer_copied.as_slice().as_ptr(), buffer.as_ptr() as *const _);
@@ -24,17 +24,8 @@ fn test_memory_buffer_copied() {
 }
 
 #[test]
-#[should_panic]
-fn test_memory_buffer_panic() {
-    let buffer = b"mem";
-    // panic since no trailing nul byte.
-    MemoryBuffer::create_from_memory_range(buffer, "mem_buf");
-}
-
-#[test]
 fn test_memory_buffer_file() {
     let memory_buffer = MemoryBuffer::create_from_file(Path::new("./LICENSE")).unwrap();
 
-    assert_eq!(memory_buffer.as_slice()[memory_buffer.get_size() - 1], b'\0'); // nul byte
-    assert_eq!(memory_buffer.as_slice()[memory_buffer.get_size() - 2], b'\n'); // new line character
+    assert_eq!(memory_buffer.as_slice()[memory_buffer.get_size() - 1], b'\n'); // new line character
 }

--- a/tests/all/test_module.rs
+++ b/tests/all/test_module.rs
@@ -147,10 +147,10 @@ fn test_write_and_load_memory_buffer() {
 #[test]
 fn test_garbage_ir_fails_create_module_from_ir() {
     let context = Context::create();
-    let memory_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data\0", "my_ir");
+    let memory_buffer = MemoryBuffer::create_from_memory_range(b"garbage ir data", "my_ir");
 
-    assert_eq!(memory_buffer.get_size(), 16);
-    assert_eq!(memory_buffer.as_slice(), b"garbage ir data\0");
+    assert_eq!(memory_buffer.get_size(), 15);
+    assert_eq!(memory_buffer.as_slice(), b"garbage ir data");
     assert!(context.create_module_from_ir(memory_buffer).is_err());
 }
 


### PR DESCRIPTION
## Description

There was an integer underflow in create_from_memory_range in `memory_buffer.rs`. While fixing the underflow error, I dug into the actual source code of LLVM to see what was going on, and discovered that there's absolutely no need for the input data to be null-terminated, so I removed that requirement entirely and provided my sources.

## Related Issue

#695 

## How This Has Been Tested

All tests, even doc tests passed on x86_64 Linux with llvm21-1.

```bash
function prepare-pr() {
    if [[ $1 != "--no-format" ]]; then
        cargo fmt || {
            local ret_code=$?
            failure "cargo fmt failed."
            return $ret_code
        }
    fi
    cargo clippy --no-default-features --features "llvm21-1 target-x86" || {
        local ret_code=$?
        failure "cargo clippy failed."
        return $ret_code
    }
    cargo test --no-default-features --features "llvm21-1 target-x86" --release || {
        local ret_code=$?
        failure "cargo test failed."
        return $ret_code
    }
    cargo test --no-default-features --features "llvm21-1 target-x86" --doc --release || {
        local ret_code=$?
        failure "cargo test --doc failed."
        return $ret_code
    }
    success "Ready for PR"
}
```

## Option\<Breaking Changes\>

<!--- If any breaking changes were made, please explain why they are required -->
<!--- If not, feel free to remove this section altogether -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
