### PR TITLE
Clarify TargetMachine emission documentation

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1147,7 +1147,7 @@ impl TargetMachine {
         unsafe { LLVMAddAnalysisPasses(self.target_machine.as_ptr(), pass_manager.pass_manager) }
     }
 
-    /// Writes a `TargetMachine` to a `MemoryBuffer`.
+    /// Compiles `module` to assembly or object code and returns the output in a `MemoryBuffer`.
     ///
     /// # Example
     ///
@@ -1210,7 +1210,7 @@ impl TargetMachine {
         unsafe { Ok(MemoryBuffer::new(memory_buffer)) }
     }
 
-    /// Saves a `TargetMachine` to a file.
+    /// Compiles `module` to assembly or object code and writes the output to `path`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Description

Correct the Rustdoc summaries for `write_to_memory_buffer` and `write_to_file` so they describe compiling the supplied module to assembly or object code and writing the result to the selected destination. The public API and examples are unchanged.

## Related Issue

Fixes #240

## How This Has Been Tested

- `cargo fmt --check`
- `cargo check --all-targets --features llvm22-1-no-llvm-linking`
- `cargo clippy --all-targets --features llvm22-1-no-llvm-linking -- -D warnings`
- `cargo test --doc --features llvm22-1-no-llvm-linking targets::TargetMachine::write_to` (2 passed)
- `cargo doc --no-deps --features llvm22-1-no-llvm-linking`

## Checklist

- [x] I have read the Contributing Guide