### PR TITLE
docs: correct the LLVM feature flag naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ inkwell = { version = "0.10.0", features = ["llvm22-1"] }
 ```
 
 Supported versions:
-LLVM 12-22 mapping to a cargo feature flag `llvmM-0` for LLVM 12-17 and `llvmM-1` for LLVM 18-22, where `M` corresponds to the LLVM major version.
+LLVM 12-22 mapping to a cargo feature flag `llvmM-N` where `M` and `N` correspond to the LLVM major and minor version, e.g. `llvm18-1` for LLVM 18.1.x.
 
 Please be aware that we may make breaking changes on master from time to time since we are
 pre-v1.0.0, in compliance with semver. Please prefer a crates.io release whenever possible!

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ inkwell = { version = "0.10.0", features = ["llvm22-1"] }
 ```
 
 Supported versions:
-LLVM 12-22 mapping to a cargo feature flag `llvmM-0` where `M` corresponds to the LLVM major version.
+LLVM 12-22 mapping to a cargo feature flag `llvmM-0` for LLVM 12-17 and `llvmM-1` for LLVM 18-22, where `M` corresponds to the LLVM major version.
 
 Please be aware that we may make breaking changes on master from time to time since we are
 pre-v1.0.0, in compliance with semver. Please prefer a crates.io release whenever possible!


### PR DESCRIPTION
_Disclosure: this patch was prepared with AI assistance (Claude Sonnet 5). I checked every feature flag in Cargo.toml against the sentence before opening this._

### Problem

The README says:

> LLVM 12-22 mapping to a cargo feature flag `llvmM-0` where `M` corresponds to the LLVM major version.

That holds for LLVM 12-17 only. `Cargo.toml` switches to a `-1` suffix from LLVM 18 on:

```toml
llvm17-0 = ["llvm-sys-170"]
llvm18-1 = ["llvm-sys-181"]
...
llvm22-1 = ["llvm-sys-221"]
```

The snippet three lines above the sentence already uses `features = ["llvm22-1"]`, so the example and the rule describing it contradict each other. A reader following the sentence for a recent LLVM would write `llvm22-0` and hit an unknown-feature error.

### Fix

State both ranges. Checked against all eleven `llvmM-N` features currently in `Cargo.toml` — `-0` covers 12 through 17, `-1` covers 18 through 22, with no exceptions on either side.

README only — no code change.
