### PR TITLE
Fixes type name typo in error message.

### DIFF
--- a/src/values/basic_value_use.rs
+++ b/src/values/basic_value_use.rs
@@ -80,7 +80,7 @@ impl<'ctx> Operand<'ctx> {
     #[must_use]
     #[track_caller]
     pub fn unwrap_value(self) -> BasicValueEnum<'ctx> {
-        self.expect_value("Called unwrap_value() on UsedValue::Block.")
+        self.expect_value("Called unwrap_value() on Operand::Block.")
     }
 
     /// Unwrap [BasicBlock]. Will panic if it is not.
@@ -88,7 +88,7 @@ impl<'ctx> Operand<'ctx> {
     #[must_use]
     #[track_caller]
     pub fn unwrap_block(self) -> BasicBlock<'ctx> {
-        self.expect_block("Called unwrap_block() on UsedValue::Value.")
+        self.expect_block("Called unwrap_block() on Operand::Value.")
     }
 }
 


### PR DESCRIPTION
<!--- This version of the form is by no means final -->
<!--- Provide a brief summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->

I was reading through the code as I do from time to time, and I noticed a typo in an error string of some of the code I had written previously. This PR just fixes that typo. Sorry for such a small and uneventful PR, I didn't want to just leave it there.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
